### PR TITLE
package: fix main file for example application 'chat'.

### DIFF
--- a/examples/chat/package.json
+++ b/examples/chat/package.json
@@ -2,7 +2,7 @@
   "name": "socket.io-chat",
   "version": "0.0.0",
   "description": "A simple chat client using socket.io",
-  "main": "app.js",
+  "main": "index.js",
   "author": "Grant Timmerman",
   "private": true,
   "license": "BSD",


### PR DESCRIPTION
The example application's main file is marked in its 'package.json' as being 'app.js'.  There is no 'app.js'.  So I've fixed the main file property to be 'index.js'.
