### PR TITLE
Update “debug” to avoid vulnerability in “ms”

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "socket.io-client": "automattic/socket.io-client#master",
     "socket.io-adapter": "automattic/socket.io-adapter#master",
     "has-binary": "0.1.7",
-    "debug": "2.1.3"
+    "debug": "^2.2.0"
   },
   "devDependencies": {
     "expect.js": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "socket.io-client": "automattic/socket.io-client#master",
     "socket.io-adapter": "automattic/socket.io-adapter#master",
     "has-binary": "0.1.7",
-    "debug": "^2.2.0"
+    "debug": "2.2.0"
   },
   "devDependencies": {
     "expect.js": "0.3.1",


### PR DESCRIPTION
[Package `ms` is vulnerable to DoS attacks](https://nodesecurity.io/advisories/46). The issue was fixed in `v0.7.1`.

Package `debug` was updated accordingly in `v2.2.0`.

This PR updates the required version of `debug` ([Node Security tools](https://www.npmjs.com/package/nsp) will complain and fail until this is fixed).