### PR TITLE
normalize the upgrade header to lowercase for ie 10 compatibility

### DIFF
--- a/lib/transports/websocket/hybi-07-12.js
+++ b/lib/transports/websocket/hybi-07-12.js
@@ -84,8 +84,9 @@ WebSocket.prototype.protocolVersion = '07-12';
 
 WebSocket.prototype.onSocketConnect = function () {
   var self = this;
+  var upgrade = this.req.headers.upgrade.toLowerCase();
 
-  if (this.req.headers.upgrade !== 'websocket') {
+  if (upgrade !== 'websocket') {
     this.log.warn(this.name + ' connection invalid');
     this.end();
     return;


### PR DESCRIPTION
Just started using IE 10's WebSocket implementation and noticed the upgrade header they send does not match the case tested for in the `hybi-07-12.js` source.

This simple patch allows WebSockets to be used successfully in the latest IE 10 developer preview.
