### PR TITLE
returning info about the connection to the client

### DIFF
--- a/support/socket.io-client/socket.io.js
+++ b/support/socket.io-client/socket.io.js
@@ -913,7 +913,7 @@ JSONPPolling.xdomainCheck = function(){
 		this.connecting = false;
 		this._doQueue();
 		if (this.options.rememberTransport) this.options.document.cookie = 'socketio=' + encodeURIComponent(this.transport.type);
-		this.emit('connect');
+		this.emit('connect', [this.transport]);
 	};
 	
 	Socket.prototype._onMessage = function(data){


### PR DESCRIPTION
This is a small change to return the transport object as an argument to the socket.on('connect' , function(trans){..});  Currently nothing gets sent back down to the client, so the client can't get info like the sessionid.  This is a small change to return the transport object so that the client can find out what the session id is (as well as other information about the connection)
