### PR TITLE
Make ETag header comply with standard.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -272,9 +272,13 @@ Server.prototype.attachServe = function(srv){
  */
 
 Server.prototype.serve = function(req, res){
+  // Per the standard, ETags must be quoted:
+  // https://tools.ietf.org/html/rfc7232#section-2.3
+  var expectedEtag = '"' + clientVersion + '"';
+
   var etag = req.headers['if-none-match'];
   if (etag) {
-    if (clientVersion == etag) {
+    if (expectedEtag == etag) {
       debug('serve client 304');
       res.writeHead(304);
       res.end();
@@ -284,7 +288,7 @@ Server.prototype.serve = function(req, res){
 
   debug('serve client source');
   res.setHeader('Content-Type', 'application/javascript');
-  res.setHeader('ETag', clientVersion);
+  res.setHeader('ETag', expectedEtag);
   res.writeHead(200);
   res.end(clientSource);
 };

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -167,7 +167,7 @@ describe('socket.io', function(){
           if (err) return done(err);
           var ctype = res.headers['content-type'];
           expect(ctype).to.be('application/javascript');
-          expect(res.headers.etag).to.be(clientVersion);
+          expect(res.headers.etag).to.be('"' + clientVersion + '"');
           expect(res.text).to.match(/engine\.io/);
           expect(res.status).to.be(200);
           done();
@@ -179,7 +179,7 @@ describe('socket.io', function(){
         io(srv);
         request(srv)
         .get('/socket.io/socket.io.js')
-        .set('If-None-Match', clientVersion)
+        .set('If-None-Match', '"' + clientVersion + '"')
         .end(function(err, res){
           if (err) return done(err);
           expect(res.statusCode).to.be(304);


### PR DESCRIPTION
The standard says that an ETag must be surrounded in double quotes:

https://tools.ietf.org/html/rfc7232#section-2.3

Although browsers tend to be lenient, omitting the quotes can confuse/break some kinds of proxies and other tools that demand compliant formatting. For example, Sandstorm.io enforces strict HTTP usage for security reasons and will block responses with invalid ETags.