### PR TITLE
Use .removeAllListeners, not listeners().splice.

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -114,7 +114,8 @@ function Manager (server, options) {
   });
 
   // reset listeners
-  this.oldListeners = server.listeners('request').splice(0);
+  this.oldListeners = server.listeners('request').slice(0);
+  server.removeAllListeners('request');
 
   server.on('request', function (req, res) {
     self.handleRequest(req, res);


### PR DESCRIPTION
This is because in Node 0.9.x, when there is only one `request`, `server._event.request` stores just that handler instead of an array, and so `.splice()` will not remove the handler.

Since `.removeAllListeners()` is a documented API, it works across Node.js versions.

This bug manifests as "Can't set headers after they are sent" similar to: https://github.com/visionmedia/express/issues/1265

Tested on OSX with node 0.8.14 and node 0.9.3.

Minimal test case (crashes on node 0.9.3 on first GET):

``` js
var app = require('express')()
  , http = require('http')
  , server = http.createServer(app)
  , io = require('socket.io').listen(server);
server.listen(3000);
```
