### PR TITLE
Setting disconnected = true prior to firing disconnect event, to avoid sc

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -1,4 +1,3 @@
-
 /*!
  * socket.io-node
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
@@ -133,8 +132,8 @@ Socket.prototype.setFlags = function () {
 
 Socket.prototype.onDisconnect = function (reason) {
   if (!this.disconnected) {
-    this.$emit('disconnect', reason);
     this.disconnected = true;
+    this.$emit('disconnect', reason);
   }
 };
 


### PR DESCRIPTION
Setting disconnected = true prior to firing disconnect event, to avoid scenario where socket disconnected is set to false inside disconnect event.

Should fix #483, although not tested.
