### PR TITLE
Fix chat display in Firefox

### DIFF
--- a/examples/chat/public/style.css
+++ b/examples/chat/public/style.css
@@ -128,7 +128,6 @@ ul {
 }
 
 .username {
-  float: left;
   font-weight: 700;
   overflow: hidden;
   padding-right: 15px;


### PR DESCRIPTION
Not sure why `.username` was floated, but it causes the messages to steadily march to the right in Firefox, per screenshot:

![socket](https://cloud.githubusercontent.com/assets/24193/13622893/e54235aa-e567-11e5-9635-36d6cde74145.png)

Removing the float (or setting `.messages > * { clear: both; }`) results in identical, correct display in both Chrome and Firefox.