### PR TITLE
Don't lowercase log messages

### DIFF
--- a/lib/transports/flashsocket.js
+++ b/lib/transports/flashsocket.js
@@ -1,4 +1,3 @@
-
 /*!
  * socket.io-node
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
@@ -62,7 +61,7 @@ FlashSocket.init = function (manager) {
 
     server = require('policyfile').createServer({ 
       log: function(msg){
-        manager.log.info(msg.toLowerCase());
+        manager.log.info(msg);
       }
     }, manager.get('origins'));
 


### PR DESCRIPTION
Lowercasing log messages is unnecessary.  It makes some messages difficult to
read, and others difficult to search for.

Discussion on Pull Request #974.
