### PR TITLE
Use single quotes in htmlfile protocol

### DIFF
--- a/lib/transports/htmlfile.js
+++ b/lib/transports/htmlfile.js
@@ -1,4 +1,3 @@
-
 /*!
  * socket.io-node
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
@@ -72,7 +71,7 @@ HTMLFile.prototype.handleRequest = function (req) {
  */
 
 HTMLFile.prototype.write = function (data) {
-  data = '<script>_(' + JSON.stringify(data) + ');</script>';
+  data = "<script>_('" + data.replace(/\'/g, "\\'") + "');</script>";
 
   if (this.response.write(data)) {
     this.drained = true;


### PR DESCRIPTION
In JSON, there are lots of unavoidable double-quotes: For strings, and for the
object keys. Looking at a htmlfile stream you'll find many double quote escapes.

Example:

`<script>_("5:::{\"name\":\"update\",\"args\":[{\"abcd\":{\"GBP8\":9445,\"GBV8\":904,\"s\":1}}]}");</script>`

If we used a single quote at the outer level though, we wouldn't need to escape
the double quotes, only the - much less used in JSON - single quotes.

The example above would thus turn into:

`<script>_("5:::{"name":"update","args":[{"abcd":{"GBP8":9445,"GBV8":904,"s":1}}]}");</script>`

**Nicer to look at**, and consumes **fewer bytes**. Encoding should also be
**faster**, but haven't actually timed `replace` against `JSON.stringify`. IE - the
browser htmlfile is targeted at - is fine with single-quotes, as it's legal
JavaScript, and socket.io-spec does not specify that, so I think it would be OK
to change
