### PR TITLE
Stops the occasional jsonp-polling error where this.response is null bec...

### DIFF
--- a/lib/transports/jsonp-polling.js
+++ b/lib/transports/jsonp-polling.js
@@ -1,4 +1,3 @@
-
 /*!
  * socket.io-node
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
@@ -84,14 +83,18 @@ JSONPPolling.prototype.doWrite = function (data) {
 
   var data = data === undefined
       ? '' : this.head + JSON.stringify(data) + this.foot;
-
-  this.response.writeHead(200, {
-      'Content-Type': 'text/javascript; charset=UTF-8'
-    , 'Content-Length': Buffer.byteLength(data)
-    , 'Connection': 'Keep-Alive'
-    , 'X-XSS-Protection': '0'
-  });
-
-  this.response.write(data);
+  
+  if (this.response)
+  {
+      this.response.writeHead(200, {
+          'Content-Type': 'text/javascript; charset=UTF-8'
+        , 'Content-Length': Buffer.byteLength(data)
+        , 'Connection': 'Keep-Alive'
+        , 'X-XSS-Protection': '0'
+      });
+  
+      this.response.write(data);
+  }
+  
   this.log.debug(this.name + ' writing', data);
 };


### PR DESCRIPTION
...ause of an error in transport at /transport.js:498:8

12 May 23:49:43 - Uncaught exception: TypeError: Cannot call method 'writeHead' of undefined
data:   TypeError: Cannot call method 'writeHead' of undefined
data:       at JSONPPolling.doWrite (/home/node/node_modules/socket.io/lib/transports/jsonp-polling.js:89:17)
data:       at JSONPPolling.write (/home/node/node_modules/socket.io/lib/transports/http-polling.js:132:8)
data:       at JSONPPolling.packet (/home/node/node_modules/socket.io/lib/transport.js:515:15)
data:       at JSONPPolling.error (/home/node/node_modules/socket.io/lib/transport.js:498:8)
data:       at JSONPPolling.onData (/home/node/node_modules/socket.io/lib/transports/jsonp-polling.js:70:7)
data:       at IncomingMessage.<anonymous> (/home/node/node_modules/socket.io/lib/transports/http.js:65:12)
data:       at IncomingMessage.emit (events.js:64:17)
data:       at HTTPParser.parserOnMessageComplete [as onMessageComplete](http.js:127:21)
data:       at Socket.ondata (http.js:1468:22)
data:       at TCP.onread (net.js:374:27)
