### PR TITLE
Add warning to .listen() to ease the migration to Express 3.x

### DIFF
--- a/lib/socket.io.js
+++ b/lib/socket.io.js
@@ -39,6 +39,13 @@ exports.clientVersion = client.version;
  */
 
 exports.listen = function (server, options, fn) {
+  if ('function' == typeof server) {
+    console.warn('Socket.IO\'s `listen()` method expects an `http.Server` instance\n'
+    + 'as its first parameter. Are you migrating from Express 2.x to 3.x?\n'
+    + 'If so, check out the "Socket.IO compatibility" section at:\n'
+    + 'https://github.com/visionmedia/express/wiki/Migrating-from-2.x-to-3.x');
+  }
+
   if ('function' == typeof options) {
     fn = options;
     options = {};


### PR DESCRIPTION
This is so people are not left clueless when they pass `app` to Socket.IO as they did with Express 2.x and it doesn't work anymore.
