### PR TITLE
change index to read build file from client

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,9 @@ var Namespace = require('./namespace');
 var Adapter = require('./adapter');
 var debug = require('debug')('socket.io:server');
 
+var read = require('fs').readFileSync;
+var clientSource = read(require.resolve('socket.io-client/socket.io.js'), 'utf-8');
+
 /**
  * Module exports.
  */
@@ -179,7 +182,7 @@ Server.prototype.serve = function(req, res){
   res.setHeader('Content-Type', 'application/javascript');
   res.setHeader('ETag', clientVersion);
   res.writeHead(200);
-  res.end(client.source);
+  res.end(clientSource);
 };
 
 /**


### PR DESCRIPTION
Originally socket.io.js was read in the client, but since we removed "fs" module from there, it needs to be read in the server. 
