### PR TITLE
Added http referrer verification to manager.js verifyOrigin

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -866,7 +866,7 @@ Manager.prototype.handshakeData = function (data) {
  */
 
 Manager.prototype.verifyOrigin = function (request) {
-  var origin = request.headers.origin
+  var origin = request.headers.origin || request.headers.referer
     , origins = this.get('origins');
 
   if (origin === 'null') origin = '*';
@@ -878,14 +878,19 @@ Manager.prototype.verifyOrigin = function (request) {
   if (origin) {
     try {
       var parts = url.parse(origin);
-
-      return
-        ~origins.indexOf(parts.host + ':' + parts.port) ||
-        ~origins.indexOf(parts.host + ':*') ||
+      var ok =
+        ~origins.indexOf(parts.hostname + ':' + parts.port) ||
+        ~origins.indexOf(parts.hostname + ':*') ||
         ~origins.indexOf('*:' + parts.port);
-    } catch (ex) {}
+      if (!ok) this.log.warn('illegal origin: ' + origin);
+      return ok;
+    } catch (ex) {
+      this.log.warn('error parsing origin');
+    }
   }
-
+  else {
+    this.log.warn('origin missing from handshake, yet required by config');        
+  }
   return false;
 };
 

--- a/test/manager.test.js
+++ b/test/manager.test.js
@@ -472,6 +472,91 @@ module.exports = {
     });
   },
 
+  'test that a referer is accepted for *:* origin': function (done) {
+    var port = ++ports
+      , io = sio.listen(port)
+      , cl = client(port);
+
+    io.configure(function () {
+      io.set('origins', '*:*');
+    });
+
+    cl.get('/socket.io/{protocol}', { headers: { referer: 'http://foo.bar.com:82/something' } }, function (res, data) {
+      res.statusCode.should.eql(200);
+      cl.end();
+      io.server.close();
+      done();
+    });
+  },
+
+  'test that valid referer is accepted for addr:* origin': function (done) {
+    var port = ++ports
+      , io = sio.listen(port)
+      , cl = client(port);
+
+    io.configure(function () {
+      io.set('origins', 'foo.bar.com:*');
+    });
+
+    cl.get('/socket.io/{protocol}', { headers: { referer: 'http://foo.bar.com/something' } }, function (res, data) {
+      res.statusCode.should.eql(200);
+      cl.end();
+      io.server.close();
+      done();
+    });
+  },
+
+  'test that erroneous referer is denied for addr:* origin': function (done) {
+    var port = ++ports
+      , io = sio.listen(port)
+      , cl = client(port);
+
+    io.configure(function () {
+      io.set('origins', 'foo.bar.com:*');
+    });
+
+    cl.get('/socket.io/{protocol}', { headers: { referer: 'http://baz.bar.com/something' } }, function (res, data) {
+      res.statusCode.should.eql(403);
+      cl.end();
+      io.server.close();
+      done();
+    });
+  },
+
+  'test that valid referer port is accepted for addr:port origin': function (done) {
+    var port = ++ports
+      , io = sio.listen(port)
+      , cl = client(port);
+
+    io.configure(function () {
+      io.set('origins', 'foo.bar.com:81');
+    });
+
+    cl.get('/socket.io/{protocol}', { headers: { referer: 'http://foo.bar.com:81/something' } }, function (res, data) {
+      res.statusCode.should.eql(200);
+      cl.end();
+      io.server.close();
+      done();
+    });
+  },
+
+  'test that erroneous referer port is denied for addr:port origin': function (done) {
+    var port = ++ports
+      , io = sio.listen(port)
+      , cl = client(port);
+
+    io.configure(function () {
+      io.set('origins', 'foo.bar.com:81');
+    });
+
+    cl.get('/socket.io/{protocol}', { headers: { referer: 'http://foo.bar.com/something' } }, function (res, data) {
+      res.statusCode.should.eql(403);
+      cl.end();
+      io.server.close();
+      done();
+    });
+  },
+
   'test limiting the supported transports for a manager': function (done) {
     var port = ++ports
       , io = sio.listen(port)


### PR DESCRIPTION
Previously submitted, but got obscured due to additional hybi10 changes.

Previous comments:
The verifyOrigin call does, as far as I can tell, only handle http requests related to pre-transport handshaking. As such, the verifyOrigin call really should either be renamed in the future, or also be used for transport source verification -- granted the ability of all transports to provide this.
