### PR TITLE
Update namespace.js fix memory leak in acks

### DIFF
--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -316,6 +316,8 @@ SocketNamespace.prototype.handlePacket = function (sessid, packet) {
     case 'ack':
       if (socket.acks[packet.ackId]) {
         socket.acks[packet.ackId].apply(socket, packet.args);
+        //clean up the acks object so that it doesn't just grow indefinitely
+        delete socket.acks[packet.ackId];
       } else {
         this.log.info('unknown ack packet');
       }


### PR DESCRIPTION
updating namespace.js similar to socket.io-client/dist/socket.io.js such that it clears the acks object after running the ack function... prevents memory leak.
