### PR TITLE
Fixed grammar issues in the README.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -145,7 +145,7 @@ server.listen(3000);
   __Potential drawbacks__:
   * in some situations, when it is not possible to determine `origin` it may have value of `*`
   * As this function will be executed for every request, it is advised to make this function work as fast as possible
-  * If `socket.io` is used together with `Express`, the CORS headers will be affected only for `socket.io` requests. For Express can use [cors](https://github.com/troygoode/node-cors/)
+  * If `socket.io` is used together with `Express`, the CORS headers will be affected only for `socket.io` requests. For Express can use [cors](https://github.com/troygoode/node-cors/).
 
 
 ### Server#sockets:Namespace
@@ -181,7 +181,7 @@ server.listen(3000);
   Initializes and retrieves the given `Namespace` by its pathname
   identifier `nsp`.
 
-  If the namespace was already initialized it returns it right away.
+  If the namespace was already initialized it returns it immediately.
 
 ### Server#emit
 
@@ -278,7 +278,7 @@ server.listen(3000);
 ### Namespace#use(fn:Function):Namespace
 
   Registers a middleware, which is a function that gets executed for
-  every incoming `Socket` and receives as parameter the socket and a
+  every incoming `Socket`, and receives as parameters the socket and a
   function to optionally defer execution to the next registered
   middleware.
 
@@ -391,7 +391,7 @@ server.listen(3000);
 ### Client
 
   The `Client` class represents an incoming transport (engine.io)
-  connection. A `Client` can be associated with many multiplexed `Socket`
+  connection. A `Client` can be associated with many multiplexed `Socket`s
   that belong to different `Namespace`s.
 
 ### Client#conn


### PR DESCRIPTION
Added a few periods and commas which were missing. Pluralised the word 'paramater' where it was incorrectly specified to singular on line 281.
Very minor edit. No source code changed.
