### PR TITLE
Use zlib.gzip instead of child_process.spawn("gzip")

### DIFF
--- a/lib/static.js
+++ b/lib/static.js
@@ -169,11 +169,11 @@ Static.prototype.init = function () {
  * @api public
  */
 
-Static.prototype.gzip = function (data, callback) {
-  if (zlib) {
-    // use zlib module if available.
-    return zlib.gzip(data, callback);
-  }
+Static.prototype.gzip = zlib 
+ ? function (data, callback) {
+  return zlib.gzip(data, callback);
+}
+ : function (data, callback) {
   var gzip = cp.spawn('gzip', ['-9', '-c', '-f', '-n'])
     , encoding = Buffer.isBuffer(data) ? 'binary' : 'utf8'
     , buffer = []


### PR DESCRIPTION
If zlib module available, use it instead of child_process.spawn("gzip")
