### PR TITLE
Utilise X-FORWARDED-[FOR|PORT] headers -- Means things work properly when behind a reverse proxy.

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -807,10 +807,10 @@ Manager.prototype.handleHandshake = function (data, req, res) {
 Manager.prototype.handshakeData = function (data) {
   var connection = data.request.connection
     , connectionAddress;
-  if (connection.headers['x-forwarded-for']) {
+  if (data.request.headers['x-forwarded-for']) {
     connectionAddress = {
-      address: connection.headers['x-forwarded-for'],
-      port: connection.headers['x-forwarded-port'] || 80
+      address: data.request.headers['x-forwarded-for'],
+      port: data.request.headers['x-forwarded-port'] || 80
     };
   } else if (connection.remoteAddress) {
     connectionAddress = {


### PR DESCRIPTION
Quite a simple patch really; but necessary when working behind reverse proxies.
