### PR TITLE
Don't set request property

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -60,7 +60,6 @@ function Socket(nsp, client){
   this.server = nsp.server;
   this.adapter = this.nsp.adapter;
   this.id = client.id;
-  this.request = client.request;
   this.client = client;
   this.conn = client.conn;
   this.rooms = [];


### PR DESCRIPTION
Socket#request is defined as getter, so we shouldn't try to set value.

Related: https://github.com/Automattic/socket.io/issues/2120