### PR TITLE
Fixes debug error after handshake authorization

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -864,7 +864,7 @@ Manager.prototype.authorize = function (data, fn) {
     var self = this;
 
     this.get('authorization').call(this, data, function (err, authorized) {
-      self.log.debug('client ' + authorized ? 'authorized' : 'unauthorized');
+      self.log.debug('client ' + (authorized ? 'authorized' : 'unauthorized'));
       fn(err, authorized);
     });
   } else {


### PR DESCRIPTION
Whether handshake is authorized or not, console always show "debug -
authorized"
