### PR TITLE
Expose path and querystring in handshakeData

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -829,6 +829,8 @@ Manager.prototype.handshakeData = function (data) {
       headers: data.headers
     , address: connectionAddress
     , time: (new Date).toString()
+    , query: data.query
+    , url: data.request.url
     , xdomain: !!data.request.headers.origin
     , secure: data.request.connection.secure
   };


### PR DESCRIPTION
Related issue: #334 if we expose query strings authentication can be based on that, as intended in socket.io protocol specification.

Related issue on the client: https://github.com/LearnBoost/socket.io-client/issues/225
