### PR TITLE
Override default browser font-family for inputs

### DIFF
--- a/examples/chat/public/style.css
+++ b/examples/chat/public/style.css
@@ -5,6 +5,11 @@
 }
 
 html {
+  font-weight: 300;
+  -webkit-font-smoothing: antialiased;
+}
+
+html, input {
   font-family:
     "HelveticaNeue-Light",
     "Helvetica Neue Light",
@@ -13,8 +18,6 @@ html {
     Arial,
     "Lucida Grande",
     sans-serif;
-  font-weight: 300;
-  -webkit-font-smoothing: antialiased;
 }
 
 html, body {


### PR DESCRIPTION
For consistent typography, explicitly declare font-family stack for `input` in addition to `html` (in Chrome and Safari on mac, the input will otherwise use default font for such elements, like Lucida Grande)
