### PR TITLE
Return error details on handshake error

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -778,7 +778,7 @@ Manager.prototype.handleHandshake = function (data, req, res) {
   };
 
   function error (err) {
-    writeErr(500, 'handshake error');
+    writeErr(500, 'handshake error ' + err);
     self.log.warn('handshake error ' + err);
   };
 


### PR DESCRIPTION
It will be nice to return error details when handshake failed, especially when using custom authorization mecanism.
Otherwise, it's impossible for clients to understand why handshake failed: unknown account, wrong password, expired credentials...

Thank you !
