### PR TITLE
updated Express instructions so they work.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,10 +40,9 @@ function.
 
 ```js
 var app = require('express')();
-var server = require('http').createServer(app);
+var server = app.listen(3000);
 var io = require('socket.io')(server);
 io.on('connection', function(){ /* … */ });
-server.listen(3000);
 ```
 
 ### In conjunction with Koa


### PR DESCRIPTION
The listed instructions do not work, this update does. I spent a good 2 hours trying to figure out why the heck nothing worked until I ran across [this SO post](http://stackoverflow.com/questions/24222483/socket-io-1-0-express-4-2-no-socket-connection/24222869#24222869) that lists the code change in this PR, which worked perfectly with modern Express.

Another update to the site's http://socket.io/docs/ will be necessary, as that also lists code for express 3/4 that simply does not work.
