### PR TITLE
This patch will prevent some random memory leaking.

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -267,7 +267,6 @@ Manager.prototype.initStore = function () {
   this.connected = {};
   this.open = {};
   this.closed = {};
-  this.closedA = [];
   this.rooms = {};
   this.roomClients = {};
 
@@ -338,8 +337,6 @@ Manager.prototype.onOpen = function (id) {
   // if we were buffering messages for the client, clear them
   if (this.closed[id]) {
     var self = this;
-
-    this.closedA.splice(this.closedA.indexOf(id), 1);
 
     this.store.unsubscribe('dispatch:' + id, function () {
       delete self.closed[id];
@@ -429,7 +426,6 @@ Manager.prototype.onClose = function (id) {
   }
 
   this.closed[id] = [];
-  this.closedA.push(id);
 
   var self = this;
 
@@ -504,7 +500,6 @@ Manager.prototype.onDisconnect = function (id, local) {
 
   if (this.closed[id]) {
     delete this.closed[id];
-    this.closedA.splice(this.closedA.indexOf(id), 1);
   }
 
   if (this.roomClients[id]) {


### PR DESCRIPTION
The internal closedA object was leaking memory while being totally useless.

It had issues with its size, at random times socket.io stopped removing keys from it,
I found that (Object.keys(closedA).length) was more than 350,000 after running for 10 hours.

Edit: i made some more tests, this really fixes a large memory leak, atleast on node 0.4.8
