### PR TITLE
Just a little bugfix.

### DIFF
--- a/lib/socket.io/client.js
+++ b/lib/socket.io/client.js
@@ -70,7 +70,6 @@ Client.prototype._onConnect = function(req, res){
   this.connection.addListener('end', function(){
     self._onClose();
     self.connection.destroy();
-    self.connection = null;
   });
   
   if (req){


### PR DESCRIPTION
Hi!

Node was crashing and dumping the following at stdout when the first connection attempt was made after all previous connections had been severed.

```
/home/thiago/Work/node/socket.io/Socket.IO-node/lib/socket.io/client.js:72
    self.connection.destroy();
                    ^
TypeError: Cannot call method 'destroy' of null
    at Stream.<anonymous> (/home/thiago/Work/node/socket.io/Socket.IO-node/lib/socket.io/client.js:72:21)
    at Stream.emit (events:48:20)
    at IOWatcher.callback (net:471:53)
    at node.js:773:9
```

This started happening after I ran "npm update" today. I tested it with your chat example code too, just to make sure my game's code had nothing to do with it.

I figured it was because of line 73 in "Socket.IO-node/lib/socket.io/client.js" which read:

```
self.connection = null;
```

Before I deleted that line I was able to reproduce that crash very easily, now it can't be triggered any longer.

Hope this helps!

;)
