### PR TITLE
new handshake data passing for custom authorization functions

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -886,9 +886,9 @@ Manager.prototype.authorize = function (data, fn) {
   if (this.get('authorization')) {
     var self = this;
 
-    this.get('authorization').call(this, data, function (err, authorized) {
+    this.get('authorization').call(this, data, function (err, authorized, newData) {
       self.log.debug('client ' + authorized ? 'authorized' : 'unauthorized');
-      fn(err, authorized);
+      fn(err, authorized, newData);
     });
   } else {
     this.log.debug('client authorized');


### PR DESCRIPTION
`Manager#handleHandshake` implementation supposes passing `newData` object to the callback. `newData` wil substitute the default handshake data if provided, but `Manager#authorize` ignores any `newData` passed from custom authorization function. Fixed in this commit.

```
io.set('authorization', function(data, cb) {
    cb(null, true, { custom: 'data' });
});

io.sockets.on('connection', function(socket) {
    console.log(socket.handshake.custom); // will print 'data'
});
```
