### PR TITLE
option to disable CORS requests by origins: 'none'

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -139,6 +139,7 @@ server.listen(3000);
   Sets the allowed origins `v`. Defaults to any origins being allowed.
 
   If no arguments are supplied this method returns the current value.
+  If origins 'v' is set to 'none', CORS requests are not served.
 
 ### Server#origins(v:Function):Server
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,7 +65,7 @@ Server.prototype.checkRequest = function(req, fn) {
 
   if (!!origin && typeof(this._origins) == 'function') return this._origins(origin, fn);
   if (this._origins.indexOf('*:*') !== -1) return fn(null, true);
-  if (origin) {
+  if (origin && this._origins !== 'none') {
     try {
       var parts = url.parse(origin);
       var defaultPort = 'https:' == parts.protocol ? 443 : 80;
@@ -80,7 +80,11 @@ Server.prototype.checkRequest = function(req, fn) {
     } catch (ex) {
     }
   }
-  fn(null, false);
+  if (!req.headers.origin) {
+    return fn(null, true);
+  } else {
+    return fn(engine.Server.errors.CORS_DISABLED, false);
+  }
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "engine.io": "1.6.8",
+    "engine.io": "https://github.com/koszny/engine.io.git",
     "socket.io-parser": "2.2.6",
     "socket.io-client": "git://github.com/nus-fboa2016-si/socket.io-client#e0580ef4",
     "socket.io-adapter": "0.4.0",

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -246,6 +246,20 @@ describe('socket.io', function(){
   describe('handshake', function(){
     var request = require('superagent');
 
+    it('should disallow cross origin requests when origin set to none', function(done) {
+      var sockets = io({ origins: 'none' }).listen('54013');
+      request.get('http://localhost:54013/socket.io/default/')
+          .query({ transport: 'polling'})
+          .set('origin', 'http://foo.bar')
+          .end(function (err, res) {
+            expect(res.status).to.be(200);
+            expect(res.header['access-control-allow-credentials']).to.be('false');
+            expect(res.header['access-control-allow-origin']).to.be('none');
+            sockets.close();
+            done();
+          });
+    });
+
     it('should disallow request when origin defined and none specified', function(done) {
       var sockets = io({ origins: 'http://foo.example:*' }).listen('54013');
       request.get('http://localhost:54013/socket.io/default/')


### PR DESCRIPTION
it adds a functionality to pass {origins: 'none'} in options
to disable serving cross origin requests. 

it depends on https://github.com/socketio/engine.io/pull/395