### PR TITLE
Fix Redis Store race condition in manager onOpen unsubscribe callback

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -343,12 +343,21 @@ Manager.prototype.onConnect = function (id) {
 Manager.prototype.onOpen = function (id) {
   this.open[id] = true;
 
-  // if we were buffering messages for the client, clear them
   if (this.closed[id]) {
     var self = this;
 
     this.store.unsubscribe('dispatch:' + id, function () {
-      delete self.closed[id];
+      var transport = self.transports[id];
+      if (self.closed[id] && self.closed[id].length && transport) {
+
+        // if we have buffered messages that accumulate between calling
+        // onOpen an this async callback, send them if the transport is 
+        // still open, otherwise leave them buffered
+        if (transport.open) {
+          transport.payload(self.closed[id]);
+          self.closed[id] = [];
+        }
+      }
     });
   }
 


### PR DESCRIPTION
Using the RedisStore and HTTP based fallbacks there is a race condition between when the buffered messages in `manager.closed[id]` are flushed after the transport reopens and when `unsubscribe` on the Redis Store is processed in Redis. In those cases, dispatched messages slip into `manager.closed[id]` but the current code for some reason just deletes `manager.closed[id]` in the callback to `unsubscribe`. 

This change will check if the transport is currently open and if so will flush the messages to the transport or else it will simply leave the messages in `manager.closed[id]` to be sent the next time the transport reconnects. 

The behavior was that these messages were getting dropped. 

I didn't create a new test to cover this but all of the current tests still pass. I did run this through the application tests I have with 20 node processes connecting with the RedisStore for a half day without dropping any messages (where we were dropping them before.

In addition it's awkward that the callback here is NOT called for the Memory Store
https://github.com/LearnBoost/socket.io/blob/master/lib/manager.js#L350 . I did not change that but it does make understanding this code confusing.
