### PR TITLE
io.configure('development', function() {...}) will trigger if NODE_ENV is not defined.

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -252,7 +252,7 @@ Manager.prototype.disabled = function (key) {
 Manager.prototype.configure = function (env, fn) {
   if ('function' == typeof env) {
     env.call(this);
-  } else if (env == process.env.NODE_ENV) {
+  } else if (env == (process.env.NODE_ENV || 'development')) {
     fn.call(this);
   }
 


### PR DESCRIPTION
This behavior makes configure consistent with express.
