### PR TITLE
Promise middleware

### DIFF
--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -112,17 +112,30 @@ Namespace.prototype.run = function(socket, fn){
   var fns = this.fns.slice(0);
   if (!fns.length) return fn(null);
 
+  function runSuccess(i) {
+    // if no middleware left, summon callback
+    if (!fns[i + 1]) return fn(null);
+
+    // go on to next
+    run(i + 1);
+  }
+
   function run(i){
-    fns[i](socket, function(err){
+
+    var result = fns[i](socket, function(err){
       // upon error, short-circuit
       if (err) return fn(err);
 
-      // if no middleware left, summon callback
-      if (!fns[i + 1]) return fn(null);
-
-      // go on to next
-      run(i + 1);
+      return runSuccess(i);
     });
+
+    if (typeof result !== 'undefined' && typeof result.then === 'function') {
+      result.then(function () {
+        return runSuccess(i);
+      }).catch(function (err) {
+        return fn(err);
+      });
+    }
   }
 
   run(0);

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "debug": "2.2.0"
   },
   "devDependencies": {
+    "bluebird": "^3.0.6",
     "expect.js": "0.3.1",
     "istanbul": "0.2.3",
     "mocha": "2.3.4",

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -2162,5 +2162,49 @@ describe('socket.io', function(){
         });
       });
     });
+
+    it('should handle Promises', function(done){
+      var srv = http();
+      var sio = io(srv);
+      var run = 0;
+      sio.use(function(socket){
+        expect(socket).to.be.a(Socket);
+        run++;
+        return Promise.resolve();
+      });
+      sio.use(function(socket){
+        expect(socket).to.be.a(Socket);
+        run++;
+        return Promise.resolve();
+      });
+      srv.listen(function(){
+        var socket = client(srv);
+        socket.on('connect', function(){
+          expect(run).to.be(2);
+          done();
+        });
+      });
+    });
+
+    it('should handle errors in Promises', function(done){
+      var srv = http();
+      var sio = io(srv);
+      sio.use(function(socket){
+        return Promise.reject(new Error('Authentication error'));
+      });
+      sio.use(function(socket){
+        return Promise.reject(new Error('nope'));
+      });
+      srv.listen(function(){
+        var socket = client(srv);
+        socket.on('connect', function(){
+          done(new Error('nope'));
+        });
+        socket.on('error', function(err){
+          expect(err).to.be('Authentication error');
+          done();
+        });
+      });
+    });
   });
 });

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -6,6 +6,7 @@ var join = require('path').join;
 var ioc = require('socket.io-client');
 var request = require('supertest');
 var expect = require('expect.js');
+var Promise = require('bluebird');
 
 // Creates a socket.io client for the given server
 function client(srv, nsp, opts){


### PR DESCRIPTION
With these changes socket.io middleware functions can return Promises instead of using the `done` callback. This does not require including a Promise polyfill in socket.io.
