### PR TITLE
Removed 0.6 from travis (no longer supported by socket.io deps), added 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - 0.6
-  - 0.8
+  - "0.8"
+  - "0.10"
 
 notifications:
   irc: "irc.freenode.org#socket.io"


### PR DESCRIPTION
Also stringified the versions as they should be, as it is a yaml file so `0.10` becomes `0.1`, so for versions we should use strings - `"0.10"` stays `0.10`
