### PR TITLE
Fix for slab buffer retention, leading to large memory consumption

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -617,7 +617,7 @@ Manager.prototype.handleRequest = function (req, res) {
  * @api private
  */
 
-Manager.prototype.handleUpgrade = function (req, socket, head) {
+Manager.prototype.handleUpgrade = function (req, socket, upgradehead) {
   var data = this.checkRequest(req)
     , self = this;
 
@@ -631,7 +631,9 @@ Manager.prototype.handleUpgrade = function (req, socket, head) {
   }
 
   var self = this;
-  this.ws.handleUpgrade(req, socket, head, function(client){
+  var head = new Buffer(upgradeHead.length);
+  upgradeHead.copy(head); 
+  this.ws.handleUpgrade(req, socket, upgradeHead, function(client){
     req.wsclient = client;
     self.handleClient(data, req);
   });


### PR DESCRIPTION
- Admittedly undertested.  This issues also affects early revs of socket.io.  The 'ws' library also exhibits this behavior and a pull request has been created for that lib.  

See: https://github.com/jmatthewsr-ms/node-slab-memory-issues
