### PR TITLE
Increase performance of generateId by avoiding sync calls to crypto.randomBytes

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -12,6 +12,7 @@ var fs = require('fs')
   , url = require('url')
   , tty = require('tty')
   , crypto = require('crypto')
+  , base64id = require('base64id')
   , util = require('./util')
   , store = require('./store')
   , client = require('socket.io-client')
@@ -730,88 +731,6 @@ Manager.prototype.handleClient = function (data, req) {
 };
 
 /**
- * Get random bytes
- *
- * @api private
- */
-
-Manager.prototype.getRandomBytes = function(bytes) {
-
-  var BUFFER_SIZE = 4096
-  var self = this;  
-  
-  bytes = bytes || 12;
-
-  if (bytes > BUFFER_SIZE) {
-    return crypto.randomBytes(bytes);
-  }
-  
-  var bytesInBuffer = parseInt(BUFFER_SIZE/bytes);
-  var threshold = parseInt(bytesInBuffer*0.85);
-
-  if (!threshold) {
-    return crypto.randomBytes(bytes);
-  }
-
-  if (this.bytesBufferIndex == null) {
-     this.bytesBufferIndex = -1;
-  }
-
-  if (this.bytesBufferIndex == bytesInBuffer) {
-    this.bytesBuffer = null;
-    this.bytesBufferIndex = -1;
-  }
-
-  // No buffered bytes available or index above threshold
-  if (this.bytesBufferIndex == -1 || this.bytesBufferIndex > threshold) {
-     
-    if (!this.isGeneratingBytes) {
-      this.isGeneratingBytes = true;
-      crypto.randomBytes(BUFFER_SIZE, function(err, bytes) {
-        self.bytesBuffer = bytes;
-        self.bytesBufferIndex = 0;
-        self.isGeneratingBytes = false;
-      }); 
-    }
-    
-    // Fall back to sync call when no buffered bytes are available
-    if (this.bytesBufferIndex == -1) {
-      return crypto.randomBytes(bytes);
-    }
-  }
-  
-  var result = this.bytesBuffer.slice(bytes*this.bytesBufferIndex, bytes*(this.bytesBufferIndex+1)); 
-  this.bytesBufferIndex++; 
-  
-  return result;
-}
-
-/**
- * Generates a session id
- *
- * @api private
- */
-
-Manager.prototype.generateId = function () {
-  var rand = new Buffer(15); // multiple of 3 for base64
-  if (!rand.writeInt32BE) {
-    return Math.abs(Math.random() * Math.random() * Date.now() | 0).toString()
-      + Math.abs(Math.random() * Math.random() * Date.now() | 0).toString();
-  }
-  this.sequenceNumber = (this.sequenceNumber + 1) | 0;
-  rand.writeInt32BE(this.sequenceNumber, 11);
-  if (crypto.randomBytes) {
-    this.getRandomBytes(12).copy(rand);
-  } else {
-    // not secure for node 0.4
-    [0, 4, 8].forEach(function(i) {
-      rand.writeInt32BE(Math.random() * Math.pow(2, 32) | 0, i);
-    });
-  }
-  return rand.toString('base64').replace(/\//g, '_').replace(/\+/g, '-');
-};
-
-/**
  * Handles a handshake request.
  *
  * @api private
@@ -856,7 +775,7 @@ Manager.prototype.handleHandshake = function (data, req, res) {
     if (err) return error(err);
 
     if (authorized) {
-      var id = self.generateId()
+      var id = base64id.generateId()
         , hs = [
               id
             , self.enabled('heartbeats') ? self.get('heartbeat timeout') || '' : ''

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
       , "policyfile": "0.0.4"
       , "redis": "0.7.2"
       , "ws": "~0.4.21"
+      , "base64id": "0.1.0"
     }
   , "devDependencies": {
         "expresso": "0.9.2"


### PR DESCRIPTION
As mentioned in https://github.com/LearnBoost/socket.io/issues/934, generateId contains a sync call to crypto.randomBytes. To try to minimize the impact of this, I've added a new function called getRandomBytes that gets bytes in chunks using async calls and keeps them in a buffer to deliver when needed, graciously falling back to the sync call only when the buffer is temporarily empty. This result in a significant decrease in blocking calls compared to the current implementation.

I tried making 100k calls to this.getRandomBytes(16) (one per process.nextTick()), and out of these only about 3k fell through to the sync crypto.randomBytes(), while the rest were delivered from the buffer.

The average return time of this.getRandomBytes(16) is roughly 0.00100, compared to a crypto.randomBytes(16) call which clocks in at an average of about 0.00600.
