### PR TITLE
Fix IE Cross Domain Security Error Message

### DIFF
--- a/lib/transports/http.js
+++ b/lib/transports/http.js
@@ -46,7 +46,7 @@ HTTPTransport.prototype.handleRequest = function (req) {
     var buffer = ''
       , res = req.res
       , origin = req.headers.origin
-      , headers = { 'Content-Length': 1, 'Content-Type': 'text/plain; charset=UTF-8' }
+      , headers = { 'Content-Length': 1, 'Content-Type': 'text/plain; charset=UTF-8', 'X-XSS-Protection': '0' }
       , self = this;
 
     req.on('data', function (data) {


### PR DESCRIPTION
There is still an XSS security message when using XHR POLLING, this resolved it for me.
