### PR TITLE
Added socket.io-flashsocket default port

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -71,7 +71,7 @@ function Manager (server, options) {
     , 'heartbeat interval': 20
     , 'polling duration': 20
     , 'flash policy server': true
-    , 'flash policy port': 843
+    , 'flash policy port': 10843
     , 'destroy upgrade': true
     , 'browser client': true
     , 'browser client minification': false


### PR DESCRIPTION
Yups, no more root required See https://github.com/LearnBoost/socket.io-client/pull/273
