### PR TITLE
Use static channels for remote syncing across nodes.

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -320,8 +320,54 @@ Manager.prototype.initStore = function () {
   this.store.subscribe('disconnect', function (id) {
     self.onDisconnect(id);
   });
-};
 
+  // we need to do this in a pub/sub way since the client can POST the message
+  // over a different socket (ie: different Transport instance)
+
+  //use persistent channel for these, don't add and remove 5 channels for every connection
+  //eg. for 10,000 concurrent users this creates 50,000 channels in redis, which kind of slows things down
+  //we only need 5 (extra) total channels at all times
+  this.store.subscribe('message-remote',function (id, packet) {
+    self.onClientMessage(id, packet);
+
+    var transport = self.transports[id];
+    if (transport) {
+      transport.onClientMessage(id, packet);
+    }
+  });
+
+  this.store.subscribe('disconnect-remote', function (id, reason) {
+    self.onClientDisconnect(id, reason);
+
+    var transport = self.transports[id];
+    if (transport) {
+      transport.onClientDisconnect(id, reason);
+    }
+  });
+
+  this.store.subscribe('dispatch-remote', function (id, packet, volatile) {
+    self.onClientDispatch(id, packet);
+
+    var transport = self.transports[id];
+    if (transport && !volatile) {
+      transport.onDispatch(packet, volatile);
+    }
+  });
+
+  this.store.subscribe('heartbeat-clear', function (id) {
+    var transport = self.transports[id];
+    if (transport) {
+      transport.onHeartbeatClear();
+    }
+  });
+
+  this.store.subscribe('disconnect-force', function (id) {
+    var transport = self.transports[id];
+    if (transport) {
+      transport.onForcedDisconnect();
+    }
+  });
+};
 /**
  * Called when a client handshakes.
  *
@@ -354,19 +400,17 @@ Manager.prototype.onOpen = function (id) {
   if (this.closed[id]) {
     var self = this;
 
-    this.store.unsubscribe('dispatch:' + id, function () {
-      var transport = self.transports[id];
-      if (self.closed[id] && self.closed[id].length && transport) {
+    var transport = self.transports[id];
+    if (self.closed[id] && self.closed[id].length && transport) {
 
-        // if we have buffered messages that accumulate between calling
-        // onOpen an this async callback, send them if the transport is 
-        // still open, otherwise leave them buffered
-        if (transport.open) {
-          transport.payload(self.closed[id]);
-          self.closed[id] = [];
-        }
+      // if we have buffered messages that accumulate between calling
+      // onOpen an this async callback, send them if the transport is
+      // still open, otherwise leave them buffered
+      if (transport.open) {
+        transport.payload(self.closed[id]);
+        self.closed[id] = [];
       }
-    });
+    }
   }
 
   // clear the current transport
@@ -495,7 +539,7 @@ Manager.prototype.onClientMessage = function (id, packet) {
  * @api private
  */
 
-Manager.prototype.onClientDisconnect = function (id, reason, local) {
+Manager.prototype.onClientDisconnect = function (id, reason) {
   for (var name in this.namespaces) {
     if (this.namespaces.hasOwnProperty(name)) {
       this.namespaces[name].handleDisconnect(id, reason, typeof this.roomClients[id] !== 'undefined' &&
@@ -503,7 +547,7 @@ Manager.prototype.onClientDisconnect = function (id, reason, local) {
     }
   }
 
-  this.onDisconnect(id, local);
+  this.onDisconnect(id);
 };
 
 /**
@@ -512,7 +556,7 @@ Manager.prototype.onClientDisconnect = function (id, reason, local) {
  * @param text
  */
 
-Manager.prototype.onDisconnect = function (id, local) {
+Manager.prototype.onDisconnect = function (id) {
   delete this.handshaken[id];
 
   if (this.open[id]) {
@@ -542,13 +586,6 @@ Manager.prototype.onDisconnect = function (id, local) {
   }
 
   this.store.destroyClient(id, this.get('client store expiration'));
-
-  this.store.unsubscribe('dispatch:' + id);
-
-  if (local) {
-    this.store.unsubscribe('message:' + id);
-    this.store.unsubscribe('disconnect:' + id);
-  }
 };
 
 /**
@@ -646,7 +683,7 @@ Manager.prototype.handleClient = function (data, req) {
     if (this.transports[data.id] && this.transports[data.id].open) {
       this.transports[data.id].onForcedDisconnect();
     } else {
-      this.store.publish('disconnect-force:' + data.id);
+      this.store.publish('disconnect-force', data.id);
     }
     req.res.writeHead(200);
     req.res.end();

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -233,7 +233,7 @@ Socket.prototype.dispatch = function (packet, volatile) {
       this.manager.onClientDispatch(this.id, packet, volatile);
     }
 
-    this.manager.store.publish('dispatch:' + this.id, packet, volatile);
+    this.manager.store.publish('dispatch-remote', this.id, packet, volatile);
   }
 };
 
@@ -296,7 +296,7 @@ Socket.prototype.disconnect = function () {
         this.manager.transports[this.id].onForcedDisconnect();
       } else {
         this.manager.onClientDisconnect(this.id);
-        this.manager.store.publish('disconnect:' + this.id);
+        this.manager.store.publish('disconnect-remote', this.id);
       }
     } else {
       this.packet({type: 'disconnect'});

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -350,7 +350,7 @@ Transport.prototype.onMessage = function (packet) {
     if (current && current.open) {
       current.onHeartbeatClear();
     } else {
-      this.store.publish('heartbeat-clear:' + this.id);
+      this.store.publish('heartbeat-clear', this.id);
     }
   } else {
     if ('disconnect' == packet.type && packet.endpoint == '') {
@@ -359,7 +359,7 @@ Transport.prototype.onMessage = function (packet) {
       if (current) {
         current.onForcedDisconnect();
       } else {
-        this.store.publish('disconnect-force:' + this.id);
+        this.store.publish('disconnect-force', this.id);
       }
 
       return;
@@ -378,7 +378,7 @@ Transport.prototype.onMessage = function (packet) {
         current.onDispatch(ack);
       } else {
         this.manager.onClientDispatch(this.id, ack);
-        this.store.publish('dispatch:' + this.id, ack);
+        this.store.publish('dispatch-remote', this.id, ack);
       }
     }
 
@@ -386,7 +386,7 @@ Transport.prototype.onMessage = function (packet) {
     if (current) {
       this.manager.onClientMessage(this.id, packet);
     } else {
-      this.store.publish('message:' + this.id, packet);
+      this.store.publish('message-remote', this.id, packet);
     }
   }
 };
@@ -464,9 +464,9 @@ Transport.prototype.end = function (reason) {
     this.disconnected = true;
 
     if (local) {
-      this.manager.onClientDisconnect(this.id, reason, true);
+      this.manager.onClientDisconnect(this.id, reason);
     } else {
-      this.store.publish('disconnect:' + this.id, reason);
+      this.store.publish('disconnect-remote', this.id, reason);
     }
   }
 };


### PR DESCRIPTION
Every time a connection is made, socket.io subscribes to 5 additional channels in redis to keep sync in state across multiple nodes (which are unsubscribed on disconnect). This causes problems with high numbers of concurrent connections, eg. 10000 concurrent = 50000 redis subscriptions, which causes redis to use orders of magnitude more CPU.

This patch uses 5 static channels to convey the sync information instead of subscribing and unsubscribing with every connection. The pub/sub count in redis now stays at 13 whether 10 users are connected, 10,000, or 100,000.
