### PR TITLE
added domain access rule for origins with *.example.com format

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,6 +73,8 @@ Server.prototype.checkRequest = function(req, fn) {
       parts.port = parts.port != null
         ? parts.port
         : defaultPort;
+      //strip subdomain e.g. *.example.com -> example.com
+      parts.hostname = parts.hostname.match(/[^\.]*\.[^.]*$/)[0];
       var ok =
         ~this._origins.indexOf(parts.hostname + ':' + parts.port) ||
         ~this._origins.indexOf(parts.hostname + ':*') ||

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -260,6 +260,17 @@ describe('socket.io', function(){
        });
     });
 
+    it('should allow request when origin defined with a subdomain format *.example.com', function(done) {
+      var sockets = io({ origins: 'http://foo.example:*' }).listen('54022');
+      request.get('http://localhost:54022/socket.io/default/')
+       .query({ transport: 'polling' })
+       .set('origin', 'http://herp.derp.foo.example')
+       .end(function (err, res) {
+          expect(res.status).to.be(200);
+          done();
+       });
+    });
+
     it('should allow request when origin defined an the same is specified', function(done) {
       var sockets = io({ origins: 'http://foo.example:*' }).listen('54015');
       request.get('http://localhost:54015/socket.io/default/')


### PR DESCRIPTION
includes failing test, checks for subdomains using regex one-liner
supports multiple subdomains e.g. herp.derp.example.com or just herp.example.com
both will return "example.com" as expected
