### PR TITLE
in examples/chat, don't allow null nicknames

### DIFF
--- a/examples/chat/app.js
+++ b/examples/chat/app.js
@@ -60,7 +60,7 @@ io.sockets.on('connection', function (socket) {
   });
 
   socket.on('nickname', function (nick, fn) {
-    if (nicknames[nick]) {
+    if (!nick.length || nicknames[nick]) {
       fn(true);
     } else {
       fn(false);

--- a/examples/chat/index.jade
+++ b/examples/chat/index.jade
@@ -72,7 +72,7 @@ html
         form.wrap#set-nickname
           p Please type in your nickname and press enter.
           input#nick
-          p#nickname-err Nickname already in use
+          p#nickname-err Nickname already in use or not entered
       #connecting
         .wrap Connecting to socket.io server
       #messages


### PR DESCRIPTION
I confirmed that blank nicknames are allowed. JSON.stringify(nicknames) gives {'':''}
