### PR TITLE
Added inRoom method to socket

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -198,6 +198,17 @@ Socket.prototype.leave = function (name, fn) {
 };
 
 /**
+ * Checks if socket is in room
+ *
+ * @api public
+ */
+
+Socket.prototype.inRoom = function(room) {
+    room = room.charAt(0) == '/' ? room : '/' + room;
+    return room in this.manager.rooms
+};
+
+/**
  * Transmits a packet.
  *
  * @api private


### PR DESCRIPTION
I needed to know if a socket is subscribed to a room, and i added the method to the Socket prototype
It can be used like this

```
socket.inRoom("some room"); // => false
socket.join("some room");
socket.inRoom("some room"); // => true
```
