### PR TITLE
Testsuite fixes

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -104,8 +104,9 @@ function Manager (server, options) {
     clearInterval(self.gc);
   });
 
-  // run our private gc every 10 seconds
-  this.gc = setInterval(this.garbageCollection.bind(this), 10000);
+  server.once('listening', function () {
+    self.gc = setInterval(self.garbageCollection.bind(self), 10000);
+  });
 
   for (var i in transports) {
     if (transports[i].init) {


### PR DESCRIPTION
We should only start our `gc` on when the server starts listening for events. Or we could prevent node from closing if a non listening server has been used.
