### PR TITLE
Always set the HTTP response in case an error should be returned to the client

### DIFF
--- a/lib/transports/http.js
+++ b/lib/transports/http.js
@@ -42,6 +42,10 @@ HTTPTransport.prototype.__proto__ = Transport.prototype;
  */
 
 HTTPTransport.prototype.handleRequest = function (req) {
+
+  // Always set the response in case an error is returned to the client
+  this.response = req.res;
+
   if (req.method == 'POST') {
     var buffer = ''
       , res = req.res
@@ -77,8 +81,6 @@ HTTPTransport.prototype.handleRequest = function (req) {
       headers['Access-Control-Allow-Credentials'] = 'true';
     }
   } else {
-    this.response = req.res;
-
     Transport.prototype.handleRequest.call(this, req);
   }
 };


### PR DESCRIPTION
The this.response member in the HTTP transport class is only set if the request is a GET. This seems to be because it expects a POST to never return anything to the client. However, in case of error (e.g. JSON parse error), an error message is sent to the client. If the response member is not set, it causes a hard crash when the response body is written.
