### PR TITLE
If the socket is destroyed, node.js from 0.8.20 version will raise an error

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -365,5 +365,9 @@ Socket.prototype.emit = function (ev) {
 
   packet.args = args;
 
-  return this.packet(packet);
+  try {
+    return this.packet(packet);
+  } catch(e) {
+    return null;
+  }
 };


### PR DESCRIPTION
If the socket is destroyed, node.js from 0.8.20 version will raise an error here.
