### PR TITLE
Server supports all event emitter methods

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ var engine = require('engine.io');
 var client = require('socket.io-client');
 var clientVersion = require('socket.io-client/package').version;
 var Client = require('./client');
+var Emitter = require('events').EventEmitter;
 var Namespace = require('./namespace');
 var Adapter = require('socket.io-adapter');
 var debug = require('debug')('socket.io:server');
@@ -363,7 +364,11 @@ Server.prototype.close = function(){
  * Expose main namespace (/).
  */
 
-['on', 'to', 'in', 'use', 'emit', 'send', 'write', 'clients', 'compress'].forEach(function(fn){
+var emitterMethods = Object.keys(Emitter.prototype).filter(function(key){
+  return typeof Emitter.prototype[key] === 'function';
+});
+
+emitterMethods.concat(['to', 'in', 'use', 'send', 'write', 'clients', 'compress']).forEach(function(fn){
   Server.prototype[fn] = function(){
     var nsp = this.sockets[fn];
     return nsp.apply(this.sockets, arguments);


### PR DESCRIPTION
Previously, only `on` and `emit` methods were supported by Socket.IO server. This PR iterates over all EventEmitter methods and proxies them over to the main namespace.
