### PR TITLE
Fix for server-side support of namespace query on connect (like 1::/private:?my=param)

### DIFF
--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -298,7 +298,8 @@ SocketNamespace.prototype.handlePacket = function (sessid, packet) {
         connect();
       } else {
         var handshakeData = manager.handshaken[sessid];
-
+		if (packet.endpoint) handshakeData.query[self.name] = packet.qp
+		
         this.authorize(handshakeData, function (err, authorized, newData) {
           if (err) return error(err);
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -194,6 +194,7 @@ exports.decodePacket = function (data) {
 
     case 'connect':
       packet.qs = data || '';
+      packet.qp = require('url').parse(packet.qs, true).query 
       break;
 
     case 'ack':


### PR DESCRIPTION
Based on your spec Socket.io supports params on namespace connect. Example in spec: 
1::/test?my=param

Based on your tests, this seems to be wrong. Instead it should be:
1::/test:?my=param

Both versions are not supported right now. To support 1::/test:?my=param (version 2), server and client has to be updated. A (working) suggestion for the server-side fix shows this pull-request. After connect, handshakeData would look like:

``` javascript
{ headers: { host: '127.0.0.1' },
  address: { address: '127.0.0.1', port: 63265 },
  time: 'Sat Apr 28 2012 11:53:19 GMT+0200 (Mitteleuropäische Sommerzeit)',
  query: { handshakeParam: '1', '/private': { my: 'param' } },
  url: '/socket.io/1?handshakeParam=1',
  xdomain: false,
  secure: undefined }
```
