### PR TITLE
Removing connection id and fixed npe for multi-node redis-store environment

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -468,13 +468,13 @@ Manager.prototype.onClientMessage = function (id, packet) {
  * @api private
  */
 
-Manager.prototype.onClientDisconnect = function (id, reason, local) {
+Manager.prototype.onClientDisconnect = function (id, reason) {
   for (var name in this.namespaces) {
     this.namespaces[name].handleDisconnect(id, reason, typeof this.roomClients[id] !== 'undefined' &&
       typeof this.roomClients[id][name] !== 'undefined');
   }
 
-  this.onDisconnect(id, local);
+  this.onDisconnect(id);
 };
 
 /**

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -457,15 +457,14 @@ Transport.prototype.end = function (reason) {
   if (!this.disconnected) {
     this.log.info('transport end');
 
-    var local = !!this.manager.transports[this.id];
+    var local = this.manager.transports[this.id];
 
     this.close();
     this.clearTimeouts();
     this.disconnected = true;
 
-
     if (local) {
-      this.manager.onClientDisconnect(this.id, reason, local);
+      this.manager.onClientDisconnect(this.id, reason, true);
     } else {
       this.store.publish('disconnect:' + this.id, reason);
     }


### PR DESCRIPTION
Fixes:
1) I came across the issue with redis-store running on multiple node server, that session id doesn't get removed from the rooms when client gets disconnected
2) When I start the new node server when some are already running it crashes with following error

throw arguments[1]; // Unhandled 'error' event

^
TypeError: Cannot convert null to object
at DELETE (native)
at Manager.onLeave (/usr/local/rails/node-api/node_modules/socket.io/lib/manager.js:393:28)
at /usr/local/rails/node-api/node_modules/socket.io/lib/manager.js:270:10
at RedisClient.message (/usr/local/rails/node-api/node_modules/socket.io/lib/stores/redis.js:155:26)
at RedisClient.emit (events.js:81:20)
at RedisClient.return_reply (/usr/local/rails/node-api/node_modules/socket.io/node_modules/redis/index.js:440:22)
at RedisReplyParser. (/usr/local/rails/node-api/node_modules/socket.io/node_modules/redis/index.js:81:14)
at RedisReplyParser.emit (events.js:64:17)
at RedisReplyParser.add_multi_bulk_reply (/usr/local/rails/node-api/node_modules/socket.io/node_modules/redis/lib/parser/javascript.js:311:14)
at RedisReplyParser.send_reply (/usr/local/rails/node-api/node_modules/socket.io/node_modules/redis/lib/parser/javascript.js:272:18)
