### PR TITLE
Honour "flash policy server" configuration

### DIFF
--- a/lib/transports/flashsocket.js
+++ b/lib/transports/flashsocket.js
@@ -100,6 +100,23 @@ FlashSocket.init = function (manager) {
     }
   });
 
+  // create or destroy the server
+  manager.on('set:flash policy server', function (value, key) {
+    var transports = manager.get('transports');
+    if (~transports.indexOf('flashsocket')) {
+      if (server && !value) {
+        // destroy the server
+        try {
+          server.close();
+        }
+        catch (e) { /* ignore exception. could e.g. be that the server isn't started yet */ }
+      }
+    } else if (!server && value) {
+      // create the server
+      create();
+    }
+  });
+
   // only start the server
   manager.on('set:transports', function (value, key){
     if (!server && ~manager.get('transports').indexOf('flashsocket')) {


### PR DESCRIPTION
At the moment the flashsocket transport ignores changes to the "flash policy server" configuration directive. Added code in the create() function that will refuse to create one no matter where it is called from. Also added a handler for if the user changes the configuration option at runtimes.
