### PR TITLE
Fix disconnectSync getting ignored

### DIFF
--- a/lib/transports/http-polling.js
+++ b/lib/transports/http-polling.js
@@ -51,8 +51,7 @@ HTTPPolling.prototype.name = 'httppolling';
 
 HTTPPolling.prototype.setHandlers = function () {
   HTTPTransport.prototype.setHandlers.call(this);
-  this.socket.removeListener('end', this.bound.end);
-  this.socket.removeListener('close', this.bound.close);
+  this.socket.removeListener('end', this.bound.end); 
 };
 
 /**


### PR DESCRIPTION
If using xhr-polling and a browser closes a tab or window, the
disconnectSync in the socket.io-client method is called which sends an
XHR request to the server indicating a disconnect. This line would cause
that to be ignored and so the server would have to wait for a timeout to
mark them as disconnect. This was possibly because it was sent from a
different tcp socket than the current connection.
