### PR TITLE
Few optimizations

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -161,11 +161,11 @@ Server.prototype.path = function(v){
 Server.prototype.adapter = function(v){
   if (!arguments.length) return this._adapter;
   this._adapter = v;
-  for (var i in this.nsps) {
-    if (this.nsps.hasOwnProperty(i)) {
-      this.nsps[i].initAdapter();
-    }
+  var prop=Object.keys(this.nsps);
+  for (var i=0; i<prop.length; i++){
+    prop[i].initAdapter();
   }
+
   return this;
 };
 
@@ -327,7 +327,7 @@ Server.prototype.onconnection = function(conn){
  */
 
 Server.prototype.of = function(name, fn){
-  if (String(name)[0] !== '/') name = '/' + name;
+  if ((name+'')[0] !== '/') name = '/' + name;
   
   var nsp = this.nsps[name];
   if (!nsp) {


### PR DESCRIPTION
I suggest to replace for in loop with hasOwnProperty check with significantly cheaper Object.keys and for loop (jsperf: https://jsperf.com/object-keys-vs-for-in-perf). In String.prototype.of method you call String constructor  which usually receives some string as an input. It is cheaper to use implicit string conversion, and performance benefit is even larger for inputs of type string (jsperf: http://jsperf.com/implicitstringconversion)
