### PR TITLE
Fixed the failing test where server crashes on disconnect involving connectBuffer

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -68,9 +68,9 @@ Client.prototype.connect = function(name){
     self.sockets.push(socket);
     self.nsps[nsp.name] = socket;
 
-    if ('/' == nsp.name && self.connectBuffer) {
+    if ('/' == nsp.name && self.connectBuffer.length > 0) {
       self.connectBuffer.forEach(self.connect, self);
-      delete self.connectBuffer;
+      self.connectBuffer = [];
     }
   });
 };


### PR DESCRIPTION
Source of bug: after connection to nsp '/', the socket's connectBuffer
was being deleted. On attempt to reconnect, we attempted to push to a deleted array.
Instead of the deleting the connect buffer, it is now emptied.
