### PR TITLE
Fixes: Socket not cleanly closed after ECONNRESET

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -166,7 +166,7 @@ Transport.prototype.onSocketClose = function (error) {
 Transport.prototype.onSocketError = function (err) {
   if (this.open) {
     this.socket.destroy();
-    this.onClose();
+    this.onSocketClose(true);
   }
 
   this.log.info('socket error '  + err.stack);


### PR DESCRIPTION
Nodejs 0.10.20 throw an "ECONNRESET" error when the socket is reset. After this exception, the socket wasn't cleanly closed, causing a weird behavior.

Pull request based on the solution given in bug report #1343

Some related issues: #1281 #1367
