### PR TITLE
Fix "syntax error" message on FF, resulting from FF trying to parse the POST result as XML due to it not having a response content-type

### DIFF
--- a/lib/transports/http.js
+++ b/lib/transports/http.js
@@ -46,7 +46,7 @@ HTTPTransport.prototype.handleRequest = function (req) {
     var buffer = ''
       , res = req.res
       , origin = req.headers.origin
-      , headers = { 'Content-Length': 1 }
+      , headers = { 'Content-Length': 1, 'Content-Type': 'text/plain; charset=UTF-8' }
       , self = this;
 
     req.on('data', function (data) {


### PR DESCRIPTION
Firefox will try to parse the response from xhr POST requests, causing a syntax error message in the Web Console. Basically an addition to https://github.com/LearnBoost/socket.io/pull/501 which fixed this for GETs but not for POSTs.
