### PR TITLE
Proposal to allow clients to specify a sessionid when connecting.  (bug 497)

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -796,8 +796,13 @@ Manager.prototype.handleHandshake = function (data, req, res) {
     if (err) return error(err);
 
     if (authorized) {
-      var id = self.generateId()
-        , hs = [
+      var id = self.generateId();
+
+      if((typeof data.query !== 'undefined') && (typeof data.query.sessionid !== 'undefined')){
+        id = data.query.sessionid;
+      }
+
+      var hs = [
               id
             , self.enabled('heartbeats') ? self.get('heartbeat timeout') || '' : ''
             , self.get('close timeout') || ''

--- a/test/manager.test.js
+++ b/test/manager.test.js
@@ -411,6 +411,21 @@ module.exports = {
     });
   },
 
+  'test handshake with provided sessionid': function(done){
+    var port = ++ports
+      , io = sio.listen(port)
+      , cl = client(port);
+      
+      cl.get('/socket.io/{protocol}/?sessionid=1234', function (res, data) {
+        res.statusCode.should.eql(200);
+        data.should.match(/1234:([0-9]+)?:([0-9]+)?:(.+)/);
+
+        cl.end();
+        io.server.close();
+        done();
+      });  
+  },
+
   'test handshake with unsupported protocol version': function (done) {
     var port = ++ports
       , io = sio.listen(port)


### PR DESCRIPTION
This is a proposal for new functionality.

The intended use case is to allow clients to reconnect using the same sessionid that they originally connected with. This, combined with the RedisStore would allow a socket server to fall out of a cluster, a client to reconnect to another server in the cluster, all while maintaining data associated with the socket.

My proposal would be to modify the Manager.handleHandshake method to pull a sessionid from the query if it exists.

In order to utilize this feature, clients would have to set the sessoinid in the socket.options.query (client).

Any thoughts?
