### PR TITLE
Fix splice arguments and `socket.rooms` value update in `socket.leaveAll`

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -242,7 +242,7 @@ Socket.prototype.leave = function(room, fn){
   this.adapter.del(this.id, room, function(err){
     if (err) return fn && fn(err);
     debug('left room %s', room);
-    self.rooms.splice(self.rooms.indexOf(room, 1));
+    self.rooms.splice(self.rooms.indexOf(room), 1);
     fn && fn(null);
   });
   return this;
@@ -256,6 +256,7 @@ Socket.prototype.leave = function(room, fn){
 
 Socket.prototype.leaveAll = function(){
   this.adapter.delAll(this.id);
+  this.rooms = [];
 };
 
 /**

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -1240,9 +1240,14 @@ describe('socket.io', function(){
             expect(s.rooms).to.eql([s.id, 'a']);
             s.join('b', function(){
               expect(s.rooms).to.eql([s.id, 'a', 'b']);
-              s.leave('b', function(){
-                expect(s.rooms).to.eql([s.id, 'a']);
-                done();
+              s.join( 'c', function(){
+                expect(s.rooms).to.eql([s.id, 'a', 'b', 'c']);
+                s.leave('b', function(){
+                  expect(s.rooms).to.eql([s.id, 'a', 'c']);
+                  s.leaveAll();
+                  expect(s.rooms).to.eql([]);
+                  done();
+                });
               });
             });
           });


### PR DESCRIPTION
Made the room management test slightly more complicated to spot the error with splice, fixed it (props @Marreck) and did the same with `socket.leaveAll` not updating the rooms array.

Addressing #1697
