### PR TITLE
Added link to HyperDev version of chat demo

### DIFF
--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -16,6 +16,8 @@ $ node .
 And point your browser to `http://localhost:3000`. Optionally, specify
 a port by supplying the `PORT` env variable.
 
+Or, [view and edit your own live copy on HyperDev](https://hyperdev.com#!/remix/socketio_chat/d5323c5b-d1fd-4d39-97ac-c5d8b4cfd3f8).
+
 ## Features
 
 - Multiple users can join a chat room by each entering a unique username


### PR DESCRIPTION
This adds a remix link to a version of the Socket.io Chat demo on HyperDev - some users might prefer this as they get a copy of the code that just runs without any setup, and they can edit it straight away. I can add maintainers to the HyperDev project.
