### PR TITLE
Make heartbeat timeout > heartbeat interval

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -72,8 +72,8 @@ function Manager (server, options) {
     , 'log level': 3
     , 'log colors': tty.isatty(process.stdout.fd)
     , 'close timeout': 25
-    , 'heartbeat timeout': 15
-    , 'heartbeat interval': 20
+    , 'heartbeat interval': 25
+    , 'heartbeat timeout': 60
     , 'polling duration': 20
     , 'flash policy server': true
     , 'flash policy port': 10843


### PR DESCRIPTION
Otherwise clients would detect timeouts before a heartbeat has a chance
of reaching them. The new values themselves were suggested by @rauchg. I
myself think that the heartbeat timeout should probably only be ~10s larger
than the interval.

Only makes sense along with: https://github.com/LearnBoost/socket.io-client/pull/394
