### PR TITLE
Take "" and "/" as equivalent namespaces on server

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -324,7 +324,7 @@ Server.prototype.onconnection = function(conn){
  */
 
 Server.prototype.of = function(name, fn){
-  if (!(String(name)[0] === '/')) name = '/' + name;
+  if (String(name)[0] !== '/') name = '/' + name;
   
   if (!this.nsps[name]) {
     debug('initializing namespace %s', name);

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -391,31 +391,27 @@ describe('socket.io', function(){
       });
     });
 
-    it('should be equivalent for "" and "/" on server', function(done){
+    it('should be able to equivalently start with "" or "/" on server', function(done){
       var srv = http();
       var sio = io(srv);
       var total = 2;
       sio.of('').on('connection', function(){
         --total || done();
       });
-      sio.of('/').on('connection', function(){
+      sio.of('abc').on('connection', function(){
         --total || done();
       });
-      var cio = client(srv);
+      var c1 = client(srv, '/');
+      var c2 = client(srv, '/abc');
     });
     
     it('should be equivalent for "" and "/" on client', function(done){
       var srv = http();
       var sio = io(srv);
+      sio.of('/').on('connection', function(){
+          done();
+      });
       var c1 = client(srv, '');
-      var c2 = client(srv, '/');
-      var total = 2;
-      c1.on('connect', function(){
-          --total || done();
-      });
-      c2.on('connect', function(){
-          --total || done();
-      });
     });
     
     it('should work with `of` and many sockets', function(done){


### PR DESCRIPTION
On server, `.of(name)` should use the same key in `.nsps` object for "" and "/"

Important to use `String(name)` and `===` to keep out keys that don't cast to ""
