### PR TITLE
client cannot connect to non-existing namespaces

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -57,6 +57,10 @@ Client.prototype.setup = function(){
 
 Client.prototype.connect = function(name){
   debug('connecting to namespace %s', name);
+  if (!this.server.nsps[name]) {
+    this.packet({ type: parser.ERROR, nsp: name, data : 'Invalid namespace'});
+    return;
+  }
   var nsp = this.server.of(name);
   if ('/' != name && !this.nsps['/']) {
     this.connectBuffer.push(name);

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -377,6 +377,8 @@ describe('socket.io', function(){
       var srv = http();
       var sio = io(srv);
       srv.listen(function(){
+        sio.of('/chat');
+        sio.of('/news');
         var chat = client(srv, '/chat');
         var news = client(srv, '/news');
         var total = 2;
@@ -487,6 +489,18 @@ describe('socket.io', function(){
         var socket = client(srv,'/ns');
         sio.on('connection', function(socket){
           socket.disconnect();
+          done();
+        });
+      });
+    });
+
+    it('should return error connecting to non-existent namespace', function(done){
+      var srv = http();
+      var sio = io(srv);
+      srv.listen(function(){
+        var socket = client(srv,'/doesnotexist');
+        socket.on('error', function(err) {
+          expect(err).to.be('Invalid namespace');
           done();
         });
       });


### PR DESCRIPTION
Namespaces should be allocated only by the server using `of`

``` js
sio.of('<namespace>').on(...)
```

A client cannot connect to a namespace not allocated by the server.

Please check it @guille

Thanks @smaffer
#1681
