### PR TITLE
Fix resource option BC with the set function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -216,7 +216,7 @@ Server.prototype.attach = function(srv, opts){
 
   // set engine.io path to `/socket.io`
   opts = opts || {};
-  opts.path = opts.path || '/socket.io';
+  opts.path = opts.path || this.path();
   // set origins verification
   opts.allowRequest = this.checkRequest.bind(this);
 

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -51,10 +51,21 @@ describe('socket.io', function(){
       expect(srv.eio.maxHttpBufferSize).to.eql(10);
     });
 
-    it('should be able to set path with setting resource', function() {
-      var srv = io(http());
-      srv.set('resource', '/random');
-      expect(srv.path()).to.be('/random');
+    it('should be able to set path with setting resource', function(done) {
+      var eio = io();
+      var srv = http();
+
+      eio.set('resource', '/random');
+      eio.attach(srv);
+
+      // Check that the server is accessible through the specified path
+      request(srv)
+      .get('/random/socket.io.js')
+      .buffer(true)
+      .end(function(err, res){
+        if (err) return done(err);
+        done();
+      });
     });
 
     it('should be able to set origins to engine.io', function() {


### PR DESCRIPTION
A `resource` value set through the `set` function is now taken into account (and any `path` value set in the constructor) if no path option is specified in the `attach` function itself. 

Updated the resource test to actually check we can reach the underlying Engine.IO server with the set path.
