### PR TITLE
Prevent null from being accepted as argument

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@ var clientSource = read(require.resolve('socket.io-client/socket.io.js'), 'utf-8
 
 function Server(srv, opts){
   if (!(this instanceof Server)) return new Server(srv, opts);
-  if ('object' == typeof srv && !srv.listen) {
+  if ('object' == typeof srv && srv instanceof Object && !srv.listen) {
     opts = srv;
     srv = null;
   }


### PR DESCRIPTION
Null can be passed as "srv" argument and will fail on "srv.listen" check.
