### PR TITLE
Support for inline (same port) flash socket policy request

### DIFF
--- a/lib/socket.io/transports/flashsocket.js
+++ b/lib/socket.io/transports/flashsocket.js
@@ -21,6 +21,40 @@ Flashsocket.init = function(listener){
       } catch(e){}
     }
   });
+  if (netserver == null) {
+    // Could not listen on port 843 so policy requests will be inline
+    listener.server.addListener('connection', function(stream){
+      var flashCheck = function (data) {
+        // Only check the initial data
+        stream.removeListener("data", flashCheck);
+        if (data[0] === 60 && data.length == 23) {
+          if (data == '<policy-file-request/>\0') {
+            listener.options.log("Answering flash policy request inline");
+            if (stream && stream.readyState == 'open'){
+              var xml = Flashsocket.generate_policy([listener]);
+              stream.write(xml);
+              stream.end();
+            }
+          }
+        }
+      };
+      stream.on("data", flashCheck);
+    });
+  }
+};
+
+Flashsocket.generate_policy = function(listeners) {
+    var xml = '<?xml version="1.0"?>\n<!DOCTYPE cross-domain-policy SYSTEM "http://www.macromedia.com/xml/dtds/cross-domain-policy.dtd">\n<cross-domain-policy>\n';
+
+    listeners.forEach(function(l){
+            [].concat(l.options.origins).forEach(function(origin){
+                    var parts = origin.split(':');
+                    xml += '<allow-access-from domain="' + parts[0] + '" to-ports="'+ parts[1] +'"/>\n';
+            });
+    });
+
+    xml += '</cross-domain-policy>\n';
+    return xml;
 };
 
 try {
@@ -28,16 +62,7 @@ try {
 		socket.addListener("error",function(err){
 			socket.end && socket.end() || socket.destroy && socket.destroy();
 		});
-		var xml = '<?xml version="1.0"?>\n<!DOCTYPE cross-domain-policy SYSTEM "http://www.macromedia.com/xml/dtds/cross-domain-policy.dtd">\n<cross-domain-policy>\n';
-
-		listeners.forEach(function(l){
-			[].concat(l.options.origins).forEach(function(origin){
-				var parts = origin.split(':');
-				xml += '<allow-access-from domain="' + parts[0] + '" to-ports="'+ parts[1] +'"/>\n';
-			});
-		});
-
-		xml += '</cross-domain-policy>\n';
+		var xml = Flashsocket.generate_policy(listeners);
 		
 		if(socket && socket.readyState == 'open'){
 		  socket.write(xml);
@@ -50,18 +75,14 @@ try {
   if (e.errno == 13){
     console.error("\x1B[1;31m" + [
       '================================================',
-      '|               WARNING! DANGER!               |',
-      '|                                              |',
-      '| The flash websocket transport will not work  |', 
-      '| unless you run your node instance with root  |',
-      '| privileges.                                  |',
-      '|                                              |',
-      '| A flash XML policy file has to be served on  |',
-      '| port 843 (privileged) for it to work.        |',
+      '| Your node instance does not have root        |', 
+      '| privileges. This means that the flash XML    |',
+      '| policy file will be served inline instead of |',
+      '| on port 843. This is better for security but |',
+      '| may slow down initial connections slightly.  |',
       '|                                              |',
       '| You can run socket.io without this transport |',
       '| to make this message go (refer to README).   |',
-      '|                                              |',
       '===============================================|'
     ].join("\n") + "\x1B[0m");
   }


### PR DESCRIPTION
Requiring that the server be run as root is generally considered a bad idea. This change listens on the target port for flash policy requests if the listener can't be started on port 843 (i.e. not root priveleged) and so it allows the flashsocket mode to work without root privelege.

I also suggest reversing the warning so that running as root produces a warning instead. Or perhaps having a (different) warning for both.
