### PR TITLE
Allow cross-domain xhr polling with Chrome/Safari when Origin header is "null"

### DIFF
--- a/lib/socket.io/transports/xhr-polling.js
+++ b/lib/socket.io/transports/xhr-polling.js
@@ -69,7 +69,7 @@ Polling.prototype._write = function(message){
     var headers = {'Content-Type': 'text/plain; charset=UTF-8', 'Content-Length': Buffer.byteLength(message)};
     // https://developer.mozilla.org/En/HTTP_Access_Control
     if (this.request.headers.origin && this._verifyOrigin(this.request.headers.origin)){
-      headers['Access-Control-Allow-Origin'] = this.request.headers.origin;
+      headers['Access-Control-Allow-Origin'] = (this.request.headers.origin === 'null' ? '*' : this.request.headers.origin);
       if (this.request.headers.cookie) headers['Access-Control-Allow-Credentials'] = 'true';
     }
     this.response.writeHead(200, headers);


### PR DESCRIPTION
Safari/Chrome don't play with "Access-Control-Allow-Origin: null" after sending a cross-domain request with "Origin: null"

Changed the header to "Access-Control-Allow-Origin: *" when the GET request's Origin header is "null"
