### PR TITLE
Remove nested callbacks by generators & promises

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "0.8"
-  - "0.10"
   - "0.12"
 
 git:

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "expect.js": "0.3.1",
     "supertest": "0.8.2",
     "superagent": "0.17.0",
+    "co": "4.4.0",
+    "bluebird": "2.9.13",
     "istanbul": "0.2.3"
   },
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/Automattic/socket.io"
   },
   "scripts": {
-    "test": "mocha --reporter dot --slow 200ms --bail"
+    "test": "mocha --harmony-generators --reporter dot --slow 200ms --bail"
   },
   "dependencies": {
     "engine.io": "automattic/engine.io#ddc64a",


### PR DESCRIPTION
How about using generators & promises for more readable and robust asynchronous operation?
First, I try it at testing code.
