### PR TITLE
Make adding headers to 304 response for static objects. ...

### DIFF
--- a/lib/static.js
+++ b/lib/static.js
@@ -296,7 +296,14 @@ Static.prototype.write = function (path, req, res) {
   function answer (reply) {
     var cached = req.headers['if-none-match'] === reply.etag;
     if (cached && self.manager.enabled('browser client etag')) {
-      return write(304);
+      var expires = self.manager.get('browser client expires');
+      headers = {};
+      headers['Etag'] = reply.etag;
+      headers['Cache-Control'] = 'private, x-gzip-ok="", max-age=' + expires;
+      headers['Date'] = new Date().toUTCString();
+      headers['Expires'] = new Date(Date.now() + (expires * 1000)).toUTCString();
+
+      return write(304, headers);
     }
 
     var accept = req.headers['accept-encoding'] || ''


### PR DESCRIPTION
Make adding headers to 304 response for static objects. Browsers want know expires date for not modified objects too.
