### PR TITLE
'send' method in Listener

### DIFF
--- a/lib/socket.io/listener.js
+++ b/lib/socket.io/listener.js
@@ -65,6 +65,18 @@ Listener.prototype.broadcast = function(message, except){
   return this;
 };
 
+Listener.prototype.send = function(message, recipient){
+  if(typeof recipient == 'number' || typeof recipient == 'string'){
+    this.clients[recipient].send(message);
+  }
+  else if(Array.isArray(recipient)){
+    for(i in recipient){
+      this.clients[recipient[i]].send(message);
+    }
+  }
+  return this;
+};
+
 Listener.prototype.check = function(req, res, httpUpgrade, head){
   var path = url.parse(req.url).pathname, parts, cn;
   if (path && path.indexOf('/' + this.options.resource) === 0){


### PR DESCRIPTION
I added a send method to Listener. It seems cleaner to do this than to have to access Listener.clients directly in order to send a message to clients based on their session IDs, and it also feels like a good compliment to the Listener.broadcast method.

The code's short and simple, and I don't see how it would break anything else, but someone who knows more about the project might want to make sure - I just saw a need for this and thought I'd suggest it.
