### PR TITLE
Stop leaking Redis channels on client disconnect

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -474,7 +474,8 @@ Manager.prototype.onClientDisconnect = function (id, reason) {
       typeof this.roomClients[id][name] !== 'undefined');
   }
 
-  this.onDisconnect(id);
+  this.onDisconnect(id, true);
+  this.store.publish('disconnect', id);
 };
 
 /**


### PR DESCRIPTION
Fix for issue #663. I don't completely understand the dispatch/closed client buffering stuff, so please check me on this, but we definitely want to send a 'disconnect' mesage to the other processes so that they can close the 'dispatch:id' subscriptions that they opened while processing the 'close' message. 

Also, it looks like the original intent was to call onDisconnect with local=true for the process that was actually connected, so that it closes its 'message:id'' and 'disconnect:id' subscriptions.

So with this change we leak 0 Redis channels (instead of 3), and clean up this.closed.
