### PR TITLE
Redis Store: removed unneeded module ('assert')

### DIFF
--- a/lib/stores/redis.js
+++ b/lib/stores/redis.js
@@ -1,4 +1,3 @@
-
 /*!
  * socket.io-node
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
@@ -10,8 +9,7 @@
  */
 
 var crypto = require('crypto')
-  , Store = require('../store')
-  , assert = require('assert');
+  , Store = require('../store');
 
 /**
  * Exports the constructor.


### PR DESCRIPTION
It's not used anywhere in the file and the test file (test/stores.redis.test.js) uses the 'should' module.
I'm assuming this is a leftover.
