### PR TITLE
Fix spelling error in chat demo

### DIFF
--- a/examples/chat/public/main.js
+++ b/examples/chat/public/main.js
@@ -7,7 +7,7 @@ $(function() {
     '#3b88eb', '#3824aa', '#a700ff', '#d300e7'
   ];
 
-  // Initialize varibles
+  // Initialize variables
   var $window = $(window);
   var $usernameInput = $('.usernameInput'); // Input for username
   var $messages = $('.messages'); // Messages area


### PR DESCRIPTION
The word 'varibles' should be 'variables' in the comment describing their initialization.