### PR TITLE
Add express 3.0 instructions on Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,6 +21,25 @@ var io = require('socket.io');
 Next, attach it to a HTTP/HTTPS server. If you're using the fantastic `express`
 web framework:
 
+#### Express 3.x
+
+```js
+var app = express()
+  , server = require('http').createServer(app)
+  , io = io.listen(server);
+
+server.listen(80);
+
+io.sockets.on('connection', function (socket) {
+  socket.emit('news', { hello: 'world' });
+  socket.on('my other event', function (data) {
+    console.log(data);
+  });
+});
+```
+
+#### Express 2.x
+
 ```js
 var app = express.createServer()
   , io = io.listen(app);


### PR DESCRIPTION
Since on Express 3.x `.createServer()` is deprecated and `express()` does not return an `http.Server` instance, people are likely to hit the `.listen()` warning when migrating. We should probably add the proper 3.x way to the readme.
