### PR TITLE
fixed event listener bug in latest node

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -115,6 +115,7 @@ function Manager (server, options) {
 
   // reset listeners
   this.oldListeners = server.listeners('request').splice(0);
+  server.removeAllListeners('request');
 
   server.on('request', function (req, res) {
     self.handleRequest(req, res);


### PR DESCRIPTION
I'm not sure when this changed in node exactly but in the most current master branch (0.9.4) server.listeners returns a copy of the list and not the real thing, so calling splice on it does not remove the old listeners.  This causes the original 'default response' handler to run before any of the real ones, which of course breaks everything.
