### PR TITLE
Fix: Remove socket session from child processes on disconnect

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -324,6 +324,10 @@ Manager.prototype.initStore = function () {
     self.onClose(id);
   });
 
+  this.store.subscribe('kick', function (id) {
+    self.onClientDisconnect(id, "socket end");
+  });
+
   this.store.subscribe('dispatch', function (room, packet, volatile, exceptions) {
     self.onDispatch(room, packet, volatile, exceptions);
   });

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -468,6 +468,8 @@ Transport.prototype.end = function (reason) {
     } else {
       this.store.publish('disconnect:' + this.id, reason);
     }
+
+    this.store.publish('kick', this.id);
   }
 };
 


### PR DESCRIPTION
Socket session is not removed from child processes (in cluster) when a client disconnects from one of the processes with memory increasing linearly.
