### PR TITLE
Enable providing custom CORS handler

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -219,7 +219,7 @@ Server.prototype.attach = function(srv, opts){
   opts = opts || {};
   opts.path = opts.path || this.path();
   // set origins verification
-  opts.allowRequest = this.checkRequest.bind(this);
+  opts.allowRequest = opts.allowRequest || this.checkRequest.bind(this);
 
   // initialize engine
   debug('creating engine.io instance with opts %j', opts);


### PR DESCRIPTION
Open up the option to provide a custom handler to check cross origin handling. This is needed (for example) for situations where CORS needs to be verified dynamically against allowed origins in a database
