### PR TITLE
Socket.IO .listen() options, added host as option

### DIFF
--- a/lib/socket.io.js
+++ b/lib/socket.io.js
@@ -1,4 +1,3 @@
-
 /*!
  * socket.io-node
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
@@ -64,7 +63,10 @@ exports.listen = function (server, options, fn) {
       res.end('Welcome to socket.io.');
     });
 
-    server.listen(port, fn);
+    if(options && options.hostname)
+      server.listen(port, options.hostname, fn);
+    else
+      server.listen(port, fn);
   }
 
   // otherwise assume a http/s server


### PR DESCRIPTION
I am semi-new to Node.JS but this was a simple add-in for configuring socket.io to support hostname/network interface binding specifics, as I do not see a way to directly assign socket.io to a specific network interface.

The only draw back I can see is that host gets passed into https createServer as an option, but it does not seam to affect server creation.
