### PR TITLE
Firefox does a CORS request (OPTION method) before sending POST requests.

### DIFF
--- a/lib/socket.io/transports/xhr-polling.js
+++ b/lib/socket.io/transports/xhr-polling.js
@@ -51,6 +51,19 @@ Polling.prototype._onConnect = function(req, res){
     , body = '';
 
   switch (req.method){
+    case 'OPTIONS':
+      res.setHeader('Content-Type', 'text/plain');
+      if (req.headers.origin){
+        if (self._verifyOrigin(req.headers.origin)){
+          res.setHeader('Access-Control-Allow-Origin', '*');
+          if (req.headers.cookie) {
+            res.setHeader('Access-Control-Allow-Credentials', 'true');
+          }
+        }
+      }
+      res.end();
+      break;
+    
     case 'GET':
       Client.prototype._onConnect.call(this, req, res);
       this._closeTimeout = setTimeout(function(){


### PR DESCRIPTION
Firefox does a CORS request (OPTION method) before sending POST requests. This fix handles this correctly and returns some headers to tell the browser that POST requests are okay.
