### PR TITLE
Extended try...catch block to handle massive load

### DIFF
--- a/lib/socket.io/transports/websocket.js
+++ b/lib/socket.io/transports/websocket.js
@@ -78,46 +78,46 @@ WebSocket.prototype._onConnect = function(req, socket){
 
   try {
     this.connection.write(headers.concat('', '').join('\r\n'));
+  
+    this.connection.setTimeout(0);
+    this.connection.setNoDelay(true);
+    this.connection.setEncoding('utf-8');
+  
+    if (this.waitingForNonce) {
+        // Since we will be receiving the binary nonce through the normal HTTP
+        // data event, set the connection to 'binary' temporarily
+        this.connection.setEncoding('binary');
+        this._headers = headers;
+    }
+    else {
+      if (this._proveReception(headers)) this._payload();
+    }
+  
+    this.buffer = "";
+  
+    this.connection.addListener('data', function(data){
+      self.buffer += data;
+      if (self.waitingForNonce) {
+        if (self.buffer.length < 8) { return; }
+        // Restore the connection to utf8 encoding after receiving the nonce
+        self.connection.setEncoding('utf8');
+        self.waitingForNonce = false;
+        // Stuff the nonce into the location where it's expected to be
+        self.upgradeHead = self.buffer.substr(0,8);
+        self.buffer = self.buffer.substr(8);
+        if (self.buffer.length > 0) {
+          self.parser.add(self.buffer);
+        }
+        if (self._proveReception(self._headers)) { self._payload(); }
+        return;
+      }
+
+      self.parser.add(data);
+    });
+
   } catch(e){
     this._onClose();
   }
-  
-  this.connection.setTimeout(0);
-  this.connection.setNoDelay(true);
-  this.connection.setEncoding('utf-8');
-  
-  if (this.waitingForNonce) {
-  	// Since we will be receiving the binary nonce through the normal HTTP
-  	// data event, set the connection to 'binary' temporarily
-  	this.connection.setEncoding('binary');
-  	this._headers = headers;
-  }
-  else {
-  	if (this._proveReception(headers)) this._payload();
-  }
-  
-  this.buffer = "";
-  
-  this.connection.addListener('data', function(data){
-    self.buffer += data;
-    if (self.waitingForNonce) {
-  		if (self.buffer.length < 8) { return; }
-  		// Restore the connection to utf8 encoding after receiving the nonce
-  		self.connection.setEncoding('utf8');
-  		self.waitingForNonce = false;
-  		// Stuff the nonce into the location where it's expected to be
-  		self.upgradeHead = self.buffer.substr(0,8);
-  		self.buffer = self.buffer.substr(8);
-  		if (self.buffer.length > 0) {
-  		  self.parser.add(self.buffer);
-  		}
-  		if (self._proveReception(self._headers)) { self._payload(); }
-  		return;
-  	}
-  	
-    self.parser.add(data);
-  });
-
 };
 
 // http://www.whatwg.org/specs/web-apps/current-work/complete/network.html#opening-handshake


### PR DESCRIPTION
This pull request really only concerns commit 68822317

While running cloud9 with socket.io websocket transport enabled, we ran into the issue that Node would throw errors in net.js (internally). We patched this by putting most of the onConnect in the try...catch block.

Appears to have little to no side-effects, we're looking to find the time to perform a more extensive analysis.
