### PR TITLE
Fixed error 'EventEmitter memory leak detected'

### DIFF
--- a/lib/socket.io/client.js
+++ b/lib/socket.io/client.js
@@ -65,13 +65,17 @@ Client.prototype._onConnect = function(req, res){
   
   this.request = req;
   this.response = res;
-  this.connection = req.connection;
-
-  this.connection.addListener('end', function(){
-    self._onClose();
-    if (self.connection)
-      self.connection.destroy();
-  });
+  var newConnection = this.connection != req.connection;
+  
+  if(newConnection) {
+    this.connection = req.connection;
+	
+    this.connection.addListener('end', function(){
+      self._onClose();
+      if (self.connection)
+        self.connection.destroy();
+    });
+  }
   
   if (req){
     req.addListener('error', function(err){
@@ -80,10 +84,11 @@ Client.prototype._onConnect = function(req, res){
     if (res) res.addListener('error', function(err){
       res.destroy && res.destroy();
     });
-    req.connection.addListener('error', function(err){
-      req.connection.destroy && req.connection.destroy();
-    });
-    
+    if(newConnection) {
+      req.connection.addListener('error', function(err){
+        req.connection.destroy && req.connection.destroy();
+      });
+    }
     if (this._disconnectTimeout) clearTimeout(this._disconnectTimeout);
   }
 };


### PR DESCRIPTION
This is a reasonably simple fix.  In SSL mode especially, multiple requests can have the same connection object, and you are calling Client._onConnect for every request, which sets events on the connection as well as the request.  Thus for multiple requests per connection, you're leaking event handlers in _onConnect.  This quick patch solves that.
