### PR TITLE
serve sourcemap for socket.io-client

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,13 @@ module.exports = Server;
  */
 
 var clientSource = read(require.resolve('socket.io-client/socket.io.js'), 'utf-8');
-var clientSourceMap = read(require.resolve('socket.io-client/socket.io.js.map'), 'utf-8');
+var clientSourceMap = '';
+try {
+  clientSourceMap = read(require.resolve('socket.io-client/socket.io.js.map'), 'utf-8');
+} catch(err) {
+  debug('could not load sourcemap file');
+}
+
 
 /**
  * Server constructor.

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,7 @@ module.exports = Server;
  */
 
 var clientSource = read(require.resolve('socket.io-client/socket.io.js'), 'utf-8');
+var clientSourceMap = read(require.resolve('socket.io-client/socket.io.js.map'), 'utf-8');
 
 /**
  * Server constructor.
@@ -249,11 +250,14 @@ Server.prototype.attach = function(srv, opts){
 Server.prototype.attachServe = function(srv){
   debug('attaching client serving req handler');
   var url = this._path + '/socket.io.js';
+  var urlMap = this._path + '/socket.io.js.map';
   var evs = srv.listeners('request').slice(0);
   var self = this;
   srv.removeAllListeners('request');
   srv.on('request', function(req, res) {
-    if (0 === req.url.indexOf(url)) {
+    if (0 === req.url.indexOf(urlMap)) {
+      self.serveMap(req, res);
+    } else if (0 === req.url.indexOf(url)) {
       self.serve(req, res);
     } else {
       for (var i = 0; i < evs.length; i++) {
@@ -287,6 +291,32 @@ Server.prototype.serve = function(req, res){
   res.setHeader('ETag', clientVersion);
   res.writeHead(200);
   res.end(clientSource);
+};
+
+/**
+ * Handles a request serving `/socket.io.js.map`
+ *
+ * @param {http.Request} req
+ * @param {http.Response} res
+ * @api private
+ */
+
+Server.prototype.serveMap = function(req, res){
+  var etag = req.headers['if-none-match'];
+  if (etag) {
+    if (clientVersion == etag) {
+      debug('serve client 304');
+      res.writeHead(304);
+      res.end();
+      return;
+    }
+  }
+
+  debug('serve client sourcemap');
+  res.setHeader('Content-Type', 'application/javascript');
+  res.setHeader('ETag', clientVersion);
+  res.writeHead(200);
+  res.end(clientSourceMap);
 };
 
 /**


### PR DESCRIPTION
This fix allows server to serve the sourcemap of socket.io-client generated by webpack builder using `gulp build` task.

The corresponding PR for `socket.io-client` is https://github.com/socketio/socket.io-client/pull/953

Tested in Chrome and Firefox using a custom package of `socket.io-client` with sourcemap file. It also catches the error when there is not sourcemap available in `socket.io-client`.

Screenshots of how the generated source map looks in browsers:
![screen shot 2016-03-10 at 4 00 40 pm](https://cloud.githubusercontent.com/assets/1209810/13664967/11eb898e-e6e5-11e5-8106-f7a87b23114f.png)
![screen shot 2016-03-10 at 4 00 29 pm](https://cloud.githubusercontent.com/assets/1209810/13664972/14d06520-e6e5-11e5-81a8-6a51a638a091.png)
