### PR TITLE
Blacklist events

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -67,7 +67,7 @@ function Manager (server, options) {
     , resource: '/socket.io'
     , transports: defaultTransports
     , authorization: false
-    , blacklist: ['connect', 'disconnect']
+    , blacklist: ['disconnect']
     , 'log level': 3
     , 'close timeout': 25
     , 'heartbeat timeout': 15

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -297,7 +297,7 @@ SocketNamespace.prototype.handlePacket = function (sessid, packet) {
       if (packet.endpoint == '') {
         connect();
       } else {
-        var manager = handshakeData = manager.handshaken[sessid];
+        var handshakeData = manager.handshaken[sessid];
 
         this.authorize(handshakeData, function (err, authorized, newData) {
           if (err) return error(err);
@@ -324,6 +324,8 @@ SocketNamespace.prototype.handlePacket = function (sessid, packet) {
     case 'event':
       // check if the emitted event is not blacklisted
       if (-~manager.get('blacklist').indexOf(packet.name)) {
+        this.log.debug('ignoring blacklisted event `' + packet.name + '`');
+      } else {
         var params = [packet.name].concat(packet.args);
 
         if (dataAck) {
@@ -331,8 +333,6 @@ SocketNamespace.prototype.handlePacket = function (sessid, packet) {
         }
 
         socket.$emit.apply(socket, params);
-      } else {
-        this.log.info('ignoring blacklisted event ' + packet.name);
       }
       break;
 


### PR DESCRIPTION
Blacklisten events that are send by client. This will disallow the `disconnect` event to be triggered from the client side.

Evil do'ers can just hack in to the io.sockets and emit this ;o.

![PULL ALL THE THINGS](http://images.memegenerator.net/instances/400x/10546806.jpg)
