### PR TITLE
Equalize message and announcement handling

### DIFF
--- a/example/chat-ssl.html
+++ b/example/chat-ssl.html
@@ -11,7 +11,7 @@
     <script>
       function message(obj){
         var el = document.createElement('p');
-        if ('announcement' in obj) el.innerHTML = '<em>' + esc(obj.announcement) + '</em>';
+        if ('announcement' in obj) el.innerHTML = '<em>' + esc(obj.announcement[0]) + ' ' + esc(obj.announcement[1]) + '</em>';
         else if ('message' in obj) el.innerHTML = '<b>' + esc(obj.message[0]) + ':</b> ' + esc(obj.message[1]);
         document.getElementById('chat').appendChild(el);
         document.getElementById('chat').scrollTop = 1000000;

--- a/example/chat.html
+++ b/example/chat.html
@@ -11,7 +11,7 @@
     <script>
       function message(obj){
         var el = document.createElement('p');
-        if ('announcement' in obj) el.innerHTML = '<em>' + esc(obj.announcement) + '</em>';
+        if ('announcement' in obj) el.innerHTML = '<em>' + esc(obj.announcement[0]) + ' ' + esc(obj.announcement[1]) + '</em>';
         else if ('message' in obj) el.innerHTML = '<b>' + esc(obj.message[0]) + ':</b> ' + esc(obj.message[1]);
         
         if( obj.message && window.console && console.log ) console.log(obj.message[0], obj.message[1]);

--- a/example/server.js
+++ b/example/server.js
@@ -48,7 +48,7 @@ var io = io.listen(server)
   
 io.on('connection', function(client){
   client.send({ buffer: buffer });
-  client.broadcast({ announcement: client.sessionId + ' connected' });
+  client.broadcast({ announcement: [client.sessionId, 'connected'] });
   
   client.on('message', function(message){
     var msg = { message: [client.sessionId, message] };
@@ -58,6 +58,6 @@ io.on('connection', function(client){
   });
 
   client.on('disconnect', function(){
-    client.broadcast({ announcement: client.sessionId + ' disconnected' });
+    client.broadcast({ announcement: [client.sessionId, 'disconnected'] });
   });
 });


### PR DESCRIPTION
This makes it possible to get rid of the client.sessionId when a announcement is displayed.
