### PR TITLE
Add connection reference in handshake

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -777,6 +777,11 @@ Manager.prototype.handleHandshake = function (data, req, res) {
 
   var handshakeData = this.handshakeData(data);
 
+  // Store the connection object reference in handshake data so that
+  // servers that need to authorize based on connection data (source
+  // IP, a certain cert etc) can do so.
+  handshakeData.connection = req.connection;
+
   if (origin) {
     // https://developer.mozilla.org/En/HTTP_Access_Control
     headers['Access-Control-Allow-Origin'] = origin;


### PR DESCRIPTION
Make the connection object reference available in handshake data so
that servers that need to authorize based on connection data (e.g.
source IP), to make decisions based on the client certificate etc, can
do so.
