### PR TITLE
Example typo fixed (missing closing '}' in server js )

### DIFF
--- a/index.html
+++ b/index.html
@@ -395,7 +395,7 @@ io.sockets.on('connection', function (socket) {
 var io = require('socket.io').listen(80);
 
 io.sockets.on('connection', function (socket) {
-  io.sockets.emit('this', { will: 'be received by everyone');
+  io.sockets.emit('this', { will: 'be received by everyone'});
 
   socket.on('private message', function (from, msg) {
     console.log('I received a private message by ', from, ' saying ', msg);


### PR DESCRIPTION
syntax error in the example code
