### PR TITLE
set browser client minification and gzip to true

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -83,10 +83,10 @@ function Manager (server, options) {
     , 'destroy buffer size': 10E7
     , 'browser client': true
     , 'browser client cache': true
-    , 'browser client minification': false
+    , 'browser client minification': true
     , 'browser client etag': false
     , 'browser client expires': 315360000
-    , 'browser client gzip': false
+    , 'browser client gzip': true
     , 'browser client handler': false
     , 'client store expiration': 15
     , 'match origin protocol': false


### PR DESCRIPTION
No one will actually view the socket.io.js in browser. 
So it makes sense to send a minified version to the browser. Also, This will improves the response time.
