### PR TITLE
fix install for 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "debug": "*",
     "engine.io": "0.4.3",
     "socket.io-parser": "1.0.2",
-    "socket.io-client": "1.0.0",
+    "socket.io-client": "learnboost/socket.io-client",
     "send": "~0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Feel free to disregard this. I'm not sure when 1.0 is landing. Basically if I do:

```
npm install learnboost/socket.io
```

The installation will error out because `socket.io-client` is not at 1.0.0 yet.
