### PR TITLE
Serve minified and gzipped source at server/socket.io/socket.io.min.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,8 @@ var Namespace = require('./namespace');
 var Adapter = require('socket.io-adapter');
 var debug = require('debug')('socket.io:server');
 var url = require('url');
+var zlib = require('zlib');
+var UglifyJS = require('uglify-js');
 
 /**
  * Module exports.
@@ -26,6 +28,10 @@ module.exports = Server;
  */
 
 var clientSource = read(require.resolve('socket.io-client/socket.io.js'), 'utf-8');
+var minSource = UglifyJS.minify(clientSource, { fromString: true }).code;
+zlib.gzip(new Buffer(minSource, 'utf-8'), function(err, source) {
+  if (!err) minSource = source;
+});
 
 /**
  * Server constructor.
@@ -249,13 +255,16 @@ Server.prototype.attach = function(srv, opts){
 
 Server.prototype.attachServe = function(srv){
   debug('attaching client serving req handler');
-  var url = this._path + '/socket.io.js';
+  var devUrl = this._path + '/socket.io.js';
+  var minUrl = this._path + '/socket.io.min.js';
   var evs = srv.listeners('request').slice(0);
   var self = this;
   srv.removeAllListeners('request');
   srv.on('request', function(req, res) {
-    if (0 === req.url.indexOf(url)) {
+    if (0 === req.url.indexOf(devUrl)) {
       self.serve(req, res);
+    } else if (0 === req.url.indexOf(minUrl)) {
+      self.serve(req, res, true);
     } else {
       for (var i = 0; i < evs.length; i++) {
         evs[i].call(srv, req, res);
@@ -272,7 +281,7 @@ Server.prototype.attachServe = function(srv){
  * @api private
  */
 
-Server.prototype.serve = function(req, res){
+Server.prototype.serve = function(req, res, isMin){
   var etag = req.headers['if-none-match'];
   if (etag) {
     if (clientVersion == etag) {
@@ -287,7 +296,7 @@ Server.prototype.serve = function(req, res){
   res.setHeader('Content-Type', 'application/javascript');
   res.setHeader('ETag', clientVersion);
   res.writeHead(200);
-  res.end(clientSource);
+  res.end(isMin ? minSource : clientSource);
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -295,6 +295,7 @@ Server.prototype.serve = function(req, res, isMin){
   debug('serve client source');
   res.setHeader('Content-Type', 'application/javascript');
   res.setHeader('ETag', clientVersion);
+  if (isMin && typeof minSource === 'object') res.setHeader('Content-Encoding', 'gzip');
   res.writeHead(200);
   res.end(isMin ? minSource : clientSource);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -274,10 +274,11 @@ Server.prototype.attachServe = function(srv){
 };
 
 /**
- * Handles a request serving `/socket.io.js`
+ * Handles a request serving `/socket.io[.min].js`
  *
  * @param {http.Request} req
  * @param {http.Response} res
+ * @param {Boolean} whether to serve minified & gzipped client code
  * @api private
  */
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "socket.io-client": "automattic/socket.io-client#ba31817",
     "socket.io-adapter": "automattic/socket.io-adapter#de5cba",
     "has-binary": "0.1.6",
-    "debug": "2.1.3"
+    "debug": "2.1.3",
+    "uglify-js": "^2.4.23"
   },
   "devDependencies": {
     "mocha": "1.16.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "socket.io-adapter": "automattic/socket.io-adapter#de5cba",
     "has-binary": "0.1.6",
     "debug": "2.1.3",
-    "uglify-js": "^2.4.23"
+    "uglify-js": "2.4.23"
   },
   "devDependencies": {
     "mocha": "1.16.2",


### PR DESCRIPTION
Currently, the server only serves the unminified, uncompressed source.  This pull adds functionality to serve the minified, gzipped source at `/socket.io.min.js`.