### PR TITLE
Tweak to get request in 'connection' event.

### DIFF
--- a/lib/socket.io/client.js
+++ b/lib/socket.io/client.js
@@ -114,9 +114,9 @@ Client.prototype._payload = function(){
   
   payload = payload.concat(this._writeQueue || []);
   this._writeQueue = [];
-
+request = this.request;
   if (payload.length) this._write(encode(payload));
-  if (this.connections === 1) this.listener._onClientConnect(this);
+  if (this.connections === 1) this.listener._onClientConnect(this,request);
   if (this.options.timeout) this._heartbeat();
 };
   

--- a/lib/socket.io/listener.js
+++ b/lib/socket.io/listener.js
@@ -143,11 +143,11 @@ Listener.prototype._serveClient = function(file, req, res){
   return false;
 };
 
-Listener.prototype._onClientConnect = function(client){
+Listener.prototype._onClientConnect = function(client, request){
   this.clients[client.sessionId] = client;
   this.options.log('Client '+ client.sessionId +' connected');
   this.emit('clientConnect', client);
-  this.emit('connection', client);
+  this.emit('connection', client, request);
 };
 
 Listener.prototype._onClientMessage = function(data, client){


### PR DESCRIPTION
I needed the request in the 'connection' event (for the cookies) and ran into the problem that xhr-polling and jsonp-polling clear client.request before the 'connection' event hooks get run. Maybe you can do something like this to make the request available to all transports, if there isn't already a way.
