### PR TITLE
Reset rooms array after each clients() call

### DIFF
--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -250,5 +250,6 @@ Namespace.prototype.write = function(){
 
 Namespace.prototype.clients = function(fn){
   this.adapter.clients(this.rooms, fn);
+  delete this.rooms;
   return this;
 };


### PR DESCRIPTION
If you call clients() multiple times with different rooms you end up with clients from all the rooms specified in previous calls.