### PR TITLE
Issue #313 TypeError: Object #<CleartextStream> has no method 'address'

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -807,9 +807,13 @@ Manager.prototype.handleHandshake = function (data, req, res) {
  */
 
 Manager.prototype.handshakeData = function (data) {
+  var connectionAddress = null;
+  if (data.request.connection.address) {
+    connectionAddress = data.request.connection.address();
+  }
   return {
       headers: data.headers
-    , address: data.request.connection.address()
+    , address: connectionAddress
     , time: (new Date).toString()
     , xdomain: !!data.request.headers.origin
     , secure: data.request.connection.secure


### PR DESCRIPTION
This patch is really simple, naive and has no concept of side effects. Though it does avoid the error that I was getting on initial connection. 

Have any thoughts about this?
