### PR TITLE
changed example boxes to be scrollable

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -259,6 +259,7 @@ header {
 		#content .example pre {
 			font-size:12px;
 			height:100%;
+      overflow:scroll;
 		}
 
 


### PR DESCRIPTION
i'm using chrome and can't scroll inside the example boxes on the website. the "client" example for the "acknowledgements" section contains a few comments, but unfortunately, they're cut off.

![socket-example](https://f.cloud.github.com/assets/71851/266712/9cd3771e-8e2d-11e2-8f83-a4a502286ab3.png)

so i would suggest to either pull this simple fix or place the comments inside the box.

thanks for this awesome library!

cheers,
daniel
