### PR TITLE
Add gulp and babel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ before_install:
   - npm install -g npm@'>=1.4.3'
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"
   - "0.12"
   - "4"

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,8 @@
 
-REPORTER = dot
-
 test:
-	@./node_modules/.bin/mocha \
-		--reporter $(REPORTER) \
-		--slow 200ms \
-		--bail
+	@./node_modules/.bin/gulp test
 
 test-cov:
-	@./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- \
-		--reporter $(REPORTER) \
-		test/
+	@./node_modules/.bin/gulp test-cov
 
 .PHONY: test

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,7 @@ var gulp = require('gulp');
 var mocha = require('gulp-mocha');
 var babel = require("gulp-babel");
 
+// By default, individual js files are transformed by babel and exported to /dist
 gulp.task("default", function () {
   return gulp.src("lib/*.js")
     .pipe(babel())

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,17 @@
+var gulp = require('gulp');
+var mocha = require('gulp-mocha');
+
+gulp.task('test', function(){
+  return gulp.src('test/*.js', {read: false})
+    .pipe(mocha({
+      timeout: 2000,
+      reporter: 'dot',
+      bail: true
+    }))
+    .once('error', function () {
+      process.exit(1);
+    })
+    .once('end', function () {
+      process.exit();
+    });
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,12 @@
 var gulp = require('gulp');
 var mocha = require('gulp-mocha');
+var babel = require("gulp-babel");
+
+gulp.task("default", function () {
+  return gulp.src("lib/*.js")
+    .pipe(babel())
+    .pipe(gulp.dest("dist"));
+});
 
 gulp.task('test', function(){
   return gulp.src('test/*.js', {read: false})

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,9 +1,9 @@
-var gulp = require('gulp');
-var mocha = require('gulp-mocha');
-var babel = require("gulp-babel");
-var istanbul = require('gulp-istanbul');
-var help = require('gulp-task-listing');
-var del = require('del');
+const gulp = require('gulp');
+const mocha = require('gulp-mocha');
+const babel = require("gulp-babel");
+const istanbul = require('gulp-istanbul');
+const help = require('gulp-task-listing');
+const del = require('del');
 
 gulp.task('help', help);
 
@@ -23,9 +23,9 @@ gulp.task('clean', function () {
 })
 
 gulp.task('test', function(){
-  return gulp.src('test/*.js', {read: false})
+  return gulp.src('test/socket.io.js', {read: false})
     .pipe(mocha({
-      timeout: 2000,
+      slow: 200,
       reporter: 'dot',
       bail: true
     }))
@@ -46,7 +46,7 @@ gulp.task('istanbul-pre-test', function () {
 });
 
 gulp.task('test-cov', ['istanbul-pre-test'], function(){
-  return gulp.src(['test/socket.io.js'])
+  return gulp.src('test/socket.io.js', {read: false})
     .pipe(mocha({
       reporter: 'dot'
     }))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,7 @@ var mocha = require('gulp-mocha');
 var babel = require("gulp-babel");
 var istanbul = require('gulp-istanbul');
 var help = require('gulp-task-listing');
+var del = require('del');
 
 gulp.task('help', help);
 
@@ -16,6 +17,10 @@ gulp.task('transpile', function () {
     .pipe(babel({ "presets": ["es2015"] }))
     .pipe(gulp.dest(TRANSPILE_DEST_DIR));
 });
+
+gulp.task('clean', function () {
+  return del([TRANSPILE_DEST_DIR]);
+})
 
 gulp.task('test', function(){
   return gulp.src('test/*.js', {read: false})

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,11 +6,15 @@ var help = require('gulp-task-listing');
 
 gulp.task('help', help);
 
+gulp.task('default', ['transpile']);
+
+const TRANSPILE_DEST_DIR = './dist';
+
 // By default, individual js files are transformed by babel and exported to /dist
-gulp.task("default", function () {
+gulp.task('transpile', function () {
   return gulp.src("lib/*.js")
     .pipe(babel({ "presets": ["es2015"] }))
-    .pipe(gulp.dest("dist"));
+    .pipe(gulp.dest(TRANSPILE_DEST_DIR));
 });
 
 gulp.task('test', function(){

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,7 @@ var istanbul = require('gulp-istanbul');
 // By default, individual js files are transformed by babel and exported to /dist
 gulp.task("default", function () {
   return gulp.src("lib/*.js")
-    .pipe(babel())
+    .pipe(babel({ "presets": ["es2015"] }))
     .pipe(gulp.dest("dist"));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp');
 var mocha = require('gulp-mocha');
 var babel = require("gulp-babel");
+var istanbul = require('gulp-istanbul');
 
 // By default, individual js files are transformed by babel and exported to /dist
 gulp.task("default", function () {
@@ -20,6 +21,28 @@ gulp.task('test', function(){
       process.exit(1);
     })
     .once('end', function () {
+      process.exit();
+    });
+});
+
+gulp.task('istanbul-pre-test', function () {
+  return gulp.src(['lib/**/*.js'])
+    // Covering files
+    .pipe(istanbul())
+    // Force `require` to return covered files
+    .pipe(istanbul.hookRequire());
+});
+
+gulp.task('test-cov', ['istanbul-pre-test'], function(){
+  return gulp.src(['test/socket.io.js'])
+    .pipe(mocha({
+      reporter: 'dot'
+    }))
+    .pipe(istanbul.writeReports())
+    .once('error', function (){
+      process.exit(1);
+    })
+    .once('end', function (){
       process.exit();
     });
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,9 @@ var gulp = require('gulp');
 var mocha = require('gulp-mocha');
 var babel = require("gulp-babel");
 var istanbul = require('gulp-istanbul');
+var help = require('gulp-task-listing');
+
+gulp.task('help', help);
 
 // By default, individual js files are transformed by babel and exported to /dist
 gulp.task("default", function () {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "git://github.com/Automattic/socket.io"
   },
   "scripts": {
-    "test": "mocha --reporter dot --slow 200ms --bail"
+    "test": "gulp test"
   },
   "dependencies": {
     "engine.io": "1.6.8",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
   "devDependencies": {
     "expect.js": "0.3.1",
     "gulp": "^3.9.0",
+    "gulp-babel": "^6.1.1",
     "gulp-mocha": "^2.2.0",
+    "istanbul": "0.4.1",
     "mocha": "2.3.4",
     "superagent": "1.6.1",
     "supertest": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "git://github.com/Automattic/socket.io"
   },
   "scripts": {
-    "test": "gulp test"
+    "test": "./node_modules/.bin/gulp test"
   },
   "dependencies": {
     "engine.io": "1.6.8",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,12 @@
     "debug": "2.2.0"
   },
   "devDependencies": {
+    "babel-preset-es2015": "6.3.13",
     "expect.js": "0.3.1",
-    "gulp": "^3.9.0",
-    "gulp-babel": "^6.1.1",
-    "gulp-istanbul": "^0.10.3",
-    "gulp-mocha": "^2.2.0",
+    "gulp": "3.9.0",
+    "gulp-babel": "6.1.1",
+    "gulp-istanbul": "0.10.3",
+    "gulp-mocha": "2.2.0",
     "istanbul": "0.4.1",
     "mocha": "2.3.4",
     "superagent": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "gulp-babel": "6.1.1",
     "gulp-istanbul": "0.10.3",
     "gulp-mocha": "2.2.0",
+    "gulp-task-listing": "1.0.1",
     "istanbul": "0.4.1",
     "mocha": "2.3.4",
     "superagent": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
   },
   "devDependencies": {
     "expect.js": "0.3.1",
+    "gulp": "^3.9.0",
+    "gulp-mocha": "^2.2.0",
     "istanbul": "0.4.1",
     "mocha": "2.3.4",
     "superagent": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "expect.js": "0.3.1",
     "gulp": "^3.9.0",
     "gulp-babel": "^6.1.1",
+    "gulp-istanbul": "^0.10.3",
     "gulp-mocha": "^2.2.0",
     "istanbul": "0.4.1",
     "mocha": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "babel-preset-es2015": "6.3.13",
+    "del": "2.2.0",
     "expect.js": "0.3.1",
     "gulp": "3.9.0",
     "gulp-babel": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "expect.js": "0.3.1",
     "gulp": "^3.9.0",
     "gulp-mocha": "^2.2.0",
-    "istanbul": "0.4.1",
     "mocha": "2.3.4",
     "superagent": "1.6.1",
     "supertest": "1.1.0",


### PR DESCRIPTION
- Add `gulp` to repo
- Add `gulp` tasks to mirror `make` recipes
- Add `transpile` task for babel transformation
- Redirect all `make` recipes to `gulp`
- Remove node 0.8 from travis

Note: ESLint will be on the next PR as fixes for linting errors will make reviewing of PR difficult