### PR TITLE
Supplemental fix to gavinuhma/authfix, it looks like the same Access-Control-Origin logic is needed in the http and xhr-polling transports

### DIFF
--- a/lib/transports/http.js
+++ b/lib/transports/http.js
@@ -72,11 +72,8 @@ HTTPTransport.prototype.handleRequest = function (req) {
 
     if (origin) {
       // https://developer.mozilla.org/En/HTTP_Access_Control
-      headers['Access-Control-Allow-Origin'] = '*';
-
-      if (req.headers.cookie) {
-        headers['Access-Control-Allow-Credentials'] = 'true';
-      }
+      headers['Access-Control-Allow-Origin'] = origin;
+      headers['Access-Control-Allow-Credentials'] = 'true';
     }
   } else {
     this.response = req.res;

--- a/lib/transports/xhr-polling.js
+++ b/lib/transports/xhr-polling.js
@@ -59,11 +59,8 @@ XHRPolling.prototype.doWrite = function (data) {
 
   if (origin) {
     // https://developer.mozilla.org/En/HTTP_Access_Control
-    headers['Access-Control-Allow-Origin'] = '*';
-
-    if (this.req.headers.cookie) {
-      headers['Access-Control-Allow-Credentials'] = 'true';
-    }
+    headers['Access-Control-Allow-Origin'] = origin;
+    headers['Access-Control-Allow-Credentials'] = 'true';
   }
 
   this.response.writeHead(200, headers);


### PR DESCRIPTION
I noticed that POST requests over JSONP were still colored red in Chrome after gavinuhma's fix (https://github.com/LearnBoost/socket.io/pull/630 ). 

It seems that that pull request did not include changes to transports/http and transports/xhr-polling, but those should also be fixed to follow https://developer.mozilla.org/En/HTTP_Access_Control#Requests_with_credentials

"Important note: when responding to a credentialed request,  server must specify a domain, and cannot use wild carding.  The above example would fail if the header was wildcarded as: Access-Control-Allow-Origin: *.  Since the Access-Control-Allow-Origin explicitly mentions http://foo.example, the credential-cognizant content is returned to the invoking web content. "
