### PR TITLE
Return Buffers when using MsgPack with Redis store

### DIFF
--- a/lib/stores/redis.js
+++ b/lib/stores/redis.js
@@ -66,18 +66,27 @@ function Redis (opts) {
     this.pub = opts.redisPub;
   } else {
     opts.redisPub || (opts.redisPub = {});
+    if (msgpack) {
+      opts.redisPub.return_buffers = true;
+    }
     this.pub = redis.createClient(opts.redisPub.port, opts.redisPub.host, opts.redisPub);
   }
   if (opts.redisSub instanceof RedisClient) {
     this.sub = opts.redisSub;
   } else {
     opts.redisSub || (opts.redisSub = {});
+    if (msgpack) {
+      opts.redisSub.return_buffers = true;
+    }
     this.sub = redis.createClient(opts.redisSub.port, opts.redisSub.host, opts.redisSub);
   }
   if (opts.redisClient instanceof RedisClient) {
     this.cmd = opts.redisClient;
   } else {
     opts.redisClient || (opts.redisClient = {});
+    if (msgpack) {
+      opts.redisClient.return_buffers = true;
+    }
     this.cmd = redis.createClient(opts.redisClient.port, opts.redisClient.host, opts.redisClient);
   }
 


### PR DESCRIPTION
Since `msgpack.unpack` expects buffers, this flag should be set for the
user in cases where MessagePack has been automatically selected for
serialization.

The implementation is a bit verbose, but I think this is unavoidable. The API allows for options like `redisPub` to specify an instance of the `node-redis` client _or_ options with which to initialize a new client.

This should be added to [the wiki page on configuring socket.io](https://github.com/LearnBoost/Socket.IO/wiki/Configuring-Socket.IO) so that users who want to manually instantiate `node-redis` clients learn how to do so correctly. I'm happy to make this change as well.
