### PR TITLE
Add helper function Server.has(namespaceId) to check for existance of namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ lib-cov
 benchmarks/*.png
 node_modules
 coverage
+.idea

--- a/Readme.md
+++ b/Readme.md
@@ -192,7 +192,7 @@ server.listen(3000);
   ```js
   var io = require('socket.io')();
   var namespaceId = '/mynamespace123';
-  if io.has(namespaceId) {
+  if (io.has(namespaceId)) {
     debug('namespace ' + namespaceId + ' exists!';
   } else {
     debug('namespace ' + namespaceId + ' does not exist!';

--- a/Readme.md
+++ b/Readme.md
@@ -182,6 +182,23 @@ server.listen(3000);
 
   If the namespace was already initialized it returns it right away.
 
+### Server#has(nsp:String):Namespace
+
+  Checks for the existance of the given `Namespace` by its pathname
+  identifier `nsp`.
+
+  If the namespace exists, it is returned.
+
+  ```js
+  var io = require('socket.io')();
+  var namespaceId = '/mynamespace123';
+  if io.has(namespaceId) {
+    debug('namespace ' + namespaceId + ' exists!';
+  } else {
+    debug('namespace ' + namespaceId + ' does not exist!';
+  }
+  ```
+
 ### Server#emit
 
   Emits an event to all connected clients. The following two are

--- a/lib/index.js
+++ b/lib/index.js
@@ -340,6 +340,17 @@ Server.prototype.of = function(name, fn){
 };
 
 /**
+ * Checks for existance of a namespace.  Returns the namespace if it exists.
+ *
+ * @param {String} nsp name
+ * @api public
+ */
+
+Server.prototype.has = function(name) {
+  return this.nsps[name];
+}
+
+/**
  * Closes server connection
  *
  * @api public

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -519,6 +519,22 @@ describe('socket.io', function(){
       });
     });
 
+    it('should check server with `has` for a namespace and return proper result', function(done){
+      var srv = http();
+      var sio = io(srv);
+      srv.listen(function(){
+        var nsid = '/chat';
+        var chat = client(srv, nsid);
+        sio.of(nsid).on('connection', function(socket){
+          var shouldExist = sio.has(nsid);
+          var shouldNotExist = sio.has('/news');
+          expect(shouldExist).to.be.a(Namespace);
+          expect(shouldNotExist).to.not.be.ok();
+          done();
+        });
+      });
+    });
+
     it('should disconnect upon transport disconnection', function(done){
       var srv = http();
       var sio = io(srv);


### PR DESCRIPTION
Allows the client codebase to check for a namespace before setting up an additional listener.  Adding multiple listeners to the same namespace can cause too many 'emit' events to get called.  So, this fork update allows code like this to work:

```
exports.createNamespace = function(namespaceId, storageFunc, cb) {
  //
  // Socket listener.  Gets messages from the clients and rebroadcasts them
  // to all the other clients.
  //

  var ioNamespaceId = '/' + namespaceId;

  if (io.has(ioNamespaceId)) {
    debug('reusing existing namespace: ' + ioNamespaceId);
  } else {
    var nsp = io.of(ioNamespaceId);
    debug('created socket namespace: ' + ioNamespaceId);

    nsp.on('connection', function(socket){
      debug('got connection!');
      socket.on('addComment', function(data) {
        storageFunc(data, function(err, result) {
          if (err) {
            debug('(error) can\'t save data! ' + util.inspect(err));
          }
          socket.broadcast.emit('addedComment', data);
        });
      });
    });
  }
  cb();
};
```

Also - adding additional ".idea" entry to .gitignore so Webstorm users don't have to manually add it when they fork.
