### PR TITLE
Update express version in samples

### DIFF
--- a/examples/chat/package.json
+++ b/examples/chat/package.json
@@ -3,7 +3,7 @@
   , "description": "example chat application with socket.io"
   , "version": "0.0.1"
   , "dependencies": {
-        "express": "2.5.0"
+        "express": ">=2.5.5"
       , "jade": "0.16.4"
       , "stylus": "0.19.0"
       , "nib": "0.2.0"

--- a/examples/irc-output/package.json
+++ b/examples/irc-output/package.json
@@ -2,7 +2,7 @@
     "name": "socket.io-irc"
   , "version": "0.0.1"
   , "dependencies": {
-        "express": "2.5.0"
+        "express": ">=2.5.5"
       , "jade": "0.16.4"
       , "stylus": "0.19.0"
       , "nib": "0.2.0"


### PR DESCRIPTION
There's an issue with Express 2.5.0 on Windows, which breaks the socket.io samples. Updating to >=2.5.5 should resolve this.
