### PR TITLE
Document that constructor options are indeed optional

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ var clientSource = read(require.resolve('socket.io-client/socket.io.js'), 'utf-8
  * Server constructor.
  *
  * @param {http.Server|Number|Object} srv http server, port or options
- * @param {Object} opts
+ * @param {Object} [opts]
  * @api public
  */
 


### PR DESCRIPTION
Looks as though the `opts` argument passed to the constructor is optional, so just ensuring that it is documented as such so our IDE's won't scream at us about it. :)