### PR TITLE
Optionally drop requests to existing transport instances from IP addresses not matching the original request IP

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -92,6 +92,8 @@ function Manager (server, options) {
     , 'browser client handler': false
     , 'client store expiration': 15
     , 'match origin protocol': false
+    , 'strict ip policy': false
+    , 'trust proxy header': false
   };
 
   for (var i in options) {
@@ -577,6 +579,28 @@ Manager.prototype.handleRequest = function (req, res) {
     }
 
     return;
+  }
+
+  var transport = this.transports[data.id]
+   ,  connection = data.request.connection;
+
+  if (this.enabled('strict ip policy') && transport && transport.open) {
+    var remoteAddr = connection.remoteAddress
+     ,  oldRemoteAddr = transport.req.connection.remoteAddress;
+
+    if (this.enabled('trust proxy header')) {
+      remoteAddr = data.headers['x-forwarded-for'] || remoteAddr;
+      oldRemoteAddr = transport.req.headers['x-forwaded-for'] || oldRemoteAddr;
+    }
+
+    if (remoteAddr !== oldRemoteAddr) {
+      this.log.warn('third party request from ' + remoteAddr + ' dropped');
+
+      res.writeHead(403);
+      res.end();
+
+      return;
+    }
   }
 
   if (data.static || !data.transport && !data.protocol) {


### PR DESCRIPTION
This addresses #619, and is based on an earlier pull request by @coolbloke1324, https://github.com/LearnBoost/socket.io/pull/624.

The issue here is to do with what happens when a naive HTTP request comes in that looks like a socket.io URI, and uses the ID of an existing transport, but does not contain an upgrade header. Due to some ISP nastiness noted in the issue thread a few of us are seeing this happening and it's killing our sockets. You can replicate the problem by firing up a server/client and exchanging a few packets via WS, then from a different IP requesting the socket URI, e.g.:

```
$ curl -v example.org/socket.io/1/websocket/Ot1dfZBv669zk_3Iqgng
```

Using the current master, you'll see:

```
debug - setting request GET /socket.io/1/websocket/Ot1dfZBv669zk_3Iqgng
debug - set heartbeat interval for client Ot1dfZBv669zk_3Iqgng
warn  - websocket connection invalid
info  - transport end (undefined)
```

Which is pretty much right ([here's the line](https://github.com/LearnBoost/socket.io/blob/master/lib/transports/websocket/default.js#L86) responsible).

Still, in practise it seems like in most cases we don't want requests coming from some random third party IP addresses to be able to close legitimate connections. This pull adds a setting to make socket.io 403 on requests like this and leave the transport untouched.
