### PR TITLE
Fix for memory leak in WebSocket transport

### DIFF
--- a/lib/socket.io/transports/websocket.js
+++ b/lib/socket.io/transports/websocket.js
@@ -108,6 +108,7 @@ WebSocket.prototype._onConnect = function(req, socket){
   		self.waitingForNonce = false;
   		// Stuff the nonce into the location where it's expected to be
   		self.upgradeHead = self.buffer.substr(0,8);
+                self.buffer = '';
   		if (self._proveReception(self._headers)) { self._payload(); }
   		return;
   	}


### PR DESCRIPTION
I was experiencing linear memory growth over time in proportion to quantity of messages sent over websockets to socket.io.  This bug can be duplicated by hitting a server with a high volume of messages, and watching the memory grow.  If you attach node-inspector to the process, and breakpoint the callback found at websocket.js::this.connection.addListener (line ~102), you can observe the length of self.buffer growing, with the contents of the buffer remaining even after successful message parsing by the Parser instance.
