### PR TITLE
Make it compile under Node 4.0.0; bump `socket.io-client`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "engine.io": "automattic/engine.io#7e77dd5",
     "socket.io-parser": "2.2.4",
-    "socket.io-client": "automattic/socket.io-client#bf98153",
+    "socket.io-client": "automattic/socket.io-client#4c22f33",
     "socket.io-adapter": "automattic/socket.io-adapter#de5cba",
     "has-binary": "0.1.6",
     "debug": "2.1.3"


### PR DESCRIPTION
The previous reference `automattic/socket.io-client#bf98153` points to 0.7.x of `ws` package which could not compile under Node 4.0.0.

We have to point to `ws` 0.8.0 to make it compile.