### PR TITLE
Example: Chat -- Welcome message is always on top. Click now focuses input.

### DIFF
--- a/examples/chat/public/main.js
+++ b/examples/chat/public/main.js
@@ -33,6 +33,7 @@ $(function() {
     if (username) {
       $loginPage.fadeOut();
       $chatPage.show();
+      $loginPage.off('click');
       $currentInput = $inputMessage.focus();
 
       // Tell the server your username
@@ -201,8 +202,14 @@ $(function() {
 
   // Click events
 
-  $window.click(function () {
+  // Focus input when clicking anywhere on login page
+  $loginPage.click(function () {
     $currentInput.focus();
+  });
+
+  // Focus input when clicking on the message input's border
+  $inputMessage.click(function () {
+    $inputMessage.focus();
   });
 
   // Socket events


### PR DESCRIPTION
Added two features to Socket.IO Chat:
- **Click to focus**: Clicking anywhere now focuses the current text input.
- **Welcome messages always on top**: (Even when messages are being loaded while still on the login screen.)
  - This was a bug where we connect and started loading messages/logs while on the login page. Once we actually logged in, the welcome message would appear below all of these messages. Now the welcome message is always on top.
  - Another way to do this would be to not load _any_ messages until the user logged in.
  - **Implementation**: Changed `addMessage` function to accept an `options` argument that have the boolean flags `fade` and `prepend`.
