### PR TITLE
Prevent clearing of client.request and client.response for XHR and JSONP polling

### DIFF
--- a/lib/socket.io/client.js
+++ b/lib/socket.io/client.js
@@ -129,8 +129,11 @@ Client.prototype._onClose = function(skipDisconnect){
     this.connection.destroy();
     this.connection = null;
   }
-  this.request = null;
-  this.response = null;
+  if(!this.dont_clear_request){
+    this.request = null;
+    this.response = null;
+    this.dont_clear_request = false;
+  }
   if (skipDisconnect !== false){
     if (this.handshaked){
       this._disconnectTimeout = setTimeout(function(){

--- a/lib/socket.io/transports/jsonp-polling.js
+++ b/lib/socket.io/transports/jsonp-polling.js
@@ -29,6 +29,7 @@ JSONPPolling.prototype._write = function(message){
     this.response.writeHead(200, {'Content-Type': 'text/javascript; charset=UTF-8', 'Content-Length': Buffer.byteLength(message)});
     this.response.write(message);
     this.response.end();
+    this.dont_clear_request	= true;
     this._onClose();
   }
 };

--- a/lib/socket.io/transports/xhr-polling.js
+++ b/lib/socket.io/transports/xhr-polling.js
@@ -2,6 +2,7 @@ var Client = require('../client')
   , qs = require('querystring');
 
 var Polling = module.exports = function(){
+  this._keep_last_request = true;
   Client.apply(this, arguments);
 };
 
@@ -72,6 +73,7 @@ Polling.prototype._write = function(message){
     this.response.writeHead(200, headers);
     this.response.write(message);
     this.response.end();
+    this.dont_clear_request = true;
     this._onClose();
   }
 };


### PR DESCRIPTION
When listening to the client 'connect' message, clients using the XHR and JSONP polling protocols have no request or response attribute so I can't get access to the cookies.  With both of these protocols, calling `_write()` calls `onClose()` and clears the requrst and response variables.  I've just made a change that keeps these around until the next request, so request.headers.cookies is still available.  Not sure if this is appropriate for the official repo, but it worked for me.

```
socket.on('connection', function(client){
  // client.request and client.response are both null
});
```
