### PR TITLE
Added binary support to broadcasting of events

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -4,6 +4,7 @@
  */
 
 var Emitter = require('events').EventEmitter;
+var parser = require('socket.io-parser');
 
 /**
  * Module exports.
@@ -22,6 +23,7 @@ function Adapter(nsp){
   this.nsp = nsp;
   this.rooms = {};
   this.sids = {};
+  this.encoder = new parser.Encoder();
 }
 
 /**
@@ -97,26 +99,30 @@ Adapter.prototype.broadcast = function(packet, opts){
   var rooms = opts.rooms || [];
   var except = opts.except || [];
   var ids = {};
+  var self = this;
   var socket;
 
-  if (rooms.length) {
-    for (var i = 0; i < rooms.length; i++) {
-      var room = this.rooms[rooms[i]];
-      if (!room) continue;
-      for (var id in room) {
-        if (ids[id] || ~except.indexOf(id)) continue;
-        socket = this.nsp.connected[id];
-        if (socket) {
-          socket.packet(packet);
-          ids[id] = true;
+  packet.nsp = this.nsp.name;
+  this.encoder.encode(packet, function(encodedPackets) {
+    if (rooms.length) {
+      for (var i = 0; i < rooms.length; i++) {
+        var room = self.rooms[rooms[i]];
+        if (!room) continue;
+        for (var id in room) {
+          if (ids[id] || ~except.indexOf(id)) continue;
+          socket = self.nsp.connected[id];
+          if (socket) {
+            socket.packet(encodedPackets, true);
+            ids[id] = true;
+          }
         }
       }
+    } else {
+      for (var id in self.sids) {
+        if (~except.indexOf(id)) continue;
+        socket = self.nsp.connected[id];
+        if (socket) socket.packet(encodedPackets, true);
+      }
     }
-  } else {
-    for (var id in this.sids) {
-      if (~except.indexOf(id)) continue;
-      socket = this.nsp.connected[id];
-      if (socket) socket.packet(packet);
-    }
-  }
+  });
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -129,16 +129,25 @@ Client.prototype.close = function(){
  * @api private
  */
 
-Client.prototype.packet = function(packet){
+Client.prototype.packet = function(packet, preEncoded){
+  var self = this;
+
+  // this writes to the actual connection
+  function writeToEngine(encodedPackets) {
+    for (var i = 0; i < encodedPackets.length; i++) {
+      self.conn.write(encodedPackets[i]);
+    }
+  }
+
   if ('open' == this.conn.readyState) {
     debug('writing packet %j', packet);
-    var self = this;
-
-    this.encoder.encode(packet, function (encodedPackets) { // encode, then write results to engine
-      for (var i = 0; i < encodedPackets.length; i++) {
-        self.conn.write(encodedPackets[i]);
-      }
-    });
+    if(!preEncoded) { // not broadcasting, need to encode
+      this.encoder.encode(packet, function (encodedPackets) { // encode, then write results to engine
+        writeToEngine(encodedPackets);
+      });
+    } else { // a broadcast pre-encodes a packet
+      writeToEngine(packet);
+    }
   } else {
     debug('ignoring packet write %j', packet);
   }

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -7,6 +7,7 @@ var Socket = require('./socket');
 var Emitter = require('events').EventEmitter;
 var parser = require('socket.io-parser');
 var debug = require('debug')('socket.io:namespace');
+var hasBin = require('has-binary-data');
 
 /**
  * Module exports.
@@ -193,7 +194,10 @@ Namespace.prototype.emit = function(ev){
   } else {
     // set up packet object
     var args = Array.prototype.slice.call(arguments);
-    var packet = { type: parser.EVENT, data: args };
+    var parserType = parser.EVENT; // default
+    if (hasBin(args)) { parserType = parser.BINARY_EVENT; } // binary
+
+    var packet = { type: parserType, data: args };
 
     if ('function' == typeof args[args.length - 1]) {
       throw new Error('Callbacks are not supported when broadcasting');

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -180,9 +180,9 @@ Socket.prototype.write = function(){
  * @api private
  */
 
-Socket.prototype.packet = function(packet){
+Socket.prototype.packet = function(packet, preEncoded){
   packet.nsp = this.nsp.name;
-  this.client.packet(packet);
+  this.client.packet(packet, preEncoded);
 };
 
 /**


### PR DESCRIPTION
Summary:
Added binary support to broadcasting by adding a binary check to namespace.js and pre-encoding events in adapter.js.

Question: 
I think the pre-encoding stuff in adapter (and the new parameter in client.js) is relatively clean, but it could possibly be better. I was thinking of checking if packet is an array (it is post-encoding) or an object (pre-encoding) rather than passing the "preEncoded" flag, but let me know what you think.

The commit message:
lib/namespace.js previously was not considering whether an event had
binary data and was giving all events parser.EVENT type -- now it uses
the has-binary-data module to set the event type appropriately.

Then, after this fix there was a problem with lib/adapter.js -- because
socket.io-parser modifies the packet object in its encoding, the sockets
after the 1st in a broadcast were not getting the correct data. To fix
this, the data is encoded once in adapter, and then the encoded data
is passed to each of the sockets.

lib/socket.js and lib/client.js were updated to allow for the above. The
.packet method of each now takes an optional second "preEncoded" parameter
-- if this is true, then client skips the encoding and just writes the
packet argument directly to engine.

test/socket.io.js was updated to add two new tests that test
multi-messaging of events with binary data.
