### PR TITLE
Move redis

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   , "dependencies": {
         "socket.io-client": "0.9.10"
       , "policyfile": "0.0.4"
-      , "redis": "0.7.2"
       , "ws": "~0.4.21"
     }
   , "devDependencies": {
@@ -27,6 +26,7 @@
       , "benchmark": "0.2.2"
       , "microtime": "0.1.3-1"
       , "colors": "0.5.1"
+      , "redis": "0.7.2"
     }
   , "main": "index"
   , "engines": { "node": ">= 0.4.0" }


### PR DESCRIPTION
I moved the redis module from the `package.json` to the `devDependencies` as it's not needed to run socket.io. There are people who have failed installations because they cannot get the redis module installed because it depends on the hiredis module.

If people still want to use the redis store that we ship inside of Socket.IO they can stil use it by adding redis to their own package.json.

If you feel that this move might be a bit overkill we could also consider lazy installing the module. For example using 3rd-Eden/canihaz so users don't have to manually install redis, but we can do it programmatically for them.

See #1003 #603  and it will so prevent issues like: #929  #752
