### PR TITLE
updated package.json with new build of policyfile and redis

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     }
   , "dependencies": {
         "socket.io-client": "0.7.4"
-      , "policyfile": "0.0.3"
-      , "redis": "0.6.5"
+      , "policyfile": "0.0.4"
+      , "redis": "0.6.6"
     }
   , "devDependencies": {
         "expresso": "0.7.7"


### PR DESCRIPTION
As the policyfile server didn't wrap `res.end` in a try catch block yet
and a new redis driver is out
