### PR TITLE
Fix for ID generation vulnerability #856

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -709,7 +709,14 @@ Manager.prototype.generateId = function () {
   var rand = new Buffer(15); // multiple of 3 for base64
   this.sequenceNumber = (this.sequenceNumber + 1) | 0;
   rand.writeInt32BE(this.sequenceNumber, 11);
-  crypto.randomBytes(12).copy(rand);
+  if (crypto.randomBytes) {
+    crypto.randomBytes(12).copy(rand);
+  } else {
+    // not secure for node 0.4
+    [0, 4, 8].forEach(function(i) {
+      rand.writeInt32BE(Math.random() * Math.pow(2, 32) | 0, i);
+    });
+  }
   return rand.toString('base64').replace(/\//g, '_').replace(/\+/g, '-');
 };
 


### PR DESCRIPTION
Using crypto.randomBytes to generate a session ID.  96 bits of randomness, 24 bits of sequence number.  Using the URL safe base64 encoding [RFC 4648](http://tools.ietf.org/html/rfc4648#section-5) to represent the value.

Backward compatibility for node 0.4 uses an insecure generation method with Math.random().  I could fix this too, but I don't believe that this version of node is still popular enough to justify the effort.
