### PR TITLE
update redis module dependency to fix sys/util error in node > 0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   , "dependencies": {
         "socket.io-client": "0.9.6"
       , "policyfile": "0.0.4"
-      , "redis": "0.6.7"
+      , "redis": ">= 0.7.0"
     }
   , "devDependencies": {
         "expresso": "0.9.2"


### PR DESCRIPTION
Allows Socket.IO to be run using RedisStore on 0.7.8
