### PR TITLE
Fix namespace iterator in disconnect

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -199,9 +199,10 @@ Client.prototype.onclose = function(reason){
   this.destroy();
 
   // `nsps` and `sockets` are cleaned up seamlessly
-  this.sockets.forEach(function(socket){
+  var socket;
+  while (socket = this.sockets.shift()) {
     socket.onclose(reason);
-  });
+  }
 
   this.decoder.destroy(); // clean up decoder
 };

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -395,6 +395,33 @@ describe('socket.io', function(){
           }
         });
       });
+
+      it('should disconnect both default and custom namespace upon disconnect', function(done){
+        var srv = http();
+        var sio = io(srv);
+        srv.listen(function(){
+          var lolcats = client(srv, '/lolcats');
+          var total = 2;
+          var totald = 2;
+          var s;
+          sio.of('/', function(socket){
+            socket.on('disconnect', function(reason){
+              --totald || done();
+            });
+            --total || close();
+          });
+          sio.of('/lolcats', function(socket){
+            s = socket;
+            socket.on('disconnect', function(reason){
+              --totald || done();
+            });
+            --total || close();
+          });
+          function close(){
+            s.disconnect(true);
+          }
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Since `socket.onclose` is going to remove things from `this.sockets` while iterating, let's make the iteration tolerant of these modifications.

Addresses https://github.com/Automattic/socket.io/issues/1539.
