### PR TITLE
use static channels for node syncing

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -320,8 +320,55 @@ Manager.prototype.initStore = function () {
   this.store.subscribe('disconnect', function (id) {
     self.onDisconnect(id);
   });
-};
 
+  // we need to do this in a pub/sub way since the client can POST the message
+  // over a different socket (ie: different Transport instance)
+
+  //use persistent channel for these, don't add and remove 5 channels for every connection
+  //eg. for 10,000 concurrent users this creates 50,000 channels in redis, which kind of slows things down
+  //we only need 5 (extra) total channels at all times
+  this.store.subscribe('message-remote',function (id, packet) {
+    self.onClientMessage(id, packet);
+
+    var transport = self.transports[id];
+    if (transport) {
+      transport.onClientMessage(id, packet);
+    }
+  });
+
+  this.store.subscribe('disconnect-remote', function (id, reason) {
+    self.onClientDisconnect(id, reason);
+
+    var transport = self.transports[id];
+    if (transport) {
+      transport.onClientDisconnect(id, reason);
+    }
+  });
+
+  this.store.subscribe('dispatch-remote', function (id, packet, volatile) {
+    self.onClientDispatch(id, packet);
+
+    var transport = self.transports[id];
+    if (transport && !volatile) {
+      transport.onDispatch(packet, volatile);
+    }
+  });
+
+    //2fours - only subscribe once to the following channels and use them for all connections
+  this.store.subscribe('heartbeat-clear', function (id) {
+    var transport = self.transports[id];
+    if (transport) {
+      transport.onHeartbeatClear();
+    }
+  });
+
+  this.store.subscribe('disconnect-force', function (id) {
+    var transport = self.transports[id];
+    if (transport) {
+      transport.onForcedDisconnect();
+    }
+  });
+};
 /**
  * Called when a client handshakes.
  *
@@ -354,19 +401,17 @@ Manager.prototype.onOpen = function (id) {
   if (this.closed[id]) {
     var self = this;
 
-    this.store.unsubscribe('dispatch:' + id, function () {
-      var transport = self.transports[id];
-      if (self.closed[id] && self.closed[id].length && transport) {
+    var transport = self.transports[id];
+    if (self.closed[id] && self.closed[id].length && transport) {
 
-        // if we have buffered messages that accumulate between calling
-        // onOpen an this async callback, send them if the transport is 
-        // still open, otherwise leave them buffered
-        if (transport.open) {
-          transport.payload(self.closed[id]);
-          self.closed[id] = [];
-        }
+      // if we have buffered messages that accumulate between calling
+      // onOpen an this async callback, send them if the transport is
+      // still open, otherwise leave them buffered
+      if (transport.open) {
+        transport.payload(self.closed[id]);
+        self.closed[id] = [];
       }
-    });
+    }
   }
 
   // clear the current transport
@@ -457,12 +502,6 @@ Manager.prototype.onClose = function (id) {
   this.closed[id] = [];
 
   var self = this;
-
-  this.store.subscribe('dispatch:' + id, function (packet, volatile) {
-    if (!volatile) {
-      self.onClientDispatch(id, packet);
-    }
-  });
 };
 
 /**
@@ -495,7 +534,7 @@ Manager.prototype.onClientMessage = function (id, packet) {
  * @api private
  */
 
