### PR TITLE
Document type change of Socket#rooms

### DIFF
--- a/History.md
+++ b/History.md
@@ -41,6 +41,7 @@
   * package: bump `has-binary` to work with all objects (fixes #1955)
   * fix origin verification default https port [evanlucas]
   * support compression [nkzawa]
+  * changed type of `Client#sockets`, `Namespace#sockets` and `Socket#rooms` to maps (instead of arrays)
 
 1.3.7 / 2015-09-21
 ==================

--- a/Readme.md
+++ b/Readme.md
@@ -299,9 +299,10 @@ server.listen(3000);
   clients. A `Socket` belongs to a certain `Namespace` (by default `/`)
   and uses an underlying `Client` to communicate.
 
-### Socket#rooms:Array
+### Socket#rooms:Object
 
-  A list of strings identifying the rooms this socket is in.
+  A hash of strings identifying the rooms this socket is in, indexed by
+  room name.
 
 ### Socket#client:Client
 


### PR DESCRIPTION
Related: https://github.com/socketio/socket.io/issues/2371

The website (http://socket.io/docs/server-api/) should be updated accordingly.