### PR TITLE
Adding socket.connect() to client example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ On the client:
 	<script src="/socket.io/socket.io.js"></script>
 	<script>
 		var socket = new io.Socket();
+		socket.connect();
 		socket.on('connect', function(){ … })
 		socket.on('message', function(){ … })
 		socket.on('disconnect', function(){ … })


### PR DESCRIPTION
Hi,

As I'm new to socket.io it took a bit to figure out I have to call <code>connect()</code> after creating a socket on the client. This patch adds the missing piece of code to the example.
