### PR TITLE
Client IP instead of server IP for connectionAddress.

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -1,4 +1,3 @@
-
 /*!
  * socket.io-node
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
@@ -821,9 +820,9 @@ Manager.prototype.handshakeData = function (data) {
     , connectionAddress;
 
   if (connection.address) {
-    connectionAddress = connection.address();
+    connectionAddress = connection.remoteAddress; // Bug fix, returns client IP instead of .address() which was returning server IP
   } else if (connection.socket && connection.socket.address) {
-    connectionAddress = connection.socket.address()
+    connectionAddress = connection.socket.address(); // Do we need .remoteAddress here too?
   }
 
   return {


### PR DESCRIPTION
Updated Manager.prototype.handshakeData to provide connection.remoteAddress instead of .address() because .address() was returning server IP and .remoteAddress returns client IP.
