### PR TITLE
Upgrade npm version in order to fix node v0.8 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: false
+before_install:
+  - npm install -g npm@'>=1.4.3'
 language: node_js
 node_js:
   - "0.8"


### PR DESCRIPTION
Hi!

As suggested [there](https://github.com/travis-ci/travis-ci/issues/2076), the npm version associated by default with node v0.8 does not support caret (^) operator, thus making the build fail.

Note: `sudo: false` allow the use of [container-based infrastructure](http://docs.travis-ci.com/user/workers/container-based-infrastructure/)