### PR TITLE
disconnect all sockets on transport close

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -199,9 +199,9 @@ Client.prototype.onclose = function(reason){
   this.destroy();
 
   // `nsps` and `sockets` are cleaned up seamlessly
-  this.sockets.forEach(function(socket){
-    socket.onclose(reason);
-  });
+  for (var i = this.sockets.length - 1; i >= 0; i--) {
+      this.sockets[i].onclose(reason);
+  }
 
   this.decoder.destroy(); // clean up decoder
 };


### PR DESCRIPTION
This should fix #1580.

When transport is closed, this piece of code tries to disconnect all sockets

https://github.com/Automattic/socket.io/blob/master/lib/client.js#L203

It loops over all sockets (spread across different namespaces) and removes them. That would be great, but when it calls `onclose` for the root namespace, it gets to this line:

https://github.com/Automattic/socket.io/blob/master/lib/socket.js#L393
followed by
https://github.com/Automattic/socket.io/blob/master/lib/client.js#L101

That means socket gets removed from the `Client.sockets` array that is being looped over and next iteration of loop never happens, because array got shorter suddenly.

I have reverted order so it removes all of them correctly and it also looks much better, because it's disconnected from the latest socket instead from the beginning.
