### PR TITLE
When radnomBytes is not available fallback to pseudoRandomBytes

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -729,16 +729,21 @@ Manager.prototype.generateId = function () {
     return Math.abs(Math.random() * Math.random() * Date.now() | 0).toString()
       + Math.abs(Math.random() * Math.random() * Date.now() | 0).toString();
   }
+  try {
+      crypto.randomBytes(12).copy(rand);
+  } catch(ex) {
+      self.log.error(ex);
+      self.log.warn('Falling back to pseudo random numbers.');
+      try {
+          crypto.pseudoRandomBytes(12).copy(rand);
+      } catch (ex) {
+          self.log.error(ex);
+          self.log.warn('Pseudo random number generator also failed. Generating random numbers should be fixed.');
+          self.log.warn('System in this state is at extremely high security risk.');
+      }
+  }
   this.sequenceNumber = (this.sequenceNumber + 1) | 0;
   rand.writeInt32BE(this.sequenceNumber, 11);
-  if (crypto.randomBytes) {
-    crypto.randomBytes(12).copy(rand);
-  } else {
-    // not secure for node 0.4
-    [0, 4, 8].forEach(function(i) {
-      rand.writeInt32BE(Math.random() * Math.pow(2, 32) | 0, i);
-    });
-  }
   return rand.toString('base64').replace(/\//g, '_').replace(/\+/g, '-');
 };
 


### PR DESCRIPTION
When using latest node and karma we are seeing the following error:

```
[Error: error:24064064:random number generator:SSLEAY_RAND_BYTES:PRNG not seeded]
```

As the error says, PRNG is not seeded. pseudoRandomNumers is ok. The problem is that entropySource, in v8, is seeded with sizeof(int64_t), which is 8 bytes (at least on macs). OpenSSL requires 32 bytes of randomness (http://git.openssl.org/gitweb/?p=openssl.git;a=blob;f=crypto/rand/rand_lcl.h;h=6696b8057bbe71d532d17bb12ca95afe07ae4f8d;hb=refs/heads/master#l115)

Also created an issue for nodejs here https://github.com/joyent/node/issues/7338
