### PR TITLE
Workaround : client not handshaken error

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -630,6 +630,58 @@ Manager.prototype.handleHTTPRequest = function (data, req, res) {
   this.handleClient(data, req);
 };
 
+
+
+/**
+ * [WAR] client not handshaken error
+ * It waits to update handshaken.
+ * 
+ * @param scope
+ * @param transport
+ * @param dataId
+ * @param until
+ * @param callback
+ * 
+ */
+Manager.prototype._waitHandshaken = function (scope, transport, dataId, until, callback) {
+    var interval = 3000;
+    var handshaken = scope.handshaken[dataId];
+    
+    if (!transport.open) {
+        scope.log.debug('socketio - WaitHandshaken transport is closed. :'
+                + " dataId = " + dataId
+        );
+        callback && callback();
+        return;
+    }
+    
+    var now = new Date().getTime();
+    if (now + interval > until) {
+        scope.log.warn('socketio - WaitHandshaken timeout. :'
+                + " dataId = " + dataId
+                + " now = " + now
+                + " interval = " + interval
+                + " until = " + until
+        );
+        callback && callback();
+        return;
+    }
+    
+    if (!handshaken) {
+        scope.log.debug('socketio - WaitHandshaken wating :'
+                + " dataId = " + dataId
+                + " interval = " + interval
+                + " until = " + until
+        );
+        setTimeout(scope._waitHandshaken, interval, scope, transport, dataId, until, callback);
+    } else {
+        scope.log.debug('socketio - WaitHandshaken handshaken :'
+                + " dataId = " + dataId
+        );
+        callback && callback();
+    }
+};
+
 /**
  * Intantiantes a new client.
  *
@@ -662,6 +714,16 @@ Manager.prototype.handleClient = function (data, req) {
   var transport = new transports[data.transport](this, data, req)
     , handshaken = this.handshaken[data.id];
 
+  var until = new Date().getTime() + (this.get('heartbeat timeout') * 1000);
+  this._waitHandshaken(this, transport, data.id, until, function() {
+      self._handleClient(data, req, transport);
+  });
+};
+
+Manager.prototype._handleClient = function(data, req, transport) {
+  var self = this;
+  var handshaken = this.handshaken[data.id];
+  
   if (transport.disconnected) {
     // failed during transport setup
     req.connection.end();


### PR DESCRIPTION
At the time of the high load of redis, there is a case where pub/sub of handshake is overdue after connection. 
This is a plan for preventing reduction of a connection rate. 
