### PR TITLE
Send response once we got all POST data, not immediately 

### DIFF
--- a/lib/transports/http.js
+++ b/lib/transports/http.js
@@ -54,6 +54,9 @@ HTTPTransport.prototype.handleRequest = function (req) {
     });
 
     req.on('end', function () {
+      res.writeHead(200, headers);
+      res.end('1');
+      
       self.onData(self.postEncoded ? qs.parse(buffer).d : buffer);
     });
 
@@ -65,9 +68,6 @@ HTTPTransport.prototype.handleRequest = function (req) {
         headers['Access-Control-Allow-Credentials'] = 'true';
       }
     }
-
-    res.writeHead(200, headers);
-    res.end('1');
   } else {
     this.response = req.res;
 


### PR DESCRIPTION
I noticed that the combination socket.io <-> nginx <-> firefox fails sometimes. When the browser sends a message via post, the server doesn't get the full post data. It only gets the first chunk and the end event is never fired. That happens randomly but I was able to stop this problem by sending the response once we've got all POST data, not immediately 
