### PR TITLE
Initial logging output (instantiation of manager) delayed

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -51,7 +51,6 @@ var parent = module.parent.exports
  * Manager constructor.
  *
  * @param {HTTPServer} server
- * @param {Object} options, optional
  * @api public
  */
 


### PR DESCRIPTION
When instantiating socket.io with `listen()` and passing a server instance as the first argument, I immediately get colored output on the console from `Manager()`. This is mildly annoying because I'm using a different strategy for outputting messages from socket.io. If this initial output is delayed the shortest amount possible (with `process.nextTick`) I can provide my own logging settings. 

Normally I guess the `options` object from the second argument of `listen()` should reach `Manager()` to override/mixin with the default settings but I'm not sure if that ties in properly with the new, express-style of configuration.
