### PR TITLE
Fixed bug in symbian anna

### DIFF
--- a/lib/transports/http.js
+++ b/lib/transports/http.js
@@ -50,7 +50,7 @@ HTTPTransport.prototype.handleRequest = function (req) {
     var buffer = ''
       , res = req.res
       , origin = req.headers.origin
-      , headers = { 'Content-Length': 1, 'Content-Type': 'text/plain; charset=UTF-8' }
+      , headers = { 'Content-Length': 1, 'Content-Type': 'application/javascript; charset=UTF-8' }
       , self = this;
 
     req.on('data', function (data) {


### PR DESCRIPTION
I changed content-type in response header from text/plain to application/javascript because some browsers forces file download with text/plain content-type (eg. symbian anna).
