### PR TITLE
Expanded 'How to Use' in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,6 +46,13 @@ Finally, load it from the client side code:
 </script>
 ```
 
+The client-side javascript is not a static file, but instead is served through the 
+same port that the socket is listening on. In many configurations, port 80 will already 
+be running a web service and the socket.io listener will have to be moved to another 
+port. If you set (for example) `app.listen(8000);` then your script source will require:
+
+ `<script src="http://localhost:8000/socket.io/socket.io.js"></script>`
+
 For more thorough examples, look at the `examples/` directory.
 
 ## Short recipes


### PR DESCRIPTION
Hi Socket.IO team.  I was trying to "learn myself" some socket.io over the weekend and found I had some difficulty with the "beginner section" sample code.  My understanding of where the client side version of the  "socket.io.js" file was unclear.

I think I had some difficulty, because port 80 is so often reserved for the "main" http server.

As a learner, my preference would be for the sample code to start socket.io on a port other than 80 - but I assume there's a good reason for your choice of port 80 in the sample code. I hope the additional 'blurb' I added to the readme is useful for other learners.
