### PR TITLE
Third-party transport access attempt fix.

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -525,7 +525,24 @@ Manager.prototype.onDisconnect = function (id, local) {
 
 Manager.prototype.handleRequest = function (req, res) {
   var data = this.checkRequest(req);
-
+  
+  // Check if the request id is already assigned to a transport
+  if (this.transports[data.id]) {
+    // Get the real client IPs if we are begind a proxy like node-http-proxy
+    var finalRemoteAddress1 = this.transports[data.id].req.headers['x-forwarded-for'] || this.transports[data.id].req.connection.remoteAddress;
+    var finalRemoteAddress2 = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+    
+    // Check if the new request's client IP matches the original transport client IP
+    if (finalRemoteAddress1 != finalRemoteAddress2) {
+      // The new connection comes from a different IP from the original so drop it
+      console.log('Access to transport from third-party IP attempted from ' + finalRemoteAddress2);
+      res.writeHead(404);
+      res.end('404');
+      
+      return;
+    }
+  }
+  
   if (!data) {
     for (var i = 0, l = this.oldListeners.length; i < l; i++) {
       this.oldListeners[i].call(this.server, req, res);


### PR DESCRIPTION
Updated handleRequest method to provide protection from third-party client access attempt to same transport ID. See issue 619 https://github.com/LearnBoost/socket.io/issues/619 for more information about why this fix is required.
