### PR TITLE
http-polling : adding 'X-XSS-Protection : 0;' to headers necessary not o...

### DIFF
--- a/lib/transports/http.js
+++ b/lib/transports/http.js
@@ -79,6 +79,7 @@ HTTPTransport.prototype.handleRequest = function (req) {
       // https://developer.mozilla.org/En/HTTP_Access_Control
       headers['Access-Control-Allow-Origin'] = origin;
       headers['Access-Control-Allow-Credentials'] = 'true';
+      headers['X-XSS-Protection'] = '0';
     }
   } else {
     Transport.prototype.handleRequest.call(this, req);


### PR DESCRIPTION
Without this fix, the following warning message will appear if security level is set very high in IE:

"Internet Explorer has modified this page to prevent Cross Site Scripting..."

There was a fix to this problem, by adding "X-XSS-Protection" to headers when using jsonp-polling.

https://github.com/ajaxorg/socket.io/commit/62f7335b5eddf0e3b41dc46a5c8d3f17e8324997

However, jsonp-polling uses http-polling also when handling requests, so I needed to add similar fix to http-polling.
