### PR TITLE
correctly unescape the send values, as we are doing a manual escape on th

### DIFF
--- a/lib/transports/http.js
+++ b/lib/transports/http.js
@@ -54,7 +54,7 @@ HTTPTransport.prototype.handleRequest = function (req) {
     });
 
     req.on('end', function () {
-      self.onData(self.postEncoded ? qs.parse(buffer).d : buffer);
+      self.onData(self.postEncoded ? unescape(qs.parse(buffer).d) : buffer);
     });
 
     if (origin) {


### PR DESCRIPTION
correctly unescape the send values, as we are doing a manual escape on the client side
