### PR TITLE
redis.js syntax error, fix.

### DIFF
--- a/lib/stores/redis.js
+++ b/lib/stores/redis.js
@@ -1,4 +1,3 @@
-
 /*!
  * socket.io-node
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
@@ -124,7 +123,7 @@ Redis.prototype.subscribe = function (name, fn, once) {
 
         self.pubsub.removeListener('subscribe', subscribe);
       }
-    }
+    });
   }
 
   this.emit('subscribe', name, fn, once);


### PR DESCRIPTION
fixes the syntax error on line 128 of lib/stores/redis.js
