### PR TITLE
patching socket.io to make adding new Transports easier

### DIFF
--- a/lib/socket.io/index.js
+++ b/lib/socket.io/index.js
@@ -19,7 +19,6 @@ exports.listen = function(server, options){
 
 exports.Listener = require('./listener');
 exports.Client = require('./client');
-
 exports.setClient = function(newClient){
   exports.Client = newClient;
 }


### PR DESCRIPTION
Hi Guillermo,

I have createded a node 2 node transport for Socket.io (see [node2node-socket.io](https://github.com/dotmaster/node2node-socket.io)).
Unfortunately I had to patch Socket.io to be able to add a new transport. I have come up with a solution, which I think is less invasive as possible.
## Modifications to Socket.io
- a static function called addTransport is exposed to the outside world to add new transports to socket.io
- the Client base class of every transport is exposed to the outside world

I hope you like the architecture and would be happy if you include it in the next release.

Best regards

Gregor
