### PR TITLE
Update Express example to work with Express 3.x

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,10 +141,10 @@ io.sockets.on('connection', function (socket) {
 					<div class="example">
 						<div class="example-left">
 							<h4>Server (app.js)</h4>
-							<pre class="prettyprint">var app = require('express').createServer()
-  , io = require('socket.io').listen(app);
-
-app.listen(80);
+							<pre class="prettyprint">// Express 3+
+var app = require('express')()
+  , server = app.listen(80)
+  , io = require('socket.io').listen(server);
 
 app.get('/', function (req, res) {
   res.sendfile(__dirname + '/index.html');
@@ -154,7 +154,7 @@ io.sockets.on('connection', function (socket) {
   socket.emit('news', { hello: 'world' });
   socket.on('my other event', function (data) {
     console.log(data);
-  });
+	});
 });</pre>
 						</div>
 						<div class="example-right">


### PR DESCRIPTION
Express 3.x branch is now default so the express instructions are no longer accurate

"For this example, simply run `npm install socket.io express`"

Should close #843
