### PR TITLE
Adding custom error message to handshake error

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -781,7 +781,7 @@ Manager.prototype.handleHandshake = function (data, req, res) {
   };
 
   function error (err) {
-    writeErr(500, 'handshake error');
+    writeErr(500, 'handshake error ' + err);
     self.log.warn('handshake error ' + err);
   };
 


### PR DESCRIPTION
The handshake error message is too generic and we can't pass more information if we want to display a more detailed error message on clients. 

Right now the log.warn is displaying enough detail in the server console. However clients can't access it. 

With this fix we can now send detailed error messages using callback("Session Invalid",false) resulting in "handshake error Session Invalid" on the client.

Fix for the following issues:
https://github.com/LearnBoost/socket.io/issues/545
https://github.com/LearnBoost/socket.io/issues/331
