### PR TITLE
stop modifying socket id on server side

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -59,7 +59,7 @@ function Socket(nsp, client){
   this.nsp = nsp;
   this.server = nsp.server;
   this.adapter = this.nsp.adapter;
-  this.id = nsp.name + '#' + client.id;
+  this.id = client.id;
   this.client = client;
   this.conn = client.conn;
   this.rooms = {};


### PR DESCRIPTION
should fix break since https://github.com/socketio/socket.io/commit/b73d9bea4efb48277eee685763026ff2df5a79ab
#2451  #2405  #2475  #2491
but this could be another breaking change, I'm not sure what will this affect to those who parse nsp name from server side id.