### PR TITLE
Handshakes leaking when using RedisStore

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -506,7 +506,7 @@ Manager.prototype.onClientMessage = function (id, packet) {
  * @api private
  */
 
-Manager.prototype.onClientDisconnect = function (id, reason) {
+Manager.prototype.onClientDisconnect = function (id, reason, local) {
   for (var name in this.namespaces) {
     if (this.namespaces.hasOwnProperty(name)) {
       this.namespaces[name].handleDisconnect(id, reason, typeof this.roomClients[id] !== 'undefined' &&
@@ -514,7 +514,7 @@ Manager.prototype.onClientDisconnect = function (id, reason) {
     }
   }
 
-  this.onDisconnect(id);
+  this.onDisconnect(id, local);
 };
 
 /**
@@ -525,23 +525,12 @@ Manager.prototype.onClientDisconnect = function (id, reason) {
 
 Manager.prototype.onDisconnect = function (id, local) {
   delete this.handshaken[id];
+  delete this.open[id];
+  delete this.connected[id];
+  delete this.closed[id];
 
-  if (this.open[id]) {
-    delete this.open[id];
-  }
-
-  if (this.connected[id]) {
-    delete this.connected[id];
-  }
-
-  if (this.transports[id]) {
-    this.transports[id].discard();
-    delete this.transports[id];
-  }
-
-  if (this.closed[id]) {
-    delete this.closed[id];
-  }
+  if (this.transports[id]) this.transports[id].discard();
+  delete this.transports[id];
 
   if (this.roomClients[id]) {
     for (var room in this.roomClients[id]) {
@@ -559,6 +548,8 @@ Manager.prototype.onDisconnect = function (id, local) {
   if (local) {
     this.store.unsubscribe('message:' + id);
     this.store.unsubscribe('disconnect:' + id);
+    this.store.publish('disconnect:' + id);
+    this.store.publish('disconnect', id);
   }
 };
 
@@ -1012,4 +1003,15 @@ Manager.prototype.garbageCollection = function () {
       this.onDisconnect(ids[i]);
     }
   }
+
+  var self = this;
+  ['closed', 'open', 'transports'].forEach(function (type) {
+    var ids = Object.keys(self[type])
+      , i = ids.length;
+    while (i--) {
+      if (!(ids[i] in self.handshaken)) {
+        delete self[type][ids[i]];
+      }
+    }
+  });
 };


### PR DESCRIPTION
We've been trying to deploy Socket.IO in production, but have been having a hard time keeping it up for more than a couple hours due to ballooning memory usage. Looking at a heap dump showed that `manager.handshaken` was not getting cleared out. I put in some logging and found that other nodes were never getting notified of disconnects, and thus not clearing out their handshake data. I added another couple of publish calls in `onDisconnect` within the `if (local)` block to let other nodes know of the disconnects.

I also found that while in manager.js, `onDisconnect` has an argument `local`, it is actually `onClientDisconnect` that gets called with the local flag in transport.js. Consequently handlers were also never getting removed from the store. I added the flag to `onClientDisconnect` and pass it on to `onDisconnect`.

With some more logging, I found that some keys still weren't getting cleared out of transport, closed, and open (usually left with an empty array). So I added an additional routine to garbageCollection to loop through those and clear out any keys that weren't in `handshaken`.

These changes have kept memory usage from climbing so quickly, though it still continues to climb slowly (not sure where else to look at this point). CPU usage using RedisStore is the larger problem for us right now.
