### PR TITLE
improve test by promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "expect.js": "0.3.1",
     "supertest": "0.8.2",
     "superagent": "0.17.0",
+    "bluebird": "2.9.13",
     "istanbul": "0.2.3"
   },
   "contributors": [

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -6,6 +6,7 @@ var join = require('path').join;
 var ioc = require('socket.io-client');
 var request = require('supertest');
 var expect = require('expect.js');
+var Promise = require('bluebird');
 
 // Creates a socket.io client for the given server
 function client(srv, nsp, opts){
@@ -971,15 +972,15 @@ describe('socket.io', function(){
         });
 
         var socket = client(srv, { transports: ['polling'] });
-        socket.on('ev', function() {
-          counter++;
+        new Promise(function(resolve) {
+          socket.on('ev', function() {
+            resolve(counter++);
+          });
+        }).then(function() {
+          expect(counter).to.be(1);
+          done();
         });
       });
-
-      setTimeout(function() {
-        expect(counter).to.be(1);
-        done();
-      }, 200);
     });
 
     it('should not emit volatile event after regular event (ws)', function(done) {
@@ -994,15 +995,15 @@ describe('socket.io', function(){
         });
 
         var socket = client(srv, { transports: ['websocket'] });
-        socket.on('ev', function() {
-          counter++;
+        new Promise(function(resolve) {
+          socket.on('ev', function() {
+            resolve(counter++);
+          });
+        }).then(function() {
+          expect(counter).to.be(1);
+          done();
         });
       });
-
-      setTimeout(function() {
-        expect(counter).to.be(1);
-        done();
-      }, 200);
     });
 
     it('should emit volatile event (polling)', function(done) {
@@ -1019,15 +1020,15 @@ describe('socket.io', function(){
         });
 
         var socket = client(srv, { transports: ['polling'] });
-        socket.on('ev', function() {
-          counter++;
+        new Promise(function(resolve) {
+          socket.on('ev', function() {
+            resolve(counter++);
+          });
+        }).then(function() {
+          expect(counter).to.be(1);
+          done();
         });
       });
-
-      setTimeout(function() {
-        expect(counter).to.be(1);
-        done();
-      }, 200);
     });
 
     it('should emit volatile event (ws)', function(done) {
@@ -1044,15 +1045,15 @@ describe('socket.io', function(){
         });
 
         var socket = client(srv, { transports: ['websocket'] });
-        socket.on('ev', function() {
-          counter++;
+        new Promise(function(resolve) {
+          socket.on('ev', function() {
+            resolve(counter++);
+          });
+        }).then(function() {
+          expect(counter).to.be(1);
+          done();
         });
       });
-
-      setTimeout(function() {
-        expect(counter).to.be(1);
-        done();
-      }, 200);
     });
 
     it('should emit only one consecutive volatile event (polling)', function(done) {
@@ -1070,15 +1071,15 @@ describe('socket.io', function(){
         });
 
         var socket = client(srv, { transports: ['polling'] });
-        socket.on('ev', function() {
-          counter++;
+        new Promise(function(resolve) {
+          socket.on('ev', function() {
+            resolve(counter++);
+          });
+        }).then(function() {
+          expect(counter).to.be(1);
+          done();
         });
       });
-
-      setTimeout(function() {
-        expect(counter).to.be(1);
-        done();
-      }, 200);
     });
 
     it('should emit only one consecutive volatile event (ws)', function(done) {
@@ -1096,15 +1097,15 @@ describe('socket.io', function(){
         });
 
         var socket = client(srv, { transports: ['websocket'] });
-        socket.on('ev', function() {
-          counter++;
+        new Promise(function(resolve) {
+          socket.on('ev', function() {
+            resolve(counter++);
+          });
+        }).then(function() {
+          expect(counter).to.be(1);
+          done();
         });
       });
-
-      setTimeout(function() {
-        expect(counter).to.be(1);
-        done();
-      }, 200);
     });
 
     it('should emit regular events after trying a failed volatile event (polling)', function(done) {


### PR DESCRIPTION
Using promises, I remove unreliable `setTimeout()` hack.
