### PR TITLE
Call the init for the correct transport

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -97,7 +97,7 @@ function Manager (server) {
 
   for (var i in transports) {
     if (transports[i].init) {
-      transports.flashsocket.init(this);
+      transports[i].init(this);
     }
   }
 


### PR DESCRIPTION
Instead of calling the `flashsockets` init function each time.. 
