### PR TITLE
We should use the standard http protocol to handler the etag header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -265,8 +265,9 @@ Server.prototype.attachServe = function(srv){
  */
 
 Server.prototype.serve = function(req, res){
-  if (req.headers.etag) {
-    if (clientVersion == req.headers.etag) {
+  var etag = req.headers['if-none-match'];
+  if (etag) {
+    if (clientVersion == etag) {
       debug('serve client 304');
       res.writeHead(304);
       res.end();

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -161,7 +161,7 @@ describe('socket.io', function(){
         io(srv);
         request(srv)
         .get('/socket.io/socket.io.js')
-        .set('ETag', clientVersion)
+        .set('If-None-Match', clientVersion)
         .end(function(err, res){
           if (err) return done(err);
           expect(res.statusCode).to.be(304);


### PR DESCRIPTION
We should use the standard http protocol to handler the etag header. The client request header should be `If-None-Match`, not `Etag`.
