### PR TITLE
add events when a room is created or deleted 

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -406,6 +406,7 @@ Manager.prototype.onJoin = function (id, name) {
 
   if (!this.rooms[name]) {
     this.rooms[name] = [];
+    this.emit('roomCreated', name);
   }
 
   if (!~this.rooms[name].indexOf(id)) {
@@ -430,6 +431,7 @@ Manager.prototype.onLeave = function (id, room) {
 
     if (!this.rooms[room].length) {
       delete this.rooms[room];
+      this.emit('roomDeleted', name);
     }
     delete this.roomClients[id][room];
   }


### PR DESCRIPTION
If a room is used to group clients together to receive a particular set of subscriptions from a publisher, knowing when to subscribe/unsubscribe is crucial since there's no point in relaying data to an empty room. This would allow for event handlers to subscribe dynamically in a pub-sub pattern. 
