### PR TITLE
Add removeListener to blacklisted events

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -25,7 +25,8 @@ exports.events = [
   'error',
   'connect',
   'disconnect',
-  'newListener'
+  'newListener',
+  'removeListener'
 ];
 
 /**


### PR DESCRIPTION
`newListener` is already supported, so `removeListener` also should be, IMO.
