### PR TITLE
Issue when using WebSockets with node.js without ssl dev libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The `Socket.IO` server provides seamless supports for a variety of transports in
 
 ## Requirements
 
-- Node v0.1.103+
+- Node v0.1.103+ with SSL Development libraries (sudo apt-get install libssl-dev)
 - [Socket.IO client](http://github.com/LearnBoost/Socket.IO) to connect from the browser
 
 ## How to use


### PR DESCRIPTION
This issue wasn't in the instructions, so I added a note for it.
