### PR TITLE
fix: We should use the standard http protocol to handler the etag header.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -265,8 +265,9 @@ Server.prototype.attachServe = function(srv){
  */
 
 Server.prototype.serve = function(req, res){
-  if (req.headers.etag) {
-    if (clientVersion == req.headers.etag) {
+  etag = req.headers['if-none-match'];
+  if (etag) {
+    if (clientVersion == etag) {
       debug('serve client 304');
       res.writeHead(304);
       res.end();


### PR DESCRIPTION
We should use the standard http protocol to handler the etag header. The 'headers.etag' in newer versions of express.js will not work anymore. Besides, people should not have to depend on express.js to use socket.io.
