### PR TITLE
README: fixed up legacy repo links

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 
 # socket.io
 
-[![Build Status](https://secure.travis-ci.org/Automattic/socket.io.svg)](http://travis-ci.org/Automattic/socket.io)
+[![Build Status](https://secure.travis-ci.org/socketio/socket.io.svg)](http://travis-ci.org/socketio/socket.io)
 ![NPM version](https://badge.fury.io/js/socket.io.svg)
 ![Downloads](http://img.shields.io/npm/dm/socket.io.svg?style=flat)
 [![](http://slack.socket.io/badge.svg)](http://slack.socket.io)
@@ -128,7 +128,7 @@ server.listen(3000);
 
   Sets the adapter `v`. Defaults to an instance of the `Adapter` that
   ships with socket.io which is memory based. See
-  [socket.io-adapter](https://github.com/Automattic/socket.io-adapter).
+  [socket.io-adapter](https://github.com/socketio/socket.io-adapter).
 
   If no arguments are supplied this method returns the current value.
 
@@ -348,7 +348,7 @@ server.listen(3000);
 
   The mechanics of joining  rooms are handled by the `Adapter`
   that has been configured (see `Server#adapter` above), defaulting to
-  [socket.io-adapter](https://github.com/Automattic/socket.io-adapter).
+  [socket.io-adapter](https://github.com/socketio/socket.io-adapter).
 
 ### Socket#leave(name:String[, fn:Function]):Socket
 
@@ -359,7 +359,7 @@ server.listen(3000);
 
   The mechanics of leaving rooms are handled by the `Adapter`
   that has been configured (see `Server#adapter` above), defaulting to
-  [socket.io-adapter](https://github.com/Automattic/socket.io-adapter).
+  [socket.io-adapter](https://github.com/socketio/socket.io-adapter).
 
 ### Socket#to(room:String):Socket
 ### Socket#in(room:String):Socket


### PR DESCRIPTION
Migrated legacy URLs containing 'Automattic' to the new org 'socketio'

### * Before
<img width="557" alt="screen shot 2015-08-16 at 8 37 00 pm" src="https://cloud.githubusercontent.com/assets/4898263/9297076/a618ed40-4456-11e5-9a76-bdccdab1c530.png">


###  * After
<img width="538" alt="screen shot 2015-08-16 at 8 38 13 pm" src="https://cloud.githubusercontent.com/assets/4898263/9297084/c5a43fc0-4456-11e5-8549-4e7e40fb7ba9.png">
