### PR TITLE
Added a broadcast method that accepts a whitelist

### DIFF
--- a/lib/socket.io/client.js
+++ b/lib/socket.io/client.js
@@ -31,14 +31,12 @@ Client.prototype.send = function(message){
 
 Client.prototype.broadcast = function(message){
   if (!('sessionId' in this)) return this;
-  this.listener.broadcast(message, this.sessionId);
+  this.listener.broadcastExcept(message, this.sessionId);
   return this;
 };
 
-Client.prototype.broadcastTo = function(message, whitelist) {
-  if (!('sessionId' in this)) return this;
-
-  this.listener.broadcastTo(message, whitelist);
+Client.prototype.broadcastOnly = function(message, whitelist) {
+  this.listener.broadcastOnly(message, whitelist);
   return this;
 };
 

--- a/lib/socket.io/listener.js
+++ b/lib/socket.io/listener.js
@@ -80,7 +80,23 @@ Listener = module.exports = function(server, options){
 sys.inherits(Listener, process.EventEmitter);
 for (var i in options) Listener.prototype[i] = options[i];
 
-Listener.prototype.broadcast = function(message, except){
+/*
+  Broadcast methods for different scenarios
+    - broadcast: sends a message to all connected clients, no exceptions. Ideal when a server is shutting down, or sending global messages.
+    - broadcastOnly: sends a message ONLY to clients you specify in a whitelist. Useful if you frequently send messages to small groups of users.
+    - broadcastExcept: sends a message to all clients, except those in a blacklist (which can be empty).
+*/
+Listener.prototype.broadcast = function(message) {
+  for(var i = 0, k = Object.keys(this.clients), l = k.length; i < l; i++) {
+    this.clients[k[i]].send(message);
+  }
+}
+
+Listener.prototype.broadcastExcept = function(message, except){
+  // if possible, revert to simple broadcast method
+  if (!except || except.length == 0) {
+    return this.broadcast(message);
+  }
   for (var i = 0, k = Object.keys(this.clients), l = k.length; i < l; i++){
     if (this.clients[k[i]] && (!except || [].concat(except).indexOf(this.clients[k[i]].sessionId) == -1)){
       this.clients[k[i]].send(message);
@@ -89,11 +105,12 @@ Listener.prototype.broadcast = function(message, except){
   return this;
 };
 
-Listener.prototype.broadcastTo = function(message, whitelist) {
-  for (var i = 0; k = Object.keys(this.clients), l = k.length; i < l; i++) {
-    if (this.clients[k][i] && (!whitelist || [].concat(whitelist).indexOf(this.clients[k][i].sessionId) >= 0)) {
-      this.clients[k][i].send(message);
+Listener.prototype.broadcastOnly = function(message, whitelist) {
+  for (var i = 0, k = Object.keys(this.clients), l = k.length; i < l; i++) {
+    if (this.clients[k[i]] && (!whitelist || [].concat(whitelist).indexOf(this.clients[k[i]].sessionId) >= 0)) {
+      this.clients[k[i]].send(message);
     }
+  }
   return this;
 };
 


### PR DESCRIPTION
Handling blacklists is unwieldy for any application that manages multiple groups that are all communicating. In my project, I'm using socket.io for basic chat, and also to pass other messages that relay people's status, or state, to other clients.

In all instances, a client should only be able to communicate with a small group of other clients, so a whitelist is preferable since enumerating all fo the clients they should not communicate with becomes increasingly difficult (and costly) as the number of users and groups grows.

I thought briefly about overloading the broadcast method to accept either a whitelist, or a blacklist, but thought the code would be cleaner this way. I am open to suggestions.
