### PR TITLE
Fix for packets containing \ufffd

### DIFF
--- a/lib/transports/websocket/default.js
+++ b/lib/transports/websocket/default.js
@@ -341,6 +341,10 @@ Parser.prototype.parse = function () {
     }
 
     if (chr == '\ufffd'){
+      // only emit now if this is really the end of a packet and
+      // not if it's just \ufffd inside the packet
+      if ((this.buffer.length != (i + 1)) && this.buffer[i+1] != '\u0000')
+        continue;
       this.emit('data', this.buffer.substr(1, i - 1));
       this.buffer = this.buffer.substr(i + 1);
       this.i = 0;


### PR DESCRIPTION
This patch fixes a problem where the data may come through containing \ufffd when it isn't used as a packet boundary. I saw this when using node-phantom with the epost.ca web site.
