### PR TITLE
reconection every 25sec fix #780 #777

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -71,7 +71,7 @@ function Manager (server, options) {
     , blacklist: ['disconnect']
     , 'log level': 3
     , 'log colors': tty.isatty(process.stdout.fd)
-    , 'close timeout': 25
+    , 'close timeout': 35
     , 'heartbeat interval': 25
     , 'heartbeat timeout': 60
     , 'polling duration': 20


### PR DESCRIPTION
issues #780 #777
From some commint be changed 'heartbeat interval'
Now 'heartbeat interval' equal 'close timeout' (eq 25) and this not correct, because if we not have some activity after 25 sec, socket-io-client close connection.
We can change 'heartbeat interval' to do 'ping pong' faster or change 'close timeout'
