### PR TITLE
Website: Fallback to monospace font

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -190,7 +190,7 @@ header {
 		background:#000;
 		background:rgba(0,0,0,0.3);
 		text-shadow:none;
-		font-family:Monaco;
+		font-family:Monaco, 'Ubuntu Mono', Inconsolata, Courier, monospace;
 		border:none;
 		padding:15px;
 		white-space:pre;


### PR DESCRIPTION
I hate it when someone loves his Mac
and thinks people all have Macs. ;)

``` css
font-family: Monaco;
```

![Your webpage on Windows](http://i.imgur.com/WVgsC.png)

should be changed to:

``` css
font-family: Monaco, 'Ubuntu Mono', Inconsolata, Courier, monospace;
```

PD: Personally, I'd prefer to not discrimitate others and put a webfont _first_,
(such as [`Ubuntu Mono`](http://code.google.com/webfonts/specimen/Ubuntu+Mono)) so that all platforms apply the **same** font (wether Mac or not).

**Note:** the Travis CI build failing doesn't have anything to do with this pull request.
Only the `gh-pages` branch is being updated (1 line changed).
