### PR TITLE
make it possible to use a regexp to match the socket.io resource URL

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -904,8 +904,17 @@ var regexp = /^\/([^\/]+)\/?([^\/]+)?\/?([^\/]+)?\/?$/
 Manager.prototype.checkRequest = function (req) {
   var resource = this.get('resource');
 
-  if (req.url.substr(0, resource.length) == resource) {
-    var uri = url.parse(req.url.substr(resource.length), true)
+  var match;
+  if (typeof resource === 'string') {
+    match = req.url.substr(0, resource.length);
+    if (match !== resource) match = null;
+  } else {
+    match = resource.exec(req.url);
+    if (match) match = match[0];
+  }
+
+  if (match) {
+    var uri = url.parse(req.url.substr(match.length), true)
       , path = uri.pathname || ''
       , pieces = path.match(regexp);
 


### PR DESCRIPTION
We need this because we have to prefix the socket.io URL with a variable
ID.
