### PR TITLE
Serve client updates

### DIFF
--- a/lib/socket.io/listener.js
+++ b/lib/socket.io/listener.js
@@ -103,6 +103,7 @@ Listener.prototype._serveClient = function(file, req, res){
       };
   
   function write(path){
+    if (!req.connection.writable) return;
     if (req.headers['if-none-match'] == clientVersion){
       res.writeHead(304);
       res.end();


### PR DESCRIPTION
There are a couple of updates _serveClient functionality.
1. When the `NODE_ENV` variable has been set to development the serve client will output the current and regular socket.io.js file. If this variable is not present or overwritten using the `options.development` property we will serve the socket.io.min.js by default. 
2. I added gzip support for all none .swf files. This is done by spawing a gzip process, feeding it the contents of the readFile and storing it inside the clientFiles object so it only happens once.

Notes on edit 1): I have also updated the support/socket.io-client to the contents this ( https://github.com/LearnBoost/Socket.IO/pull/91 ) pull request in order to have a minified build of socket.io
