### PR TITLE
Fixed duplicate request listeners in latest node

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -115,6 +115,7 @@ function Manager (server, options) {
 
   // reset listeners
   this.oldListeners = server.listeners('request').splice(0);
+  server.removeAllListeners('request');
 
   server.on('request', function (req, res) {
     self.handleRequest(req, res);


### PR DESCRIPTION
Listeners now returned as a clone rather than the array itself, so splice does not clear the listeners anymore. Use removeAllListeners(...) instead.
