### PR TITLE
Update engine.io and socket.io-client dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "test": "mocha --reporter dot --slow 200ms --bail"
   },
   "dependencies": {
-    "engine.io": "automattic/engine.io#7e77dd5",
+    "engine.io": "automattic/engine.io#3df49bb",
     "socket.io-parser": "2.2.4",
-    "socket.io-client": "automattic/socket.io-client#bf98153",
+    "socket.io-client": "automattic/socket.io-client#4c22f33",
     "socket.io-adapter": "automattic/socket.io-adapter#de5cba",
     "has-binary": "0.1.6",
     "debug": "2.1.3"


### PR DESCRIPTION
Fixes npm install failures with node 4. (Requires XCode 7).