### PR TITLE
Surround noop packet polling with try-catch. Since node.js version 0.8.2...

### DIFF
--- a/lib/transports/http-polling.js
+++ b/lib/transports/http-polling.js
@@ -76,8 +76,12 @@ HTTPPolling.prototype.handleRequest = function (req) {
     var self = this;
 
     this.pollTimeout = setTimeout(function () {
-      self.packet({ type: 'noop' });
-      self.log.debug(self.name + ' closed due to exceeded duration');
+      try {
+        self.packet({ type: 'noop' });
+        self.log.debug(self.name + ' closed due to exceeded duration');
+      } catch(e) {
+        self.log.debug('socket destroyed');
+      }
     }, this.manager.get('polling duration') * 1000);
 
     this.log.debug('setting poll timeout');


### PR DESCRIPTION
Surround noop packet polling with try-catch. Since node.js version 0.8.20 (http: Raise hangup error on destroyed socket write (isaacs)) a hangup error is raised when trying to write on destroyed sockets.

fixes #1160
