### PR TITLE
Assume 'development' environment if NODE_ENV is not set

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -236,7 +236,9 @@ Manager.prototype.disabled = function (key) {
 Manager.prototype.configure = function (env, fn) {
   if ('function' == typeof env) {
     env.call(this);
-  } else if (env == process.env.NODE_ENV) {
+  } else if (env == process.env.NODE_ENV ||
+             (!process.env.NODE_ENV && env == 'development'))
+  {
     fn.call(this);
   }
 


### PR DESCRIPTION
And therefore run all the configurations for the 'development' environment
