### PR TITLE
fix the text alignment in firefox

### DIFF
--- a/examples/chat/public/style.css
+++ b/examples/chat/public/style.css
@@ -95,7 +95,7 @@ ul {
 /* Font */
 
 .messages {
-  font-size: 150%;
+  font-size: 100%;
 }
 
 .inputMessage {


### PR DESCRIPTION
This is just plain strange, but using fotn size above 150% makes the alignment got crazy on firefox. No idea at all why and how. 

Check http://imgur.com/TRdhV8Y to have an idea of what I am talking about.