### PR TITLE
Fixing chat display bug

### DIFF
--- a/examples/chat/public/style.css
+++ b/examples/chat/public/style.css
@@ -95,7 +95,7 @@ ul {
 /* Font */
 
 .messages {
-  font-size: 150%;
+  font-size: 140%;
 }
 
 .inputMessage {


### PR DESCRIPTION
I just downloaded the program and looked at it and it showed the messages being weirdly displayed (adding the width of the last username to the start of the new message like so:

```
TestUser this is a mesage
               TestUser this is another message
                             TestUser this is message 3
```

For some reason, reducing the font-size by 10% appears to fix the bug.