### PR TITLE
websocket transport with origins other than *:* - WebSocket connection invalid or Origin not verified                

### DIFF
--- a/lib/socket.io/client.js
+++ b/lib/socket.io/client.js
@@ -175,8 +175,8 @@ Client.prototype._verifyOrigin = function(origin){
   if (origin) {
     try {
       var parts = urlparse(origin);
-      return origins.indexOf(parts.host + ':' + parts.port) !== -1 ||
-          origins.indexOf(parts.host + ':*') !== -1 ||
+      return origins.indexOf(parts.hostname + ':' + parts.port) !== -1 ||
+          origins.indexOf(parts.hostname + ':*') !== -1 ||
           origins.indexOf('*:' + parts.port) !== -1;  
     } catch (ex) {}
   }


### PR DESCRIPTION
Hello,

Specifying e.g. 

```
var socket = io.listen(app, {
  origin: '192.168.1.110:3002'
});        
```

the second part of the client.js' `_verifyOrigin` fails to resolve the host name 

```
var parts = urlparse(origin);
return origins.indexOf(parts.host + ':' + parts.port) !== -1 ||
   origins.indexOf(parts.host + ':*') !== -1 ||
   origins.indexOf('*:' + parts.port) !== -1;  
```

and will try matching `parts.host`, which is `192.168.1.110:3002`, with the port `:3002`, which ends up being `192.168.1.110:3002:3002`.

```
$ node
> var p = require('url').parse; console.log(p('http://192.168.1.110:3002'));
  { protocol: 'http:',
  slashes: true,
  host: '192.168.1.110:3002',
  port: '3002',
  hostname: '192.168.1.110',
  pathname: '/',
  href: 'http://192.168.1.110:3002/' }                                             
```

Best Regards,
Torgeir

(and thanks for a sweet library :)             
