### PR TITLE
Fix operator precedence bug

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -900,7 +900,7 @@ Manager.prototype.authorize = function (data, fn) {
     var self = this;
 
     this.get('authorization').call(this, data, function (err, authorized) {
-      self.log.debug('client ' + authorized ? 'authorized' : 'unauthorized');
+      self.log.debug('client ' + (authorized ? 'authorized' : 'unauthorized'));
       fn(err, authorized);
     });
   } else {


### PR DESCRIPTION
Debug log level always prints "authorized", because the original expression is parsed as

``` javascript
('client ' + authorized) ? 'authorized' : 'unauthorized';
```
