### PR TITLE
having separate pub and sub connections helps to cope with redis queue ov

### DIFF
--- a/lib/stores/redis.js
+++ b/lib/stores/redis.js
@@ -43,7 +43,7 @@ function Redis (opts) {
   this.nodeId = nodeId();
 
   // packing / unpacking mechanism
-  if (opts.pack) {
+  if (opts.pack && opts.unpack) {
     this.pack = opts.pack;
     this.unpack = opts.unpack;
   } else {
@@ -79,8 +79,10 @@ Redis.prototype.__proto__ = Store.prototype;
 
 Redis.prototype.publish = function (name) {
   var args = Array.prototype.slice.call(1);
-  this.pub.publish(name, this.pack({ nodeId: this.nodeId, args: args }));
-  this.emit.apply(this, ['publish', name].concat(args));
+  try {
+     this.pub.publish(name, this.pack({ nodeId: this.nodeId, args: args }));
+     this.emit.apply(this, ['publish', name].concat(args));
+  catch(err) { /* ... */ }
 };
 
 /**
@@ -98,7 +100,7 @@ Redis.prototype.subscribe = function (name, fn, once) {
     self.sub.on('subscribe', function subscribe (ch) {
       if (name == ch) {
         function message (ch, msg) {
-          if (name == ch) {
+          if (name == ch) try {
             msg = this.unpack(msg);
 
             // we check that the message consumed wasnt emitted by this node
@@ -109,7 +111,7 @@ Redis.prototype.subscribe = function (name, fn, once) {
                 self.sub.removeListener('message', message);
               }
             }
-          }
+          } catch(err) { /*...*/ }
         };
 
         self.sub.on('message', message);


### PR DESCRIPTION
having separate pub and sub connections helps to cope with redis queue overflow; added Client#has, #Client#del; accessors made async friendly
