### PR TITLE
Working travis build status

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 
 # socket.io
 
-[![Build Status](https://secure.travis-ci.org/Automattic/socket.io.svg)](http://travis-ci.org/Automattic/socket.io)
+[![Build Status](https://secure.travis-ci.org/socketio/socket.io.svg)](http://travis-ci.org/socketio/socket.io)
 ![NPM version](https://badge.fury.io/js/socket.io.svg)
 ![Downloads](http://img.shields.io/npm/dm/socket.io.svg?style=flat)
 [![](http://slack.socket.io/badge.svg)](http://slack.socket.io)


### PR DESCRIPTION
Remove broken build status caused by the name change of the github organization.