### PR TITLE
Allow x-domain xhr-polling with Origin: null for Chrome/Safari

### DIFF
--- a/lib/socket.io/transports/xhr-polling.js
+++ b/lib/socket.io/transports/xhr-polling.js
@@ -69,7 +69,7 @@ Polling.prototype._write = function(message){
     var headers = {'Content-Type': 'text/plain; charset=UTF-8', 'Content-Length': Buffer.byteLength(message)};
     // https://developer.mozilla.org/En/HTTP_Access_Control
     if (this.request.headers.origin && this._verifyOrigin(this.request.headers.origin)){
-      headers['Access-Control-Allow-Origin'] = this.request.headers.origin;
+      headers['Access-Control-Allow-Origin'] = (this.request.headers.origin === 'null' ? '*' : this.request.headers.origin);
       if (this.request.headers.cookie) headers['Access-Control-Allow-Credentials'] = 'true';
     }
     this.response.writeHead(200, headers);


### PR DESCRIPTION
(Sending this pull request for the 2nd time - I accidentally closed it manually the first time around)

Safari/Chrome won't alllow the response header "Access-Control-Allow-Origin: null" after sending a cross-domain request with "Origin: null"

Changed the header to "Access-Control-Allow-Origin: *" when the GET request's Origin header is "null"

This is really useful for folks running javascript from the iPhone's webview (probably applies to Android, AIR and any platform where the document domain is  the file system, e.g file:///Users/tifroz/index.html)
