### PR TITLE
Very small fix for the authorization logging code.

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -899,7 +899,7 @@ Manager.prototype.authorize = function (data, fn) {
     var self = this;
 
     this.get('authorization').call(this, data, function (err, authorized) {
-      self.log.debug('client ' + authorized ? 'authorized' : 'unauthorized');
+      self.log.debug('client ' + (authorized ? 'authorized' : 'unauthorized'));
       fn(err, authorized);
     });
   } else {


### PR DESCRIPTION
self.log.debug('client ' + authorized ? 'authorized' : 'unauthorized');

This line of code always print 'client authorized'. The conditional operator should be wrapped by braces.

When the 'authorized' is 'true' that statement becomes, 
- 'client true' ? 'authorized' : 'unauthorized'
  And when it is 'false',
- 'client false' ? 'authorized' : 'unauthorized'

Thanks.
