### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "git://github.com/socketio/socket.io"
   },
   "scripts": {
-    "test": "./node_modules/.bin/gulp test"
+    "test": "gulp test"
   },
   "dependencies": {
     "engine.io": "1.6.8",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/Automattic/socket.io"
+    "url": "git://github.com/socketio/socket.io"
   },
   "scripts": {
     "test": "./node_modules/.bin/gulp test"


### PR DESCRIPTION
I updated the repository URL and removed an unnecessary path to gulp.

Even if gulp is not installed globally, the script 'test' will still run fine.  "...executables will be added to the PATH for executing the scripts." (https://docs.npmjs.com/misc/scripts#path)