### PR TITLE
Fixed a bug: GET "/socket.io/socket.io.js.min" throws Error

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -955,7 +955,9 @@ Manager.prototype.checkRequest = function (req) {
       data.protocol = Number(pieces[1]);
       data.transport = pieces[2];
       data.id = pieces[3];
-      data.static = !!Manager.static.paths[path];
+      if (path !== '/socket.io.js.min') {
+        data.static = !!Manager.static.paths[path];
+      }
     };
 
     return data;

--- a/test/manager.test.js
+++ b/test/manager.test.js
@@ -133,6 +133,23 @@ module.exports = {
     });
   },
 
+  'test that the particular requests doesnt fail': function (done) {
+    var server = http.createServer();
+    var io = sio.listen(server)
+      , port = ++ports
+      , cl = client(port);
+
+    server.listen(ports);
+    cl.get('/socket.io/socket.io.js.min', function (res, data) {
+      res.statusCode.should.eql(200);
+      data.should.eql('Welcome to socket.io.');
+
+      cl.end();
+      server.close();
+      done();
+    });
+  },
+
   'test that the client is served': function (done) {
     var port = ++ports
       , io = sio.listen(port)


### PR DESCRIPTION
Manager.static.paths includes a key "/socket.io.js.min" and GET request for this PATH will serve "socket.io.min.js". but the PATH is "socket.io.js.min" that doesn't has mime type.
I fixed Manager not to serve static content for "socket.io.js.min".
