### PR TITLE
Try/Catch block around JSON.parse

### DIFF
--- a/lib/socket.io/client.js
+++ b/lib/socket.io/client.js
@@ -48,7 +48,11 @@ Client.prototype._onMessage = function(data){
       case '~h~':
         return this._onHeartbeat(messages[i].substr(3));
       case '~j~':
-        messages[i] = JSON.parse(messages[i].substr(3));
+        try {
+          messages[i] = JSON.parse(messages[i].substr(3));
+        } catch(e) {
+          messages[i] = {};
+        }
         break;
     }
     this.emit('message', messages[i]);


### PR DESCRIPTION
Socket.IO would not catch the JSON.parse exception if the payload was framed as JSON but contained an invalid JSON string. This would cause NodeJS to exit.

This patch wraps JSON.parse with a try/catch block which returns an empty object if parsing fails.
