### PR TITLE
Enabled unsecure flashsocket swf by default

### DIFF
--- a/lib/socket.io/listener.js
+++ b/lib/socket.io/listener.js
@@ -94,7 +94,8 @@ Listener.prototype._serveClient = function(file, req, res){
         'socket.io.js': 'socket.io.js',
         'lib/vendor/web-socket-js/WebSocketMain.swf': 'lib/vendor/web-socket-js/WebSocketMain.swf', // for compat with old clients
         'WebSocketMain.swf': 'lib/vendor/web-socket-js/WebSocketMain.swf',
-        'WebSocketMainInsecure.swf' : 'WebSocketMainInsecure.swf'
+        'lib/vendor/web-socket-js/WebSocketMainInsecure.swf': 'lib/vendor/web-socket-js/WebSocketMainInsecure.swf', // for compat with old clients
+        'WebSocketMainInsecure.swf' : 'lib/vendor/web-socket-js/WebSocketMainInsecure.swf'
       }
     , types = {
         swf: 'application/x-shockwave-flash',


### PR DESCRIPTION
I unzipped WebSocketMainInsecure.zip and included the mapping in the listener to make it available. Otherwise, it wasn't possible to use Socket.io va NPM OOTB unless you copied the WebSocketMainInsecure.swf and managed it and the serving of it yourself which doesn't seem right either.

My only hesitation is if it exposes more risk having WebSocketMainInsecure.swf available by default.

Mike
