### PR TITLE
Added backwards compatible settability of engine.io maxHttpBufferSize

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -101,7 +101,8 @@ Server.prototype.serveClient = function(v){
 var oldSettings = {
   "transports": "transports",
   "heartbeat timeout": "pingTimeout",
-  "heartbeat interval": "pingInterval"
+  "heartbeat interval": "pingInterval",
+  "destroy buffer size": "maxHttpBufferSize"
 };
 
 /**

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -45,6 +45,12 @@ describe('socket.io', function(){
       expect(srv.eio.transports).to.eql(['polling']);
     });
 
+    it('should be able to set maxHttpBufferSize to engine.io', function() {
+      var srv = io(http());
+      srv.set('destroy buffer size', 10);
+      expect(srv.eio.maxHttpBufferSize).to.eql(10);
+    });
+
     it('should be able to set path with setting resource', function() {
       var srv = io(http());
       srv.set('resource', '/random');


### PR DESCRIPTION
Works if https://github.com/LearnBoost/engine.io/pull/238 is merged and engine.io version is bumped.
