### PR TITLE
middlewares of main namespace should be called first

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -30,6 +30,7 @@ function Client(server, conn){
   this.setup();
   this.sockets = [];
   this.nsps = {};
+  this.connectBuffer = [];
 }
 
 /**
@@ -55,10 +56,20 @@ Client.prototype.setup = function(){
 Client.prototype.connect = function(name){
   debug('connecting to namespace %s', name);
   var nsp = this.server.of(name);
+  if ('/' != name && !this.nsps['/']) {
+    this.connectBuffer.push(name);
+    return;
+  }
+
   var self = this;
   var socket = nsp.add(this, function(){
     self.sockets.push(socket);
     self.nsps[nsp.name] = socket;
+
+    if ('/' == nsp.name) {
+      self.connectBuffer.forEach(self.connect, self);
+      delete self.connectBuffer;
+    }
   });
 };
 

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -713,5 +713,36 @@ describe('socket.io', function(){
         });
       });
     });
+
+    it('should call functions in expected order', function(done){
+      var srv = http();
+      var sio = io(srv);
+      var result = [];
+
+      sio.use(function(socket, next) {
+        result.push(1);
+        setTimeout(next, 50);
+      });
+      sio.use(function(socket, next) {
+        result.push(2);
+        setTimeout(next, 50);
+      });
+      sio.of('/chat').use(function(socket, next) {
+        result.push(3);
+        setTimeout(next, 50);
+      });
+      sio.of('/chat').use(function(socket, next) {
+        result.push(4);
+        setTimeout(next, 50);
+      });
+
+      srv.listen(function() {
+        var chat = client(srv, '/chat');
+        chat.on('connect', function() {
+          expect(result).to.eql([1, 2, 3, 4]);
+          done();
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
When you set middlewares both with and without namespaces, these middleware functions run in parallel. I believe they should run in series. All middlewares of main namespace should be called first.
