### PR TITLE
get rid of regexp in `checkRequest`

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -905,7 +905,7 @@ Manager.prototype.checkRequest = function (req) {
 
   var match;
   if (typeof resource === 'string') {
-    match = 0 === req.url.indexOf(resource)
+    match = 0 === req.url.indexOf(resource) ? resource : null
   } else {
     match = resource.exec(req.url);
     if (match) match = match[0];
@@ -924,7 +924,7 @@ Manager.prototype.checkRequest = function (req) {
       , path: path
     };
 
-    if (0 !== path.indexOf('/')) {
+    if (0 === path.indexOf('/')) {
       data.protocol = Number(pieces[1]);
       data.transport = pieces[2];
       data.id = pieces[3];


### PR DESCRIPTION
Replaced ugly:

```
  var regexp = /^\/([^\/]+)\/?([^\/]+)?\/?([^\/]+)?\/?$/
```

with a simple `split('/')`, this is easier to understand, and much faster. Also replaced the "string" case matching  of the '/socket.io' resource via `substr` with a simpler and faster call to `indexOf` ...
