### PR TITLE
fix for EventEmitters always reusing the same Array instance for listeners

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -109,8 +109,7 @@ function Manager (server, options) {
   });
 
   // reset listeners
-  this.oldListeners = server.listeners('request');
-  server.removeAllListeners('request');
+  this.oldListeners = server.listeners('request').splice(0);
 
   server.on('request', function (req, res) {
     self.handleRequest(req, res);


### PR DESCRIPTION
This fixes node v0.7.x.

The node commits that broke this old behavior is here: https://github.com/joyent/node/compare/78dc13fbf97e2e3003e6f3baacdd5ff60e8de3f7%5E...928ea564d16da47e615ddac627e0b4d4a40d8196
