### PR TITLE
Fixed issue #438 which caused high rate of "client not handshaken should reconnect"

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -794,11 +794,11 @@ Manager.prototype.handleHandshake = function (data, req, res) {
         res.writeHead(200, headers);
       }
 
-      res.end(hs);
-
       self.onHandshake(id, newData || handshakeData);
       self.store.publish('handshake', id, newData || handshakeData);
-
+	  
+	  res.end(hs);
+	  
       self.log.info('handshake authorized', id);
     } else {
       writeErr(403, 'handshake unauthorized');


### PR DESCRIPTION
This error (issue #438) appeared to come up while using some browsers (the operating system on which the socket.io server was running may also have been a factor).

It seems that emitting the handshake event on the store before ending the handshake request takes care of this issue... I tested it several times and I didn't encounter any handshake errors.
