### PR TITLE
Add Server#addListener and Server#removeListener

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -329,7 +329,7 @@ Server.prototype.onconnection = function(conn){
 
 Server.prototype.of = function(name, fn){
   if (String(name)[0] !== '/') name = '/' + name;
-  
+
   if (!this.nsps[name]) {
     debug('initializing namespace %s', name);
     var nsp = new Namespace(this, name);
@@ -361,7 +361,7 @@ Server.prototype.close = function(){
  * Expose main namespace (/).
  */
 
-['on', 'to', 'in', 'use', 'emit', 'send', 'write'].forEach(function(fn){
+['on', 'to', 'in', 'use', 'emit', 'send', 'write', 'addListener', 'removeListener'].forEach(function(fn){
   Server.prototype[fn] = function(){
     var nsp = this.sockets[fn];
     return nsp.apply(this.sockets, arguments);


### PR DESCRIPTION
Now we can remove a previously attached main namespace listener directly, eg. removing a `connection` event handler.
