### PR TITLE
Request and response are being destroyed before 'connection' event handlers are called.

### DIFF
--- a/lib/socket.io/transports/xhr-polling.js
+++ b/lib/socket.io/transports/xhr-polling.js
@@ -25,6 +25,7 @@ Polling.prototype._onConnect = function(req, res){
         self._write('');
       }, this.options.duration);
       this._payload();
+      this._onClose();
       break;
       
     case 'POST':
@@ -75,6 +76,5 @@ Polling.prototype._write = function(message){
     this.response.writeHead(200, headers);
     this.response.write(message);
     this.response.end();
-    this._onClose();
   }
 };


### PR DESCRIPTION
Changed the call to _onClose() from in _write() so that request and response are preserved during 'connection' event
