### PR TITLE
Added socket.handshake BC object

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -5,6 +5,7 @@
 
 var Emitter = require('events').EventEmitter;
 var parser = require('socket.io-parser');
+var url = require('url');
 var debug = require('debug')('socket.io:socket');
 var hasBin = require('has-binary-data');
 
@@ -65,6 +66,7 @@ function Socket(nsp, client){
   this.acks = {};
   this.connected = true;
   this.disconnected = false;
+  this.handshake = this.buildHandshake();
 }
 
 /**
@@ -94,6 +96,25 @@ flags.forEach(function(flag){
 Socket.prototype.__defineGetter__('request', function(){
   return this.conn.request;
 });
+
+/**
+ * Builds the `handshake` BC object
+ *
+ * @api private
+ */
+
+Socket.prototype.buildHandshake = function(){
+  return {
+    headers: this.request.headers,
+    time: (new Date) + '',
+    address: this.request.connection.address(),
+    xdomain: !!this.request.headers.origin,
+    secure: !!this.request.connection.encrypted,
+    issued: +(new Date),
+    url: this.request.url,
+    query: url.parse(this.request.url, true).query || {}
+  };
+};
 
 /**
  * Emits to this client.

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -99,6 +99,40 @@ describe('socket.io', function(){
         expect().fail();
       });
     });
+
+    it('should set the handshake BC object', function(done){
+      var httpSrv = http();
+      var srv = io(httpSrv);
+
+      srv.on('connection', function(s) {
+        expect(s.handshake).to.not.be(undefined);
+
+        // Headers set and has some valid properties
+        expect(s.handshake.headers).to.be.an('object');
+        expect(s.handshake.headers['user-agent']).to.be('node-XMLHttpRequest');
+
+        // Time set and is valid looking string
+        expect(s.handshake.time).to.be.a('string');
+        expect(s.handshake.time.split(' ').length > 0); // Is "multipart" string representation
+
+        // Address, xdomain, secure, issued and url set
+        expect(s.handshake.address).to.not.be(undefined);
+        expect(s.handshake.xdomain).to.be.a('boolean');
+        expect(s.handshake.secure).to.be.a('boolean');
+        expect(s.handshake.issued).to.be.a('number');
+        expect(s.handshake.url).to.be.a('string');
+
+        // Query set and has some right properties
+        expect(s.handshake.query).to.be.an('object');
+        expect(s.handshake.query.EIO).to.not.be(undefined);
+        expect(s.handshake.query.transport).to.not.be(undefined);
+        expect(s.handshake.query.t).to.not.be(undefined);
+
+        done();
+      });
+
+      var socket = client(httpSrv);
+    });
   });
 
   describe('server attachment', function(){


### PR DESCRIPTION
This PR has sketch of the backwards compatibility for `socket.handshake`.

For some reason `req.connection.address()` returns null. I'm assuming that it's visible if we do it in the actual handshake logic in Engine.IO, so we might want to consider moving the call there, and setting the property on the Engine.IO socket.

Another thing we might want to consider is moving the `time` and `issued` properties to be set in Engine.IO exactly when handshaking.

@guille thoughts?
