### PR TITLE
Add docs badge to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,7 @@
 # socket.io
 
 [![Build Status](https://secure.travis-ci.org/Automattic/socket.io.svg)](http://travis-ci.org/Automattic/socket.io)
+[![Inline docs](http://inch-ci.org/github/Automattic/socket.io.svg?branch=master)](http://inch-ci.org/github/Automattic/socket.io)
 ![NPM version](https://badge.fury.io/js/socket.io.svg)
 ![Downloads](http://img.shields.io/npm/dm/socket.io.svg?style=flat)
 


### PR DESCRIPTION
Hi there,

I want to propose to add this badge to the README to show off inline-documentation: [![Inline docs](http://inch-ci.org/github/Automattic/socket.io.svg)](http://inch-ci.org/github/Automattic/socket.io)

The badge links to [Inch CI](http://inch-ci.org) and shows an evaluation by [InchJS](http://trivelop.de/inchjs), a project that tries to raise the visibility of inline-docs (early adopters include [forever](https://github.com/foreverjs/forever), [node-sass](https://github.com/sass/node-sass) and [when](https://github.com/cujojs/when)).

The idea is to motivate aspiring Node developers to dive into Open Source projects and read the code.
It's about _engagement_, because, while testing and code coverage are important, inline-docs are the humanly engaging factor in Open Source. This project is about making people less adverse to jumping into the code and see whats happening, because they are not left alone while doing so. I know that, because I put off reading other people's code way too long in my life.

Although this is "only" a passion project, I really would like to hear your thoughts, critique and suggestions. Your status page is http://inch-ci.org/github/Automattic/socket.io

What do you think?
