### PR TITLE
if using 'match origin protocol',occasional .match of undefined

### DIFF
--- a/lib/transports/websocket/hybi-07-12.js
+++ b/lib/transports/websocket/hybi-07-12.js
@@ -1,4 +1,3 @@
-
 /*!
  * socket.io-node
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
@@ -98,8 +97,12 @@ WebSocket.prototype.onSocketConnect = function () {
     return;
   }
 
-  var origin = this.req.headers['sec-websocket-origin']
-    , location = ((this.manager.settings['match origin protocol'] ?
+  var origin = this.req.headers['sec-websocket-origin'];
+  if (origin === null)
+  {
+     origin = 'http'; // default to http
+  }
+    var location = ((this.manager.settings['match origin protocol'] ?
                       origin.match(/^https/) : this.socket.encrypted) ?
                         'wss' : 'ws')
                + '://' + this.req.headers.host + this.req.url;


### PR DESCRIPTION
If using 'match origin protocol' I've noticed occasionally that the origin will be null, in which case .match is called on something undefined and things break. This just makes sure origin is at least http and not null.
