### PR TITLE
Adding pluggable ID generation see #497

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -705,8 +705,12 @@ Manager.prototype.handleClient = function (data, req) {
  * @api private
  */
 
-Manager.prototype.generateId = function () {
-  var rand = new Buffer(15); // multiple of 3 for base64
+Manager.prototype.generateId = function (data) {
+  var rand;
+  if (this.get('id generator')) {
+    return this.get('id generator').call(this, data);
+  }
+  rand = new Buffer(15); // multiple of 3 for base64
   this.sequenceNumber = (this.sequenceNumber + 1) | 0;
   rand.writeInt32BE(this.sequenceNumber, 11);
   if (crypto.randomBytes) {
@@ -765,7 +769,7 @@ Manager.prototype.handleHandshake = function (data, req, res) {
     if (err) return error(err);
 
     if (authorized) {
-      var id = self.generateId()
+      var id = self.generateId(newData || handshakeData)
         , hs = [
               id
             , self.enabled('heartbeats') ? self.get('heartbeat timeout') || '' : ''
@@ -885,9 +889,9 @@ Manager.prototype.authorize = function (data, fn) {
   if (this.get('authorization')) {
     var self = this;
 
-    this.get('authorization').call(this, data, function (err, authorized) {
+    this.get('authorization').call(this, data, function (err, authorized, newData) {
       self.log.debug('client ' + authorized ? 'authorized' : 'unauthorized');
-      fn(err, authorized);
+      fn(err, authorized, newData);
     });
   } else {
     this.log.debug('client authorized');


### PR DESCRIPTION
I want control over session IDs (see #497), but I don't need to give that control to the client.  This enables both options.

In my example, I am embedding application state in the session ID so that I can forward messages to back end processing without maintaining additional mappings.

I've also added the ability to get the handshake data through to the ID generator and for the authorize method to add to or override the handshake data.  This was obviously intended originally, but never quite connected up (repeated use of ``newData || handshakeData'').  This handshake data can be seen by the ID generator as well in order to advise in its processing.

A few more tests added to cover these capabilities.
