### PR TITLE
Fixed test semantics, though tests seem to be failing now.

### DIFF
--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -467,20 +467,21 @@ describe('socket.io', function(){
       sio.of('').on('connection', function(){
         --total || done();
       });
-      sio.of('abc').on('connection', function(){
+      sio.of('/').on('connection', function(){
         --total || done();
       });
       var c1 = client(srv, '/');
-      var c2 = client(srv, '/abc');
     });
 
     it('should be equivalent for "" and "/" on client', function(done){
       var srv = http();
       var sio = io(srv);
+      var total = 2;
       sio.of('/').on('connection', function(){
-          done();
+          --total || done();
       });
       var c1 = client(srv, '');
+      var c2 = client(srv, '/');
     });
 
     it('should work with `of` and many sockets', function(done){
@@ -490,7 +491,7 @@ describe('socket.io', function(){
         var chat = client(srv, '/chat');
         var news = client(srv, '/news');
         var total = 2;
-        sio.of('/news').on('connection', function(socket){
+        sio.of('/chat').on('connection', function(socket){
           expect(socket).to.be.a(Socket);
           --total || done();
         });
@@ -508,7 +509,7 @@ describe('socket.io', function(){
         var chat = client(srv, '/chat');
         var news = client(srv, '/news');
         var total = 2;
-        sio.of('/news', function(socket){
+        sio.of('/chat', function(socket){
           expect(socket).to.be.a(Socket);
           --total || done();
         });


### PR DESCRIPTION
A couple tests seemed to be testing different semantics than what they described, so I updated them. However, upon updating the test `should be equivalent for "" and "/" on client`, the tests appear to be broken. I may be misunderstanding the wording of the unit tests, but it seems that the tests shouldn't fail here if the functionality as described is working.
