### PR TITLE
Fix issue with longstanding connections

### DIFF
--- a/lib/transports/websocket/default.js
+++ b/lib/transports/websocket/default.js
@@ -343,6 +343,7 @@ Parser.prototype.parse = function () {
       this.emit('close');
       this.buffer = '';
       this.i = 0;
+      this._dataLength = 0;
       return;
     }
 
@@ -357,6 +358,7 @@ Parser.prototype.parse = function () {
       this.emit('data', this.buffer.substr(1, i - 1));
       this.buffer = this.buffer.substr(i + 1);
       this.i = 0;
+      this._dataLength = this.buffer.length;
       return this.parse();
     }
   }
@@ -371,6 +373,7 @@ Parser.prototype.parse = function () {
 Parser.prototype.error = function (reason) {
   this.buffer = '';
   this.i = 0;
+  this._dataLength = 0;
   this.emit('error', reason);
   return this;
 };

--- a/lib/transports/websocket/hybi-07-12.js
+++ b/lib/transports/websocket/hybi-07-12.js
@@ -570,7 +570,8 @@ Parser.prototype.endPacket = function() {
   this.state.lastFragment = false;
   this.state.opcode = this.state.activeFragmentedOperation != null ? this.state.activeFragmentedOperation : 0;
   this.state.masked = false;
-  this.expect('Opcode', 2, this.processPacket);  
+  this.expect('Opcode', 2, this.processPacket);
+  this._dataLength = 0;
 }
 
 /**

--- a/lib/transports/websocket/hybi-16.js
+++ b/lib/transports/websocket/hybi-16.js
@@ -570,7 +570,8 @@ Parser.prototype.endPacket = function() {
   this.state.lastFragment = false;
   this.state.opcode = this.state.activeFragmentedOperation != null ? this.state.activeFragmentedOperation : 0;
   this.state.masked = false;
-  this.expect('Opcode', 2, this.processPacket);  
+  this.expect('Opcode', 2, this.processPacket);
+  this._dataLength = 0;
 }
 
 /**


### PR DESCRIPTION
Pull request https://github.com/LearnBoost/socket.io/pull/1346 introduced an issue with long connections, because the `_dataLength` variable in the parser was never reset to 0.

Fix this issue by reseting the variable when the parser gets an error, closes or reaches the end of a packet.
