### PR TITLE
Update for new npm check

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "socket",
     "io"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/LearnBoost/socket.io"
+  },
   "scripts": {
     "test": "make test"
   },


### PR DESCRIPTION
Npm will now throw a warning:

npm WARN package.json socket.io@1.0.0-pre2 No repository field.

If the repository field is not present.
