### PR TITLE
io.Socket options could have smarter defaults

### DIFF
--- a/support/socket.io-client/socket.io.js
+++ b/support/socket.io-client/socket.io.js
@@ -783,9 +783,9 @@ JSONPPolling.xdomainCheck = function(){
 	var Socket = io.Socket = function(host, options){
 		this.host = host || document.domain;
 		this.options = {
-			secure: false,
+			secure: document.location.protocol == 'https:',
 			document: document,
-			port: document.location.port || 80,
+			port: document.location.port || (document.location.protocol == 'https:' ? 443 : 80),
 			resource: 'socket.io',
 			transports: ['websocket', 'flashsocket', 'htmlfile', 'xhr-multipart', 'xhr-polling', 'jsonp-polling'],
 			transportOptions: {


### PR DESCRIPTION
The client-side javascript should be able to detect if it's on a secure connection and set options.secure and options.port appropriately.
