### PR TITLE
Actually prevent double callbacks...

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -358,6 +358,8 @@ Socket.prototype.ack = function(id){
       type: type,
       data: args
     });
+
+    sent = true;
   };
 };
 


### PR DESCRIPTION
We declare `sent = false` and even check `if (sent)` is truthy, but we never set it to truthy, therefore it never really *prevents double callbacks*...