### PR TITLE
Update unit test + send buffers instead of strings

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -424,9 +424,10 @@ Manager.prototype.handleClientRequest = function (req, res, data) {
       }
 
       cache = Manager.static.cache[file] = {
-        content: data.toString()
+        content: data
       , length: data.length
       , Etag: client.version
+      , encoding: static.encoding[extension]
       };
 
       serve();

--- a/test/manager.test.js
+++ b/test/manager.test.js
@@ -217,8 +217,11 @@ module.exports = {
       res.headers.etag.should.match(/([0-9]+)\.([0-9]+)\.([0-9]+)/);
 
       data.should.match(/XMLHttpRequest/);
-      var static = sio.Manager.static;
-      static.cache['/socket.io.js'].content.should.match(/XMLHttpRequest/);
+      var static = sio.Manager.static
+        , cache = static.cache['/socket.io.js'];
+
+      cache.content.toString().should.match(/XMLHttpRequest/);
+      Buffer.isBuffer(cache.content).should.be.true;
 
       cl.get('/socket.io/socket.io.js', function (res, data) {
         res.headers['content-type'].should.eql('application/javascript');
@@ -279,6 +282,11 @@ module.exports = {
       res.headers['content-length'].should.match(/([0-9]+)/);
       should.strictEqual(res.headers.etag, undefined);
 
+      var static = sio.Manager.static
+        , cache = static.cache['/static/flashsocket/WebSocketMain.swf'];
+
+      Buffer.isBuffer(cache.content).should.be.true;
+
       cl.end();
       io.server.close();
       done();
@@ -294,6 +302,11 @@ module.exports = {
       res.headers['content-type'].should.eql('application/x-shockwave-flash');
       res.headers['content-length'].should.match(/([0-9]+)/);
       should.strictEqual(res.headers.etag, undefined);
+
+      var static = sio.Manager.static
+        , cache = static.cache['/static/flashsocket/WebSocketMain.swf'];
+
+      Buffer.isBuffer(cache.content).should.be.true;
 
       cl.end();
       io.server.close();


### PR DESCRIPTION
Fix for encoding of the static serve and we should send buffers instead of strings
