### PR TITLE
Improve performance of parser.decodePayload

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -234,7 +234,7 @@ exports.decodePayload = function (data) {
 
     for (var i = 1, length = ''; i < data.length; i++) {
       if (data[i] == '\ufffd') {
-        ret.push(exports.decodePacket(data.substr(i + 1).substr(0, length)));
+        ret.push(exports.decodePacket(data.substr(i + 1, length)));
         i += Number(length) + 1;
         length = '';
       } else {


### PR DESCRIPTION
this combines the two substr calls that were happening in decodePayload into one call.

I ran benchmark before and after on this change, the relevant decode packer payload ops/second are bellow

Before: 121934.70 and 124131.01
after: 133308.74 and 146079.29

so while not scientific it seems to speeds things up by about 13%
