### PR TITLE
Added client.sendWillQueue() and "readytosend" event. 

### DIFF
--- a/lib/socket.io/client.js
+++ b/lib/socket.io/client.js
@@ -25,8 +25,12 @@ var Client = module.exports = function(listener, req, res, options, head){
 
 util.inherits(Client, process.EventEmitter);
 
+Client.prototype.sendWillQueue = function(){
+  return !this._open || !(this.connection.readyState === 'open' || this.connection.readyState === 'writeOnly');
+};
+
 Client.prototype.send = function(message){
-  if (!this._open || !(this.connection.readyState === 'open' || this.connection.readyState === 'writeOnly')){
+  if (this._forcequeue || this.sendWillQueue()){
     return this._queue(message);
   }
   this._write(encode(message));
@@ -100,6 +104,9 @@ Client.prototype._payload = function(){
     payload.push(this.sessionId);
     this.handshaked = true;
   }
+  this._forcequeue = true;
+  this.emit('readytosend');
+  this._forcequeue = false;
   
   payload = payload.concat(this._writeQueue || []);
   this._writeQueue = [];


### PR DESCRIPTION
This is useful for throttling sends. I have rapidly-changing state
on the server, but I only need to send the most recent state to the
client - so if sendWillQueue() is true I wait for the 'readytosend'
event before sending the latest state.

'readytosend' is emitted from _payload() after the connection state
is set up, but before sending the content of the write queue; so
a readytosend callback can call send() and it will be sent immediately.
