### PR TITLE
Optimize TCP usage, send one TCP segment instead of three.

### DIFF
--- a/lib/socket.io/transports/websocket.js
+++ b/lib/socket.io/transports/websocket.js
@@ -160,9 +160,11 @@ WebSocket.prototype._proveReception = function(headers){
 
 WebSocket.prototype._write = function(message){
   try {
-    this.connection.write('\u0000', 'binary');
-    this.connection.write(message, 'utf8');
-    this.connection.write('\uffff', 'binary');
+    var sendbuf = new Buffer(Buffer.byteLength(message, 'utf8') + 2);
+    sendbuf[0] = 0;
+    sendbuf.write(message, 1, 'utf8');
+    sendbuf[sendbuf.length - 1] = 255;
+    this.connection.write(sendbuf);
   } catch(e){
     this._onClose();
   }


### PR DESCRIPTION
Use a Buffer to construct message frame instead of multiple writes. This sends the message in a single TCP segment in most cases instead of three segments.

For example, the Socket.IO protocol heartbeat send a TCP segment with a single \x00, another with the ~m~~h..., and a final segment with \xFF. This behavior causes poor TCP performance in many cases and is inefficient.
