### PR TITLE
stop prepend /# before id when no namespace

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -59,7 +59,7 @@ function Socket(nsp, client){
   this.nsp = nsp;
   this.server = nsp.server;
   this.adapter = this.nsp.adapter;
-  this.id = nsp.name + '#' + client.id;
+  this.id = nsp.name !== '/' ? nsp.name + '#' + client.id : client.id;
   this.client = client;
   this.conn = client.conn;
   this.rooms = {};


### PR DESCRIPTION
#2451 #2405 #2475 #2491 
This should fix break since b73d9be and #2239 

Since I'm not using namespaces, I need someone else help to check if this would break them.