### PR TITLE
Fix to manage namespace disconnection and reconnection

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -301,9 +301,15 @@ Socket.prototype.disconnect = function () {
     } else {
       this.packet({type: 'disconnect'});
       this.manager.onLeave(this.id, this.namespace.name);
-      this.$emit('disconnect', 'booted');
+
+	    if (this.namespace.sockets[this.id]) {
+		    this.removeAllListeners();
+		    delete this.namespace.sockets[this.id];
+	    }
+
     }
 
+	  this.onDisconnect('booted');
   }
 
   return this;


### PR DESCRIPTION
Hi,

I was struggling to manage the namespace client disconnection in the application that we are working. 
I realised that when the client disconnect from a namespace, after if I tried to connect again to the same namespace, it didn't receive the messages from the server, at least if the client reconnected the socket to the same namespace some seconds after he had disconnected it.

After debugging the code for awhile, I found this fix.

This pull request corresponds to another pull request to socket.io-client that I've done: [#568](https://github.com/LearnBoost/socket.io-client/issues/568)

By the way, I also realised that if I would like to manage a disconnection to a namespace, emitted by the client I have to listen the 'disconnect' event and manage the first call checking if the message is 'packet' and in that case call the method 'disconnect()' from the socket; next the piece of code  to do that:

``` js
var io = require('socket.io').listen(80);
var chat = io
    .of('/chat')
    .on('connection', function (socket) {
        socket.on('disconnect', function (msg) {
            if (msg === 'packet') {
                socket.disconnect();
            }
        });
    });
```
