### PR TITLE
Timeout for handshaken clients which never connect to fix memory leak

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -279,6 +279,16 @@ Manager.prototype.initStore = function () {
 
 Manager.prototype.onHandshake = function (id, data) {
   this.handshaken[id] = data;
+
+  // set timeout to filter clients which handshake and never connect.
+  if (!this.connected[id]) {
+    var self = this;
+    setTimeout(function () {
+      if (!self.connected[id] && self.handshaken[id]) {
+        delete self.handshaken[id];
+      }
+    }, this.get('client store expiration') * 1000);
+  }
 };
 
 /**


### PR DESCRIPTION
Under some circumstances there seem to be clients which only perform one handshake and are then never seen again. I don't know the exact source of the problem, but it shouldn't affect the server. However, this problem introduces a memory leak in manager.js. The clients are not correctly removed from the "handshaken" member in manager.js, leading to a memory leak and frequent crashes of the server because of constantly increasing load and cpu (most probably because of operations on this member taking longer and longer).

Here is a graph to illustrate the problem:
http://img684.imageshack.us/img684/9707/handshakememleak.png

(The drop at around 18:00 was the result of a crash)

The fix introduces a timeout which fires after the "client store expiration" and checks if the client has connected within the given interval. If he hasn't, the client is deleted from the "handshaken" member. This fixes the problem of the evergrowing "handshaken" member.
