### PR TITLE
"close timeout" should be for client only

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -74,6 +74,7 @@ function Manager (server, options) {
     , 'log level': 3
     , 'log colors': tty.isatty(process.stdout.fd)
     , 'close timeout': 60
+    , 'reopen timeout': 10
     , 'heartbeat interval': 25
     , 'heartbeat timeout': 60
     , 'polling duration': 20

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -227,17 +227,17 @@ Transport.prototype.onDispatch = function (packet, volatile) {
  * Sets the close timeout.
  */
 
-Transport.prototype.setCloseTimeout = function () {
-  if (!this.closeTimeout) {
+Transport.prototype.setReopenTimeout = function () {
+  if (!this.reopenTimeout) {
     var self = this;
 
-    this.closeTimeout = setTimeout(function () {
-      self.log.debug('fired close timeout for client', self.id);
-      self.closeTimeout = null;
-      self.end('close timeout');
-    }, this.manager.get('close timeout') * 1000);
+    this.reopenTimeout = setTimeout(function () {
+      self.log.debug('fired reopen timeout for client', self.id);
+      self.reopenTimeout = null;
+      self.end('reopen timeout');
+    }, this.manager.get('reopen timeout') * 1000);
 
-    this.log.debug('set close timeout for client', this.id);
+    this.log.debug('set reopen timeout for client', this.id);
   }
 };
 
@@ -245,12 +245,12 @@ Transport.prototype.setCloseTimeout = function () {
  * Clears the close timeout.
  */
 
-Transport.prototype.clearCloseTimeout = function () {
-  if (this.closeTimeout) {
-    clearTimeout(this.closeTimeout);
-    this.closeTimeout = null;
+Transport.prototype.clearReopenTimeout = function () {
+  if (this.reopenTimeout) {
+    clearTimeout(this.reopenTimeout);
+    this.reopenTimeout = null;
 
-    this.log.debug('cleared close timeout for client', this.id);
+    this.log.debug('cleared reopen timeout for client', this.id);
   }
 };
 
@@ -313,7 +313,7 @@ Transport.prototype.setHeartbeatInterval = function () {
  */
 
 Transport.prototype.clearTimeouts = function () {
-  this.clearCloseTimeout();
+  this.clearReopenTimeout();
   this.clearHeartbeatTimeout();
   this.clearHeartbeatInterval();
 };
@@ -439,7 +439,7 @@ Transport.prototype.close = function () {
 
 Transport.prototype.onClose = function () {
   if (this.open) {
-    this.setCloseTimeout();
+    this.setReopenTimeout();
     this.clearHandlers();
     this.open = false;
     this.manager.onClose(this.id);

--- a/lib/transports/http-polling.js
+++ b/lib/transports/http-polling.js
@@ -75,12 +75,17 @@ HTTPPolling.prototype.handleRequest = function (req) {
   if (req.method == 'GET') {
     var self = this;
 
+    this.log.debug('setting poll timeout');
     this.pollTimeout = setTimeout(function () {
       self.packet({ type: 'noop' });
       self.log.debug(self.name + ' closed due to exceeded duration');
     }, this.manager.get('polling duration') * 1000);
 
-    this.log.debug('setting poll timeout');
+    req.on("close", function() {
+        self.clearPollTimeout();
+        self.log.info(self.name + " closed unexpectedly for " + self.id);
+        self.setReopenTimeout();
+    });
   }
 };
 


### PR DESCRIPTION
"close timeout" is passed to the client, and the client closes connection if no data is exchanged in said timeout. Great. But server also sets a timeout **after** client closes connection. This timeout is completely orthogonal to client's "close timeout".  

As per the wiki, which I suspect is a little outdated, "close timeout" is for the server to wait for clients to reconnect **after** closing connections. Since clients are used to "close timeout" as mentioned above, I propose a new option "reopen timeout" for the server, which does exactly what the wiki says for "close timeout".

This is especially helpful with polling transports. Right now, server has to wait polling timeout + close timeout to emit "disconnected". Setting "close timeout" too low to speed up this forces all clients to keep refreshing connections very frequently.
