### PR TITLE
Buffered Sends

### DIFF
--- a/lib/socket.io/client.js
+++ b/lib/socket.io/client.js
@@ -72,32 +72,43 @@ Client.prototype._onMessage = function(data){
 };
 
 Client.prototype._onConnect = function(req, res){
-  var self = this;
-  
+  var self = this
+    , attachConnection = !this.connection;
+
   this.request = req;
   this.response = res;
   this.connection = req.connection;
 
-  this.connection.addListener('end', function(){
-    self._onClose();
-    if (self.connection)
-      self.connection.destroy();
-  });
+  if(!attachConnection) attachConnection = !attachConnection && this.connection.eventsAttached === undefined;
+  this.connection.eventsAttached = true;
+  
+  if (attachConnection){
+    function destroyConnection(){
+      self._onClose();
+      self.connection && self.connection.destroy()
+    };
+    this.connection.addListener('end', destroyConnection);
+    this.connection.addListener('timeout', destroyConnection);
+    this.connection.addListener('error', destroyConnection);
+    }
   
   if (req){
-    req.addListener('error', function(err){
+    function destroyRequest(){
       req.destroy && req.destroy();
-    });
-    if (res) res.addListener('error', function(err){
-      res.destroy && res.destroy();
-    });
-    req.connection.addListener('error', function(err){
-      req.connection.destroy && req.connection.destroy();
-    });
-    
+    };
+    req.addListener('error', destroyRequest);
+    req.addListener('timeout', destroyRequest);
+    if (res){
+      function destroyResponse(){
+        res.destroy && res.destroy();
+      }
+      res.addListener('error', destroyResponse);
+      res.addListener('timeout', destroyResponse);
+    }
     if (this._disconnectTimeout) clearTimeout(this._disconnectTimeout);
   }
 };
+
 
 Client.prototype._payload = function(){
   var payload = [];


### PR DESCRIPTION
Since Socket.IO has the built-in functionality for encoding and delivering multiple messages, I thought it would be convenient to wrap that up in some public interface on the Client object.

```
client.bufferSends(funciton(){
  //all client.send() calls in here are added to the queue
  //and then the whole queue is sent after we return
});
```
