### PR TITLE
Buffered sends (rebased)

### DIFF
--- a/lib/socket.io/client.js
+++ b/lib/socket.io/client.js
@@ -26,21 +26,28 @@ var Client = module.exports = function(listener, req, res, options, head){
 util.inherits(Client, process.EventEmitter);
 
 Client.prototype.send = function(message){
-  if (this._shouldBuffer || !this._open || !(this.connection.readyState === 'open' || this.connection.readyState === 'writeOnly')){
+  if (!this.canSend()){
     return this._queue(message);
   }
   this._write(encode(message));
   return this;
 };
 
+Client.prototype.canSend = function(){
+  return !(this._shouldBuffer || !this._open || !(this.connection.readyState === 'open' || this.connection.readyState === 'writeOnly'));
+}
+
 Client.prototype.bufferSends = function(callback, context){
   this._shouldBuffer = true;
   try {
     callback.apply(context);
-    this._write(encode(this._writeQueue));
+    this._shouldBuffer = false;
+    if(this.canSend()){
+      this._write(encode(this._writeQueue));
+      this._writeQueue = [];
+    }
   } finally {
     this._shouldBuffer = false;
-    this._writeQueue = [];
   }
 }
 


### PR DESCRIPTION
I've done this properly so there are only 3 commits instead of others from my master branch

Since Socket.IO has the built-in functionality for encoding and delivering multiple messages, I thought it would be convenient to wrap that up in some public interface on the Client object.

```
client.bufferSends(funciton(){
  //all client.send() calls in here are added to the queue
  //and then the whole queue is sent after we return
});
```
