### PR TITLE
Corrects unsafe usage of for..in, permitting socket.io to be used in environments that extend Object, etc.

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -93,7 +93,9 @@ function Manager (server, options) {
   };
 
   for (var i in options) {
-    this.settings[i] = options[i];
+    if (options.hasOwnProperty(i)) {
+      this.settings[i] = options[i];
+    }
   }
 
   var self = this;
@@ -129,8 +131,10 @@ function Manager (server, options) {
   });
 
   for (var i in transports) {
-    if (transports[i].init) {
-      transports[i].init(this);
+    if (transports.hasOwnProperty(i)) {
+      if (transports[i].init) {
+        transports[i].init(this);
+      }
     }
   }
 
@@ -489,8 +493,10 @@ Manager.prototype.onClientMessage = function (id, packet) {
 
 Manager.prototype.onClientDisconnect = function (id, reason) {
   for (var name in this.namespaces) {
-    this.namespaces[name].handleDisconnect(id, reason, typeof this.roomClients[id] !== 'undefined' &&
-      typeof this.roomClients[id][name] !== 'undefined');
+    if (this.namespaces.hasOwnProperty(name)) {
+      this.namespaces[name].handleDisconnect(id, reason, typeof this.roomClients[id] !== 'undefined' &&
+        typeof this.roomClients[id][name] !== 'undefined');
+    }
   }
 
   this.onDisconnect(id);
@@ -524,7 +530,9 @@ Manager.prototype.onDisconnect = function (id, local) {
 
   if (this.roomClients[id]) {
     for (var room in this.roomClients[id]) {
-      this.onLeave(id, room);
+      if (this.roomClients[id].hasOwnProperty(room)) {
+        this.onLeave(id, room);
+      }
     }
     delete this.roomClients[id]
   }
@@ -674,11 +682,13 @@ Manager.prototype.handleClient = function (data, req) {
 
       // initialize the socket for all namespaces
       for (var i in this.namespaces) {
-        var socket = this.namespaces[i].socket(data.id, true);
+        if (this.namespaces.hasOwnProperty(i)) {
+          var socket = this.namespaces[i].socket(data.id, true);
 
-        // echo back connect packet and fire connection event
-        if (i === '') {
-          this.namespaces[i].handlePacket(data.id, { type: 'connect' });
+          // echo back connect packet and fire connection event
+          if (i === '') {
+            this.namespaces[i].handlePacket(data.id, { type: 'connect' });
+          }
         }
       }
 


### PR DESCRIPTION
For more information on safe usage of for..in, please see:
  http://yuiblog.com/blog/2006/09/26/for-in-intrigue/
