### PR TITLE
Make chat example wrap long words (no overflow)

### DIFF
--- a/examples/chat/public/style.css
+++ b/examples/chat/public/style.css
@@ -25,6 +25,7 @@ html, body {
 
 ul {
   list-style: none;
+  word-wrap: break-word;
 }
 
 /* Pages */


### PR DESCRIPTION
Disables horizontal scroll. 

Bug example:

![hscroll](https://cloud.githubusercontent.com/assets/744973/3110685/28cf2ece-e6a8-11e3-9f0e-dd57e7a4a1c8.gif)
