### PR TITLE
Added alias for to to in and in to to

### DIFF
--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -108,7 +108,7 @@ SocketNamespace.prototype.__defineGetter__('volatile', function () {
  * @api public
  */
 
-SocketNamespace.prototype.in = function (room) {
+SocketNamespace.prototype.in = SocketNamespace.prototype.to = function (room) {
   this.flags.endpoint = this.name + (room ? '/' + room : '');
   return this;
 };

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -106,7 +106,7 @@ Socket.prototype.__defineGetter__('broadcast', function () {
  * @api public
  */
 
-Socket.prototype.to = function (room) {
+Socket.prototype.to = Socket.prototype.in = function (room) {
   this.flags.room = room;
   return this;
 };


### PR DESCRIPTION
To prevent further confusion about different method names in of a socket and a namespace. 
