### PR TITLE
iOS6 cache-control

### DIFF
--- a/lib/transports/htmlfile.js
+++ b/lib/transports/htmlfile.js
@@ -25,7 +25,7 @@ exports = module.exports = HTMLFile;
 
 function HTMLFile (mng, data, req) {
   HTTPTransport.call(this, mng, data, req);
-};
+}
 
 /**
  * Inherits from Transport.
@@ -55,6 +55,7 @@ HTMLFile.prototype.handleRequest = function (req) {
         'Content-Type': 'text/html; charset=UTF-8'
       , 'Connection': 'keep-alive'
       , 'Transfer-Encoding': 'chunked'
+      , 'Cache-Control': 'no-cache'
     });
 
     req.res.write(

--- a/lib/transports/http-polling.js
+++ b/lib/transports/http-polling.js
@@ -25,7 +25,7 @@ exports = module.exports = HTTPPolling;
 
 function HTTPPolling (mng, data, req) {
   HTTPTransport.call(this, mng, data, req);
-};
+}
 
 /**
  * Inherits from HTTPTransport.

--- a/lib/transports/http.js
+++ b/lib/transports/http.js
@@ -27,7 +27,7 @@ exports = module.exports = HTTPTransport;
 
 function HTTPTransport (mng, data, req) {
   Transport.call(this, mng, data, req);
-};
+}
 
 /**
  * Inherits from Transport.
@@ -46,11 +46,15 @@ HTTPTransport.prototype.handleRequest = function (req) {
   // Always set the response in case an error is returned to the client
   this.response = req.res;
 
-  if (req.method == 'POST') {
+  if (req.method === 'POST') {
     var buffer = ''
       , res = req.res
       , origin = req.headers.origin
-      , headers = { 'Content-Length': 1, 'Content-Type': 'text/plain; charset=UTF-8' }
+      , headers = {
+            'Content-Length': 1
+          , 'Content-Type': 'text/plain; charset=UTF-8'
+          , 'Cache-Control': 'no-cache'
+        }
       , self = this;
 
     req.on('data', function (data) {

--- a/lib/transports/jsonp-polling.js
+++ b/lib/transports/jsonp-polling.js
@@ -9,8 +9,8 @@
  * Module requirements.
  */
 
-var HTTPPolling = require('./http-polling');
-var jsonpolling_re = /^\d+$/
+var HTTPPolling = require('./http-polling')
+  , jsonpolling_re = /^\d+$/;
 
 /**
  * Export the constructor.
@@ -33,7 +33,7 @@ function JSONPPolling (mng, data, req) {
   if (data.query.i && jsonpolling_re.test(data.query.i)) {
     this.head = 'io.j[' + data.query.i + '](';
   }
-};
+}
 
 /**
  * Inherits from Transport.
@@ -89,6 +89,7 @@ JSONPPolling.prototype.doWrite = function (data) {
       'Content-Type': 'text/javascript; charset=UTF-8'
     , 'Content-Length': Buffer.byteLength(data)
     , 'Connection': 'Keep-Alive'
+    , 'Cache-Control': 'no-cache'
     , 'X-XSS-Protection': '0'
   });
 

--- a/lib/transports/xhr-polling.js
+++ b/lib/transports/xhr-polling.js
@@ -25,7 +25,7 @@ exports = module.exports = XHRPolling;
 
 function XHRPolling (mng, data, req) {
   HTTPPolling.call(this, mng, data, req);
-};
+}
 
 /**
  * Inherits from Transport.
@@ -55,6 +55,7 @@ XHRPolling.prototype.doWrite = function (data) {
           'Content-Type': 'text/plain; charset=UTF-8'
         , 'Content-Length': data === undefined ? 0 : Buffer.byteLength(data)
         , 'Connection': 'Keep-Alive'
+        , 'Cache-Control': 'no-cache'
       };
 
   if (origin) {


### PR DESCRIPTION
Added cache-control headers to each GET and POST request to instruct the browser to NOT cache these requests.

See for the related information:
http://stackoverflow.com/questions/12506897/is-ios6-safari-caching-ajax-results

In addition to that I removed some pointless semicolons and added missing semicolons.
