### PR TITLE
fixed typo socket.io.js.min -> socket.io.min.js

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -665,7 +665,7 @@ Manager.static = {
       , '/static/flashsocket/WebSocketMainInsecure.swf':
           client.dist + '/WebSocketMainInsecure.swf'
       , '/socket.io.js':  client.dist + '/socket.io.js'
-      , '/socket.io.js.min': client.dist + '/socket.io.min.js'
+      , '/socket.io.min.js': client.dist + '/socket.io.min.js'
     }
   , mime: {
         'js': {


### PR DESCRIPTION
I guess, that this is just a typo. I tried to get the minified socket.io client code and failed. A quick look in https://github.com/LearnBoost/socket.io/blob/master/lib/manager.js#L668 revealed the problem.
