### PR TITLE
Fix leaking message:id, disconnect:id

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -510,7 +510,7 @@ Manager.prototype.onClientMessage = function (id, packet) {
  * @api private
  */
 
-Manager.prototype.onClientDisconnect = function (id, reason) {
+Manager.prototype.onClientDisconnect = function (id, reason, local) {
   for (var name in this.namespaces) {
     if (this.namespaces.hasOwnProperty(name)) {
       this.namespaces[name].handleDisconnect(id, reason, typeof this.roomClients[id] !== 'undefined' &&
@@ -518,7 +518,7 @@ Manager.prototype.onClientDisconnect = function (id, reason) {
     }
   }
 
-  this.onDisconnect(id);
+  this.onDisconnect(id, local);
 };
 
 /**


### PR DESCRIPTION
When using RedisStore and clustering processes Redis leaks pubsub channels. This leads to high CPU especially over time as more and more channels leak. When using xhr-polling and clustering processes `message` and `disconnect` channels are not unsubscribed correctly. Websocket connections correctly unsubscribe from the message and disconnect channels. 

This commit reverted passing the local flag through to `Manager.prototype.onClientDisconnect` and subsequently `Manager.prototype.onClientDisconnect`, but this is required to handled unsubscribing. 

https://github.com/Learnboost/socket.io/commit/94d513c85a960f2a041e9027cee09cc87b89edf6
