### PR TITLE
Update index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -159,7 +159,9 @@ Server.prototype.adapter = function(v){
   if (!arguments.length) return this._adapter;
   this._adapter = v;
   for (var i in this.nsps) {
-    this.nsps[i].initAdapter();
+    if (this.nsps[i].hasOwnProperty(i)) {
+      this.nsps[i].initAdapter();
+    }
   }
   return this;
 };


### PR DESCRIPTION
Added missing hasOwnProperty check. socket.io breaks without it when Object.prototype has been extended.
