### PR TITLE
Update package dependencies socket.io-client version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "engine.io": "automattic/engine.io#ab2bd0",
     "socket.io-parser": "2.2.4",
-    "socket.io-client": "automattic/socket.io-client#ba31817",
+    "socket.io-client": "automattic/socket.io-client#1659122",
     "socket.io-adapter": "automattic/socket.io-adapter#de5cba",
     "has-binary": "0.1.6",
     "debug": "2.1.3"


### PR DESCRIPTION
The package.json dependency for 1.3.6 was on an earlier version of socket.io-client, 1.3.5, causing the test suite to fail. This change pulls the correct version of socket.io-client after `npm install`.
See Issue #2182 