### PR TITLE
xhr-polling fix for issue #119

### DIFF
--- a/lib/socket.io/client.js
+++ b/lib/socket.io/client.js
@@ -131,7 +131,6 @@ Client.prototype._onClose = function(skipDisconnect){
   this._open = false;
   if (this.connection){
     this.connection.end();
-    this.connection.destroy();
     this.connection = null;
   }
   this.request = null;


### PR DESCRIPTION
This fixes https://github.com/LearnBoost/Socket.IO-node/issues/issue/119

Don't destroy the connection in _onClose. Destroying
it will prevent the buffers from being flushed and
will result in corrupted responses for the
xhr-polling transport.

According to the node documentation "destroy" is
only necessary in case of a errors.
