### PR TITLE
WebSocket ping/pong fixes.

### DIFF
--- a/lib/transports/websocket/hybi-07-12.js
+++ b/lib/transports/websocket/hybi-07-12.js
@@ -39,10 +39,11 @@ function WebSocket (mng, data, req) {
   this.parser.on('data', function (packet) {
     self.onMessage(parser.decodePacket(packet));
   });
-  this.parser.on('ping', function () {
+  this.parser.on('ping', function (data) {
     // version 8 ping => pong
+    var buf = self.frame(0x8a, data);
     try {
-      self.socket.write('\u008a\u0000');
+      self.socket.write(buf, 'binary');
     }
     catch (e) {
       self.end();

--- a/lib/transports/websocket/hybi-16.js
+++ b/lib/transports/websocket/hybi-16.js
@@ -38,10 +38,11 @@ function WebSocket (mng, data, req) {
   this.parser.on('data', function (packet) {
     self.onMessage(parser.decodePacket(packet));
   });
-  this.parser.on('ping', function () {
+  this.parser.on('ping', function (data) {
     // version 8 ping => pong
+    var buf = self.frame(0x8a, data);
     try {
-      self.socket.write('\u008a\u0000');
+      self.socket.write(buf, 'binary');
     }
     catch (e) {
       self.end();


### PR DESCRIPTION
- Fix the pong frame converting to utf8.
- Echo ping's data: http://tools.ietf.org/html/rfc6455#section-5.5.3.
