### PR TITLE
Missing Line in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ By default, the server will intercept requests that contain `socket.io` in the p
 		res.writeBody('<h1>Hello world</h1>');
 		res.finish();
 	});
-			
+	
+	server.listen(8124);
+	
 	// socket.io, I choose you
 	var socket = io.listen(server);
 	


### PR DESCRIPTION
I'm sure it's obvious enough to most people, but took me a bit to figure out the missing `server.listen()` call in the example.
