### PR TITLE
fix duplicates calling of old request listeners of server

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -115,6 +115,7 @@ function Manager (server, options) {
 
   // reset listeners
   this.oldListeners = server.listeners('request').splice(0);
+  server.removeAllListeners('request');
 
   server.on('request', function (req, res) {
     self.handleRequest(req, res);


### PR DESCRIPTION
The 'oldListeners' stored in Manager will be called duplicately by the server because the listeners are not removed from server. It causes the error of resetting http header.
