### PR TITLE
Fixes when browser doesn't send origin header, defaults to empty string ...

### DIFF
--- a/lib/transports/websocket/hybi-07-12.js
+++ b/lib/transports/websocket/hybi-07-12.js
@@ -1,4 +1,3 @@
-
 /*!
  * socket.io-node
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
@@ -98,7 +97,7 @@ WebSocket.prototype.onSocketConnect = function () {
     return;
   }
 
-  var origin = this.req.headers['sec-websocket-origin']
+  var origin = this.req.headers['sec-websocket-origin'] || ''
     , location = ((this.manager.settings['match origin protocol'] ?
                       origin.match(/^https/) : this.socket.encrypted) ?
                         'wss' : 'ws')


### PR DESCRIPTION
...instead of UNDEFINED (which would throw an error on the origin.match(/^https/) below