-Manager.prototype.onClientDisconnect = function (id, reason, local) {
+Manager.prototype.onClientDisconnect = function (id, reason) {
   for (var name in this.namespaces) {
     if (this.namespaces.hasOwnProperty(name)) {
       this.namespaces[name].handleDisconnect(id, reason, typeof this.roomClients[id] !== 'undefined' &&
@@ -503,7 +542,7 @@ Manager.prototype.onClientDisconnect = function (id, reason, local) {
     }
   }
 
-  this.onDisconnect(id, local);
+  this.onDisconnect(id);
 };
 
 /**
@@ -512,7 +551,7 @@ Manager.prototype.onClientDisconnect = function (id, reason, local) {
  * @param text
  */
 
-Manager.prototype.onDisconnect = function (id, local) {
+Manager.prototype.onDisconnect = function (id) {
   delete this.handshaken[id];
 
   if (this.open[id]) {
@@ -542,13 +581,6 @@ Manager.prototype.onDisconnect = function (id, local) {
   }
 
   this.store.destroyClient(id, this.get('client store expiration'));
-
-  this.store.unsubscribe('dispatch:' + id);
-
-  if (local) {
-    this.store.unsubscribe('message:' + id);
-    this.store.unsubscribe('disconnect:' + id);
-  }
 };
 
 /**
@@ -646,7 +678,7 @@ Manager.prototype.handleClient = function (data, req) {
     if (this.transports[data.id] && this.transports[data.id].open) {
       this.transports[data.id].onForcedDisconnect();
     } else {
-      this.store.publish('disconnect-force:' + data.id);
+      this.store.publish('disconnect-force', data.id);
     }
     req.res.writeHead(200);
     req.res.end();
@@ -699,14 +731,6 @@ Manager.prototype.handleClient = function (data, req) {
           }
         }
       }
-
-      this.store.subscribe('message:' + data.id, function (packet) {
-        self.onClientMessage(data.id, packet);
-      });
-
-      this.store.subscribe('disconnect:' + data.id, function (reason) {
-        self.onClientDisconnect(data.id, reason);
-      });
     }
   } else {
     if (transport.open) {

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -233,7 +233,7 @@ Socket.prototype.dispatch = function (packet, volatile) {
       this.manager.onClientDispatch(this.id, packet, volatile);
     }
 
-    this.manager.store.publish('dispatch:' + this.id, packet, volatile);
+    this.manager.store.publish('dispatch-remote', this.id, packet, volatile);
   }
 };
 
@@ -296,7 +296,7 @@ Socket.prototype.disconnect = function () {
         this.manager.transports[this.id].onForcedDisconnect();
       } else {
         this.manager.onClientDisconnect(this.id);
-        this.manager.store.publish('disconnect:' + this.id);
+        this.manager.store.publish('disconnect-remote', this.id);
       }
     } else {
       this.packet({type: 'disconnect'});

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -89,20 +89,6 @@ Transport.prototype.onSocketConnect = function () { };
 Transport.prototype.setHandlers = function () {
   var self = this;
 
-  // we need to do this in a pub/sub way since the client can POST the message
-  // over a different socket (ie: different Transport instance)
-  this.store.subscribe('heartbeat-clear:' + this.id, function () {
-    self.onHeartbeatClear();
-  });
-
-  this.store.subscribe('disconnect-force:' + this.id, function () {
-    self.onForcedDisconnect();
-  });
-
-  this.store.subscribe('dispatch:' + this.id, function (packet, volatile) {
-    self.onDispatch(packet, volatile);
-  });
-
   this.bound = {
       end: this.onSocketEnd.bind(this)
     , close: this.onSocketClose.bind(this)
@@ -126,10 +112,6 @@ Transport.prototype.setHandlers = function () {
 
 Transport.prototype.clearHandlers = function () {
   if (this.handlersSet) {
-    this.store.unsubscribe('disconnect-force:' + this.id);
-    this.store.unsubscribe('heartbeat-clear:' + this.id);
-    this.store.unsubscribe('dispatch:' + this.id);
-
     this.socket.removeListener('end', this.bound.end);
     this.socket.removeListener('close', this.bound.close);
     this.socket.removeListener('error', this.bound.error);
@@ -350,7 +332,7 @@ Transport.prototype.onMessage = function (packet) {
     if (current && current.open) {
       current.onHeartbeatClear();
     } else {
-      this.store.publish('heartbeat-clear:' + this.id);
+      this.store.publish('heartbeat-clear', this.id);
     }
   } else {
     if ('disconnect' == packet.type && packet.endpoint == '') {
@@ -359,7 +341,7 @@ Transport.prototype.onMessage = function (packet) {
       if (current) {
         current.onForcedDisconnect();
       } else {
-        this.store.publish('disconnect-force:' + this.id);
+        this.store.publish('disconnect-force', this.id);
       }
 
       return;
@@ -378,7 +360,7 @@ Transport.prototype.onMessage = function (packet) {
         current.onDispatch(ack);
       } else {
         this.manager.onClientDispatch(this.id, ack);
-        this.store.publish('dispatch:' + this.id, ack);
+        this.store.publish('dispatch-remote', this.id, ack);
       }
     }
 
@@ -386,7 +368,7 @@ Transport.prototype.onMessage = function (packet) {
     if (current) {
       this.manager.onClientMessage(this.id, packet);
     } else {
-      this.store.publish('message:' + this.id, packet);
+      this.store.publish('message-remote', this.id, packet);
     }
   }
 };
@@ -464,9 +446,9 @@ Transport.prototype.end = function (reason) {
     this.disconnected = true;
 
     if (local) {
-      this.manager.onClientDisconnect(this.id, reason, true);
+      this.manager.onClientDisconnect(this.id, reason);
     } else {
-      this.store.publish('disconnect:' + this.id, reason);
+      this.store.publish('disconnect-remote', this.id, reason);
     }
   }
 };


### PR DESCRIPTION
Every time a connection is made, socket.io subscribes to 5 additional channels in redis to keep sync in state across multiple nodes (which are unsubscribed on disconnect). This causes problems with high numbers of concurrent connections, eg. 10000 concurrent = 50000 redis subscriptions, which causes redis to use orders of magnitude more CPU.

This patch uses 5 static channels to convey the sync information instead of subscribing and unsubscribing with every connection. The pub/sub count in redis now stays at 13 whether 10 users are connected, 10,000, or 100,000.
