### PR TITLE
Allow storing and retrieving various JSON'able types in Redis store

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -90,6 +90,8 @@ function Manager (server, options) {
     , 'browser client handler': false
     , 'client store expiration': 15
     , 'match origin protocol': false
+    , 'strict ip policy': false
+    , 'trust proxy header': false
   };
 
   for (var i in options) {
@@ -565,6 +567,28 @@ Manager.prototype.handleRequest = function (req, res) {
     }
 
     return;
+  }
+
+  var transport = this.transports[data.id]
+   ,  connection = data.request.connection;
+
+  if (this.enabled('strict ip policy') && transport && transport.open) {
+    var remoteAddr = connection.remoteAddress
+     ,  oldRemoteAddr = transport.req.connection.remoteAddress;
+
+    if (this.enabled('trust proxy header')) {
+      remoteAddr = data.headers['x-forwarded-for'] || remoteAddr;
+      oldRemoteAddr = transport.req.headers['x-forwaded-for'] || oldRemoteAddr;
+    }
+
+    if (remoteAddr !== oldRemoteAddr) {
+      this.log.warn('third party request from ' + remoteAddr + ' dropped');
+
+      res.writeHead(403);
+      res.end();
+
+      return;
+    }
   }
 
   if (data.static || !data.transport && !data.protocol) {


### PR DESCRIPTION
Allow storing and retrieving various JSON'able types in Redis store (arrays, objects, booleans, null).
Undefined will be returned as null, since JSON spec does not support this type.
