### PR TITLE
Trigger callback even when joining an already joined room

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -222,7 +222,10 @@ Socket.prototype.packet = function(packet, opts){
 Socket.prototype.join = function(room, fn){
   debug('joining room %s', room);
   var self = this;
-  if (this.rooms.hasOwnProperty(room)) return this;
+  if (this.rooms.hasOwnProperty(room)) {
+    fn && fn(null);
+    return this;
+  }
   this.adapter.add(this.id, room, function(err){
     if (err) return fn && fn(err);
     debug('joined room %s', room);

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -1685,6 +1685,21 @@ describe('socket.io', function(){
         });
       });
     });
+
+    it('should always trigger the callback (if provided) when joining a room', function(done){
+      var srv = http();
+      var sio = io(srv);
+
+      srv.listen(function(){
+        var socket = client(srv);
+        sio.on('connection', function(s){
+          s.join('a', function(){
+            s.join('a', done);
+          });
+        });
+      });
+    });
+
   });
 
   describe('messaging many', function(){


### PR DESCRIPTION
Related:
* https://github.com/socketio/socket.io/pull/2312
* https://github.com/socketio/socket.io-redis/issues/53 (the second point should also be fixed as `this.rooms` is now an object)