### PR TITLE
Suggestion for intercom API

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -292,6 +292,26 @@ server.listen(3000);
   Errors passed to middleware callbacks are sent as special `error`
   packets to clients.
 
+### Namespace#intercom(name:String[, …]):Namespace
+
+  Emits an event to server sockets socket identified by the string `name`. Any
+  other parameters can be included.
+
+  All datastructures are supported, including `Buffer`. JavaScript
+  functions can't be serialized/deserialized.
+
+  ```js
+  var io = require('socket.io')();
+  io.intercom('an event', { some: 'data' });
+  ```
+
+  Intercom also supports `of` and `in`, just like `broadcast`.
+
+  ```js
+  var io = require('socket.io')();
+  io.of('/namespace').in('room').intercom('an event', { some: 'data' });
+  ```
+
 ### Socket
 
   A `Socket` is the fundamental class for interacting with browser
@@ -372,6 +392,15 @@ server.listen(3000);
   var io = require('socket.io')();
   io.on('connection', function(socket){
     socket.to('others').emit('an event', { some: 'data' });
+  });
+  ```
+
+  Intercom (server to server broadcasting) works the same.
+
+  ```js
+  var io = require('socket.io')();
+  io.on('connection', function(socket){
+    socket.to('others').intercom.emit('an event', { some: 'data' });
   });
   ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -329,7 +329,7 @@ Server.prototype.onconnection = function(conn){
 
 Server.prototype.of = function(name, fn){
   if (String(name)[0] !== '/') name = '/' + name;
-  
+
   if (!this.nsps[name]) {
     debug('initializing namespace %s', name);
     var nsp = new Namespace(this, name);
@@ -361,7 +361,7 @@ Server.prototype.close = function(){
  * Expose main namespace (/).
  */
 
-['on', 'to', 'in', 'use', 'emit', 'send', 'write', 'clients'].forEach(function(fn){
+['on', 'to', 'in', 'use', 'emit', 'send', 'write', 'clients', 'intercom'].forEach(function(fn){
   Server.prototype[fn] = function(){
     var nsp = this.sockets[fn];
     return nsp.apply(this.sockets, arguments);

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -227,6 +227,32 @@ Namespace.prototype.emit = function(ev){
 };
 
 /**
+ * Emits to all server sockets.
+ *
+ * @return {Namespace} self
+ * @api public
+ */
+
+Namespace.prototype.intercom = function(){
+  var args = Array.prototype.slice.call(arguments);
+
+  if ('function' == typeof args[args.length - 1]) {
+    throw new Error('Callbacks are not supported when broadcasting');
+  }
+
+  this.adapter.intercom(args, {
+    rooms: this.rooms
+  });
+
+  delete this.rooms;
+
+  // we don't use flags, but delete them for consistency
+  delete this.flags;
+
+  return this;
+};
+
+/**
  * Sends a `message` event to all clients.
  *
  * @return {Namespace} self

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -38,7 +38,8 @@ exports.events = [
 var flags = [
   'json',
   'volatile',
-  'broadcast'
+  'broadcast',
+  'intercom'
 ];
 
 /**
@@ -144,12 +145,20 @@ Socket.prototype.emit = function(ev){
       packet.id = this.nsp.ids++;
     }
 
-    if (this._rooms || (this.flags && this.flags.broadcast)) {
-      this.adapter.broadcast(packet, {
-        except: [this.id],
-        rooms: this._rooms,
-        flags: this.flags
-      });
+    if (this._rooms || (this.flags && (this.flags.broadcast || this.flags.intercom))) {
+      if (this.flags.broadcast) {
+        this.adapter.broadcast(packet, {
+          except: [this.id],
+          rooms: this._rooms,
+          flags: this.flags
+        });
+      }
+      if (this.flags.intercom) {
+        this.adapter.intercom(args, {
+          except: [this.id],
+          rooms: this._rooms
+        });
+      }
     } else {
       // dispatch packet
       this.packet(packet);

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -597,7 +597,7 @@ describe('socket.io', function(){
         });
       });
     });
-    
+
     it('should not reuse same-namespace connections', function(done){
       var srv = http();
       var sio = io(srv);
@@ -1574,6 +1574,34 @@ describe('socket.io', function(){
       });
     });
 
+    it('intercoms to a namespace', function(done){
+      var srv = http();
+      var sio = io(srv);
+      var total = 2;
+
+      srv.listen(function(){
+        var socket1 = client(srv, { multiplex: false });
+        var socket2 = client(srv, { multiplex: false });
+        var socket3 = client(srv, '/test');
+
+        var sockets = 3;
+        sio.on('connection', function(socket){
+          socket.on('a', function(a){
+            expect(a).to.be('b');
+            --total || done();
+          });
+          --sockets || intercom();
+        });
+        sio.of('/test', function(socket){
+          socket.on('a', function(){ done(new Error('not')); });
+          --sockets || intercom();
+        });
+        function intercom(){
+          sio.intercom('a', 'b');
+        }
+      });
+    });
+
     it('emits to the rest', function(done){
       var srv = http();
       var sio = io(srv);
@@ -1600,6 +1628,47 @@ describe('socket.io', function(){
             done();
           });
         });
+      });
+    });
+
+    it('intercoms to the rest', function(done){
+      var srv = http();
+      var sio = io(srv);
+      var total = 2;
+
+      srv.listen(function(){
+        var socket1 = client(srv, { multiplex: false });
+        var socket2 = client(srv, { multiplex: false });
+        var socket3 = client(srv, '/test');
+        socket1.emit('other');
+        socket2.emit('self');
+        socket3.emit('namespace');
+
+        var sockets = 3;
+        var intercomSocket = null;
+        sio.on('connection', function(socket){
+          socket.on('other', function(){
+            socket.on('a', function(a){
+              expect(a).to.be('b');
+              setTimeout(done, 10);
+            });
+            --sockets || intercom()
+          });
+          socket.on('self', function(){
+            socket.on('a', function(){ done(new Error('wrong socket')); });
+            intercomSocket = socket;
+            --sockets || intercom()
+          });
+        });
+        sio.of('/test', function(socket){
+          socket.on('namespace', function(){
+            socket.on('a', function(){ done(new Error('wrong namespace')); });
+            --sockets || intercom()
+          });
+        });
+        function intercom(){
+          intercomSocket.intercom.emit('a', 'b');
+        }
       });
     });
 
@@ -1672,6 +1741,49 @@ describe('socket.io', function(){
       });
     });
 
+    it('intercoms to rooms avoiding dupes', function(done){
+      var srv = http();
+      var sio = io(srv);
+      var total = 2;
+      var sockets = total;
+
+      srv.listen(function(){
+        var socket1 = client(srv, { multiplex: false });
+        var socket2 = client(srv, { multiplex: false });
+
+        socket1.emit('first');
+        socket2.emit('second');
+
+        sio.on('connection', function(socket){
+          socket.on('first', function(){
+            socket.join('woot', function(){
+              socket.join('test', function(){
+                socket.on('a', function(){
+                  --total || done();
+                });
+                --sockets || intercom();
+              });
+            });
+          });
+          socket.on('second', function(){
+            socket.join('third', function(){
+              socket.on('a', function(){
+                done(new Error('not'));
+              });
+              socket.on('b', function(){
+                --total || done();
+              });
+              --sockets || intercom();
+            });
+          });
+          function intercom(){
+            sio.in('woot').in('test').intercom('a');
+            sio.in('third').intercom('b');
+          }
+        });
+      });
+    });
+
     it('broadcasts to rooms', function(done){
       var srv = http();
       var sio = io(srv);
@@ -1711,6 +1823,55 @@ describe('socket.io', function(){
             socket.emit('b');
           });
         });
+      });
+    });
+
+    it('intercoms to rooms', function(done){
+      var srv = http();
+      var sio = io(srv);
+      var total = 1;
+      var sockets = 3;
+
+      srv.listen(function(){
+        var socket1 = client(srv, { multiplex: false });
+        var socket2 = client(srv, { multiplex: false });
+        var socket3 = client(srv, { multiplex: false });
+
+        socket1.emit('first');
+        socket2.emit('second');
+        socket3.emit('third');
+
+        var intercomSocket = null;
+        sio.on('connection', function(socket){
+          socket.on('first', function(){
+            socket.join('woot', function(){
+              socket.on('a', function(){
+                done(new Error('wrong room'));
+              });
+              --sockets || intercom();
+            });
+          });
+          socket.on('second', function(){
+            socket.join('test', function(){
+              socket.on('a', function(){
+                --total || done();
+              });
+              --sockets || intercom();
+            });
+          });
+          socket.on('third', function(){
+            socket.join('test', function(){
+              socket.on('a', function(){
+                done(new Error('wrong socket'));
+              });
+              intercomSocket = socket;
+              --sockets || intercom();
+            });
+          });
+        });
+        function intercom(){
+          intercomSocket.intercom.to('test').emit('a');
+        };
       });
     });
 


### PR DESCRIPTION
I've found that it would be very useful for synchronization purposes to be able to send messages to server-side sockets in namespaces/rooms directly without transiting to/from the client.

My proposal for this functionality is a new method `intercom` which functions essentially identically to the `broadcast` API, except that it broadcasts to server-side sockets instead of client-side sockets.

`intercom` is implemented as both a `Namespace` instance method as well as a flag for sockets. This allows syntax like:

`io.of('/namespace').in('room').intercom('event', data);`

as well as

`socket.intercom.emit('event', data);`

the latter following the same semantics as its broadcast equivalent -- namely, the origin socket is skipped in the emission.
