### PR TITLE
Implementing classes using the new ES6 syntax

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,3 +1,4 @@
+'use strict';
 
 /**
  * Module dependencies.

--- a/lib/client.js
+++ b/lib/client.js
@@ -9,12 +9,6 @@ var debug = require('debug')('socket.io:client');
 var url = require('url');
 
 /**
- * Module exports.
- */
-
-module.exports = Client;
-
-/**
  * Client constructor.
  *
  * @param {Server} server instance
@@ -22,232 +16,242 @@ module.exports = Client;
  * @api private
  */
 
-function Client(server, conn){
-  this.server = server;
-  this.conn = conn;
-  this.encoder = new parser.Encoder();
-  this.decoder = new parser.Decoder();
-  this.id = conn.id;
-  this.request = conn.request;
-  this.setup();
-  this.sockets = {};
-  this.nsps = {};
-  this.connectBuffer = [];
+class Client{
+  constructor(server, conn){
+    this.server = server;
+    this.conn = conn;
+    this.encoder = new parser.Encoder();
+    this.decoder = new parser.Decoder();
+    this.id = conn.id;
+    this.request = conn.request;
+    this.setup();
+    this.sockets = {};
+    this.nsps = {};
+    this.connectBuffer = [];
+  }
+
+  /**
+   * Sets up event listeners.
+   *
+   * @api private
+   */
+
+  setup(){
+    this.onclose = this.onclose.bind(this);
+    this.ondata = this.ondata.bind(this);
+    this.onerror = this.onerror.bind(this);
+    this.ondecoded = this.ondecoded.bind(this);
+
+    this.decoder.on('decoded', this.ondecoded);
+    this.conn.on('data', this.ondata);
+    this.conn.on('error', this.onerror);
+    this.conn.on('close', this.onclose);
+  }
+
+  /**
+   * Connects a client to a namespace.
+   *
+   * @param {String} name namespace
+   * @api private
+   */
+
+  connect(name, query){
+    debug('connecting to namespace %s', name);
+    var nsp = this.server.nsps[name];
+    if (!nsp) {
+      this.packet({ type: parser.ERROR, nsp: name, data : 'Invalid namespace'});
+      return;
+    }
+
+    if ('/' != name && !this.nsps['/']) {
+      this.connectBuffer.push(name);
+      return;
+    }
+
+    var self = this;
+    var socket = nsp.add(this, query, function(){
+      self.sockets[socket.id] = socket;
+      self.nsps[nsp.name] = socket;
+
+      if ('/' == nsp.name && self.connectBuffer.length > 0) {
+        self.connectBuffer.forEach(self.connect, self);
+        self.connectBuffer = [];
+      }
+    });
+  }
+
+  /**
+   * Disconnects from all namespaces and closes transport.
+   *
+   * @api private
+   */
+
+  disconnect(){
+    for (var id in this.sockets) {
+      if (this.sockets.hasOwnProperty(id)) {
+        this.sockets[id].disconnect();
+      }
+    }
+    this.sockets = {};
+    this.close();
+  }
+
+  /**
+   * Removes a socket. Called by each `Socket`.
+   *
+   * @api private
+   */
+
+  remove(socket){
+    if (this.sockets.hasOwnProperty(socket.id)) {
+      var nsp = this.sockets[socket.id].nsp.name;
+      delete this.sockets[socket.id];
+      delete this.nsps[nsp];
+    } else {
+      debug('ignoring remove for %s', socket.id);
+    }
+  }
+
+  /**
+   * Closes the underlying connection.
+   *
+   * @api private
+   */
+
+  close(){
+    if ('open' == this.conn.readyState) {
+      debug('forcing transport close');
+      this.conn.close();
+      this.onclose('forced server close');
+    }
+  }
+
+  /**
+   * Writes a packet to the transport.
+   *
+   * @param {Object} packet object
+   * @param {Object} opts
+   * @api private
+   */
+
+  packet(packet, opts){
+    opts = opts || {};
+    var self = this;
+
+    // this writes to the actual connection
+    function writeToEngine(encodedPackets) {
+      if (opts.volatile && !self.conn.transport.writable) return;
+      for (var i = 0; i < encodedPackets.length; i++) {
+        self.conn.write(encodedPackets[i], { compress: opts.compress });
+      }
+    }
+
+    if ('open' == this.conn.readyState) {
+      debug('writing packet %j', packet);
+      if (!opts.preEncoded) { // not broadcasting, need to encode
+        this.encoder.encode(packet, function (encodedPackets) { // encode, then write results to engine
+          writeToEngine(encodedPackets);
+        });
+      } else { // a broadcast pre-encodes a packet
+        writeToEngine(packet);
+      }
+    } else {
+      debug('ignoring packet write %j', packet);
+    }
+  }
+
+  /**
+   * Called with incoming transport data.
+   *
+   * @api private
+   */
+
+  ondata(data){
+    // try/catch is needed for protocol violations (GH-1880)
+    try {
+      this.decoder.add(data);
+    } catch(e) {
+      this.onerror(e);
+    }
+  }
+
+  /**
+   * Called when parser fully decodes a packet.
+   *
+   * @api private
+   */
+
+  ondecoded(packet) {
+    if (parser.CONNECT == packet.type) {
+      this.connect(url.parse(packet.nsp).pathname, url.parse(packet.nsp, true).query);
+    } else {
+      var socket = this.nsps[packet.nsp];
+      if (socket) {
+        socket.onpacket(packet);
+      } else {
+        debug('no socket for namespace %s', packet.nsp);
+      }
+    }
+  }
+
+  /**
+   * Handles an error.
+   *
+   * @param {Object} err object
+   * @api private
+   */
+
+  onerror(err){
+    for (var id in this.sockets) {
+      if (this.sockets.hasOwnProperty(id)) {
+        this.sockets[id].onerror(err);
+      }
+    }
+    this.onclose('client error');
+  }
+
+  /**
+   * Called upon transport close.
+   *
+   * @param {String} reason
+   * @api private
+   */
+
+  onclose(reason){
+    debug('client close with reason %s', reason);
+
+    // ignore a potential subsequent `close` event
+    this.destroy();
+
+    // `nsps` and `sockets` are cleaned up seamlessly
+    for (var id in this.sockets) {
+      if (this.sockets.hasOwnProperty(id)) {
+        this.sockets[id].onclose(reason);
+      }
+    }
+    this.sockets = {};
+
+    this.decoder.destroy(); // clean up decoder
+  }
+
+  /**
+   * Cleans up event listeners.
+   *
+   * @api private
+   */
+
+  destroy(){
+    this.conn.removeListener('data', this.ondata);
+    this.conn.removeListener('error', this.onerror);
+    this.conn.removeListener('close', this.onclose);
+    this.decoder.removeListener('decoded', this.ondecoded);
+  }
+
 }
 
 /**
- * Sets up event listeners.
- *
- * @api private
+ * Module exports.
  */
 
-Client.prototype.setup = function(){
-  this.onclose = this.onclose.bind(this);
-  this.ondata = this.ondata.bind(this);
-  this.onerror = this.onerror.bind(this);
-  this.ondecoded = this.ondecoded.bind(this);
+module.exports = Client;
 
-  this.decoder.on('decoded', this.ondecoded);
-  this.conn.on('data', this.ondata);
-  this.conn.on('error', this.onerror);
-  this.conn.on('close', this.onclose);
-};
-
-/**
- * Connects a client to a namespace.
- *
- * @param {String} name namespace
- * @api private
- */
-
-Client.prototype.connect = function(name, query){
-  debug('connecting to namespace %s', name);
-  var nsp = this.server.nsps[name];
-  if (!nsp) {
-    this.packet({ type: parser.ERROR, nsp: name, data : 'Invalid namespace'});
-    return;
-  }
-
-  if ('/' != name && !this.nsps['/']) {
-    this.connectBuffer.push(name);
-    return;
-  }
-
-  var self = this;
-  var socket = nsp.add(this, query, function(){
-    self.sockets[socket.id] = socket;
-    self.nsps[nsp.name] = socket;
-
-    if ('/' == nsp.name && self.connectBuffer.length > 0) {
-      self.connectBuffer.forEach(self.connect, self);
-      self.connectBuffer = [];
-    }
-  });
-};
-
-/**
- * Disconnects from all namespaces and closes transport.
- *
- * @api private
- */
-
-Client.prototype.disconnect = function(){
-  for (var id in this.sockets) {
-    if (this.sockets.hasOwnProperty(id)) {
-      this.sockets[id].disconnect();
-    }
-  }
-  this.sockets = {};
-  this.close();
-};
-
-/**
- * Removes a socket. Called by each `Socket`.
- *
- * @api private
- */
-
-Client.prototype.remove = function(socket){
-  if (this.sockets.hasOwnProperty(socket.id)) {
-    var nsp = this.sockets[socket.id].nsp.name;
-    delete this.sockets[socket.id];
-    delete this.nsps[nsp];
-  } else {
-    debug('ignoring remove for %s', socket.id);
-  }
-};
-
-/**
- * Closes the underlying connection.
- *
- * @api private
- */
-
-Client.prototype.close = function(){
-  if ('open' == this.conn.readyState) {
-    debug('forcing transport close');
-    this.conn.close();
-    this.onclose('forced server close');
-  }
-};
-
-/**
- * Writes a packet to the transport.
- *
- * @param {Object} packet object
- * @param {Object} opts
- * @api private
- */
-
-Client.prototype.packet = function(packet, opts){
-  opts = opts || {};
-  var self = this;
-
-  // this writes to the actual connection
-  function writeToEngine(encodedPackets) {
-    if (opts.volatile && !self.conn.transport.writable) return;
-    for (var i = 0; i < encodedPackets.length; i++) {
-      self.conn.write(encodedPackets[i], { compress: opts.compress });
-    }
-  }
-
-  if ('open' == this.conn.readyState) {
-    debug('writing packet %j', packet);
-    if (!opts.preEncoded) { // not broadcasting, need to encode
-      this.encoder.encode(packet, function (encodedPackets) { // encode, then write results to engine
-        writeToEngine(encodedPackets);
-      });
-    } else { // a broadcast pre-encodes a packet
-      writeToEngine(packet);
-    }
-  } else {
-    debug('ignoring packet write %j', packet);
-  }
-};
-
-/**
- * Called with incoming transport data.
- *
- * @api private
- */
-
-Client.prototype.ondata = function(data){
-  // try/catch is needed for protocol violations (GH-1880)
-  try {
-    this.decoder.add(data);
-  } catch(e) {
-    this.onerror(e);
-  }
-};
-
-/**
- * Called when parser fully decodes a packet.
- *
- * @api private
- */
-
-Client.prototype.ondecoded = function(packet) {
-  if (parser.CONNECT == packet.type) {
-    this.connect(url.parse(packet.nsp).pathname, url.parse(packet.nsp, true).query);
-  } else {
-    var socket = this.nsps[packet.nsp];
-    if (socket) {
-      socket.onpacket(packet);
-    } else {
-      debug('no socket for namespace %s', packet.nsp);
-    }
-  }
-};
-
-/**
- * Handles an error.
- *
- * @param {Object} err object
- * @api private
- */
-
-Client.prototype.onerror = function(err){
-  for (var id in this.sockets) {
-    if (this.sockets.hasOwnProperty(id)) {
-      this.sockets[id].onerror(err);
-    }
-  }
-  this.onclose('client error');
-};
-
-/**
- * Called upon transport close.
- *
- * @param {String} reason
- * @api private
- */
-
-Client.prototype.onclose = function(reason){
-  debug('client close with reason %s', reason);
-
-  // ignore a potential subsequent `close` event
-  this.destroy();
-
-  // `nsps` and `sockets` are cleaned up seamlessly
-  for (var id in this.sockets) {
-    if (this.sockets.hasOwnProperty(id)) {
-      this.sockets[id].onclose(reason);
-    }
-  }
-  this.sockets = {};
-
-  this.decoder.destroy(); // clean up decoder
-};
-
-/**
- * Cleans up event listeners.
- *
- * @api private
- */
-
-Client.prototype.destroy = function(){
-  this.conn.removeListener('data', this.ondata);
-  this.conn.removeListener('error', this.onerror);
-  this.conn.removeListener('close', this.onclose);
-  this.decoder.removeListener('decoded', this.ondecoded);
-};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-'use strict';
 
 /**
  * Module dependencies.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+'use strict';
 
 /**
  * Module dependencies.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+'use strict';
 
 /**
  * Module dependencies.
@@ -15,87 +16,10 @@ var debug = require('debug')('socket.io:server');
 var url = require('url');
 
 /**
- * Module exports.
- */
-
-module.exports = Server;
-
-/**
  * Socket.IO client source.
  */
 
 var clientSource = read(require.resolve('socket.io-client/socket.io.js'), 'utf-8');
-
-/**
- * Server constructor.
- *
- * @param {http.Server|Number|Object} srv http server, port or options
- * @param {Object} opts
- * @api public
- */
-
-function Server(srv, opts){
-  if (!(this instanceof Server)) return new Server(srv, opts);
-  if ('object' == typeof srv && !srv.listen) {
-    opts = srv;
-    srv = null;
-  }
-  opts = opts || {};
-  this.nsps = {};
-  this.path(opts.path || '/socket.io');
-  this.serveClient(false !== opts.serveClient);
-  this.adapter(opts.adapter || Adapter);
-  this.origins(opts.origins || '*:*');
-  this.sockets = this.of('/');
-  if (srv) this.attach(srv, opts);
-}
-
-/**
- * Server request verification function, that checks for allowed origins
- *
- * @param {http.IncomingMessage} req request
- * @param {Function} fn callback to be called with the result: `fn(err, success)`
- */
-
-Server.prototype.checkRequest = function(req, fn) {
-  var origin = req.headers.origin || req.headers.referer;
-
-  // file:// URLs produce a null Origin which can't be authorized via echo-back
-  if ('null' == origin || null == origin) origin = '*';
-
-  if (!!origin && typeof(this._origins) == 'function') return this._origins(origin, fn);
-  if (this._origins.indexOf('*:*') !== -1) return fn(null, true);
-  if (origin) {
-    try {
-      var parts = url.parse(origin);
-      var defaultPort = 'https:' == parts.protocol ? 443 : 80;
-      parts.port = parts.port != null
-        ? parts.port
-        : defaultPort;
-      var ok =
-        ~this._origins.indexOf(parts.hostname + ':' + parts.port) ||
-        ~this._origins.indexOf(parts.hostname + ':*') ||
-        ~this._origins.indexOf('*:' + parts.port);
-      return fn(null, !!ok);
-    } catch (ex) {
-    }
-  }
-  fn(null, false);
-};
-
-/**
- * Sets/gets whether client code is being served.
- *
- * @param {Boolean} v whether to serve client code
- * @return {Server|Boolean} self when setting or value when getting
- * @api public
- */
-
-Server.prototype.serveClient = function(v){
-  if (!arguments.length) return this._serveClient;
-  this._serveClient = v;
-  return this;
-};
 
 /**
  * Old settings for backwards compatibility
@@ -109,269 +33,346 @@ var oldSettings = {
 };
 
 /**
- * Backwards compatiblity.
+ * Server constructor.
  *
+ * @param {http.Server|Number|Object} srv http server, port or options
+ * @param {Object} opts
  * @api public
  */
 
-Server.prototype.set = function(key, val){
-  if ('authorization' == key && val) {
-    this.use(function(socket, next) {
-      val(socket.request, function(err, authorized) {
-        if (err) return next(new Error(err));
-        if (!authorized) return next(new Error('Not authorized'));
-        next();
-      });
-    });
-  } else if ('origins' == key && val) {
-    this.origins(val);
-  } else if ('resource' == key) {
-    this.path(val);
-  } else if (oldSettings[key] && this.eio[oldSettings[key]]) {
-    this.eio[oldSettings[key]] = val;
-  } else {
-    console.error('Option %s is not valid. Please refer to the README.', key);
-  }
-
-  return this;
-};
-
-/**
- * Sets the client serving path.
- *
- * @param {String} v pathname
- * @return {Server|String} self when setting or value when getting
- * @api public
- */
-
-Server.prototype.path = function(v){
-  if (!arguments.length) return this._path;
-  this._path = v.replace(/\/$/, '');
-  return this;
-};
-
-/**
- * Sets the adapter for rooms.
- *
- * @param {Adapter} v pathname
- * @return {Server|Adapter} self when setting or value when getting
- * @api public
- */
-
-Server.prototype.adapter = function(v){
-  if (!arguments.length) return this._adapter;
-  this._adapter = v;
-  for (var i in this.nsps) {
-    if (this.nsps.hasOwnProperty(i)) {
-      this.nsps[i].initAdapter();
+class _Server{
+  constructor(srv, opts){
+    if ('object' == typeof srv && !srv.listen) {
+      opts = srv;
+      srv = null;
     }
+    opts = opts || {};
+    this.nsps = {};
+    this.path(opts.path || '/socket.io');
+    this.serveClient(false !== opts.serveClient);
+    this.adapter(opts.adapter || Adapter);
+    this.origins(opts.origins || '*:*');
+    this.sockets = this.of('/');
+    if (srv) this.attach(srv, opts);
   }
-  return this;
-};
+    
+  /**
+   * Server request verification function, that checks for allowed origins
+   *
+   * @param {http.IncomingMessage} req request
+   * @param {Function} fn callback to be called with the result: `fn(err, success)`
+   */
 
-/**
- * Sets the allowed origins for requests.
- *
- * @param {String} v origins
- * @return {Server|Adapter} self when setting or value when getting
- * @api public
- */
+  checkRequest(req, fn) {
+    var origin = req.headers.origin || req.headers.referer;
 
-Server.prototype.origins = function(v){
-  if (!arguments.length) return this._origins;
+    // file:// URLs produce a null Origin which can't be authorized via echo-back
+    if ('null' == origin || null == origin) origin = '*';
 
-  this._origins = v;
-  return this;
-};
-
-/**
- * Attaches socket.io to a server or port.
- *
- * @param {http.Server|Number} server or port
- * @param {Object} options passed to engine.io
- * @return {Server} self
- * @api public
- */
-
-Server.prototype.listen =
-Server.prototype.attach = function(srv, opts){
-  if ('function' == typeof srv) {
-    var msg = 'You are trying to attach socket.io to an express ' +
-    'request handler function. Please pass a http.Server instance.';
-    throw new Error(msg);
-  }
-
-  // handle a port as a string
-  if (Number(srv) == srv) {
-    srv = Number(srv);
-  }
-
-  if ('number' == typeof srv) {
-    debug('creating http server and binding to %d', srv);
-    var port = srv;
-    srv = http.Server(function(req, res){
-      res.writeHead(404);
-      res.end();
-    });
-    srv.listen(port);
-
-  }
-
-  // set engine.io path to `/socket.io`
-  opts = opts || {};
-  opts.path = opts.path || this.path();
-  // set origins verification
-  opts.allowRequest = opts.allowRequest || this.checkRequest.bind(this);
-
-  // initialize engine
-  debug('creating engine.io instance with opts %j', opts);
-  this.eio = engine.attach(srv, opts);
-
-  // attach static file serving
-  if (this._serveClient) this.attachServe(srv);
-
-  // Export http server
-  this.httpServer = srv;
-
-  // bind to engine events
-  this.bind(this.eio);
-
-  return this;
-};
-
-/**
- * Attaches the static file serving.
- *
- * @param {Function|http.Server} srv http server
- * @api private
- */
-
-Server.prototype.attachServe = function(srv){
-  debug('attaching client serving req handler');
-  var url = this._path + '/socket.io.js';
-  var evs = srv.listeners('request').slice(0);
-  var self = this;
-  srv.removeAllListeners('request');
-  srv.on('request', function(req, res) {
-    if (0 === req.url.indexOf(url)) {
-      self.serve(req, res);
-    } else {
-      for (var i = 0; i < evs.length; i++) {
-        evs[i].call(srv, req, res);
+    if (!!origin && typeof(this._origins) == 'function') return this._origins(origin, fn);
+    if (this._origins.indexOf('*:*') !== -1) return fn(null, true);
+    if (origin) {
+      try {
+        var parts = url.parse(origin);
+        var defaultPort = 'https:' == parts.protocol ? 443 : 80;
+        parts.port = parts.port != null
+          ? parts.port
+          : defaultPort;
+        var ok =
+          ~this._origins.indexOf(parts.hostname + ':' + parts.port) ||
+          ~this._origins.indexOf(parts.hostname + ':*') ||
+          ~this._origins.indexOf('*:' + parts.port);
+        return fn(null, !!ok);
+      } catch (ex) {
       }
     }
-  });
-};
+    fn(null, false);
+  }
 
-/**
- * Handles a request serving `/socket.io.js`
- *
- * @param {http.Request} req
- * @param {http.Response} res
- * @api private
- */
+  /**
+   * Sets/gets whether client code is being served.
+   *
+   * @param {Boolean} v whether to serve client code
+   * @return {Server|Boolean} self when setting or value when getting
+   * @api public
+   */
 
-Server.prototype.serve = function(req, res){
-  var etag = req.headers['if-none-match'];
-  if (etag) {
-    if (clientVersion == etag) {
-      debug('serve client 304');
-      res.writeHead(304);
-      res.end();
-      return;
+  serveClient(v){
+    if (!arguments.length) return this._serveClient;
+    this._serveClient = v;
+    return this;
+  }
+
+  /**
+   * Backwards compatiblity.
+   *
+   * @api public
+   */
+
+  set(key, val){
+    if ('authorization' == key && val) {
+      this.use(function(socket, next) {
+        val(socket.request, function(err, authorized) {
+          if (err) return next(new Error(err));
+          if (!authorized) return next(new Error('Not authorized'));
+          next();
+        });
+      });
+    } else if ('origins' == key && val) {
+      this.origins(val);
+    } else if ('resource' == key) {
+      this.path(val);
+    } else if (oldSettings[key] && this.eio[oldSettings[key]]) {
+      this.eio[oldSettings[key]] = val;
+    } else {
+      console.error('Option %s is not valid. Please refer to the README.', key);
+    }
+
+    return this;
+  }
+
+  /**
+   * Sets the client serving path.
+   *
+   * @param {String} v pathname
+   * @return {Server|String} self when setting or value when getting
+   * @api public
+   */
+
+  path(v){
+    if (!arguments.length) return this._path;
+    this._path = v.replace(/\/$/, '');
+    return this;
+  }
+
+  /**
+   * Sets the adapter for rooms.
+   *
+   * @param {Adapter} v pathname
+   * @return {Server|Adapter} self when setting or value when getting
+   * @api public
+   */
+
+  adapter(v){
+    if (!arguments.length) return this._adapter;
+    this._adapter = v;
+    for (var i in this.nsps) {
+      if (this.nsps.hasOwnProperty(i)) {
+        this.nsps[i].initAdapter();
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Sets the allowed origins for requests.
+   *
+   * @param {String} v origins
+   * @return {Server|Adapter} self when setting or value when getting
+   * @api public
+   */
+
+  origins(v){
+    if (!arguments.length) return this._origins;
+
+    this._origins = v;
+    return this;
+  }
+
+  /**
+   * Attaches socket.io to a server or port.
+   *
+   * @param {http.Server|Number} server or port
+   * @param {Object} options passed to engine.io
+   * @return {Server} self
+   * @api public
+   */
+
+  attach(srv, opts){
+    if ('function' == typeof srv) {
+      var msg = 'You are trying to attach socket.io to an express ' +
+      'request handler function. Please pass a http.Server instance.';
+      throw new Error(msg);
+    }
+
+    // handle a port as a string
+    if (Number(srv) == srv) {
+      srv = Number(srv);
+    }
+
+    if ('number' == typeof srv) {
+      debug('creating http server and binding to %d', srv);
+      var port = srv;
+      srv = http.Server(function(req, res){
+        res.writeHead(404);
+        res.end();
+      });
+      srv.listen(port);
+
+    }
+
+    // set engine.io path to `/socket.io`
+    opts = opts || {};
+    opts.path = opts.path || this.path();
+    // set origins verification
+    opts.allowRequest = opts.allowRequest || this.checkRequest.bind(this);
+
+    // initialize engine
+    debug('creating engine.io instance with opts %j', opts);
+    this.eio = engine.attach(srv, opts);
+
+    // attach static file serving
+    if (this._serveClient) this.attachServe(srv);
+
+    // Export http server
+    this.httpServer = srv;
+
+    // bind to engine events
+    this.bind(this.eio);
+
+    return this;
+  }
+
+  /**
+   * Attaches the static file serving.
+   *
+   * @param {Function|http.Server} srv http server
+   * @api private
+   */
+
+  attachServe(srv){
+    debug('attaching client serving req handler');
+    var url = this._path + '/socket.io.js';
+    var evs = srv.listeners('request').slice(0);
+    var self = this;
+    srv.removeAllListeners('request');
+    srv.on('request', function(req, res) {
+      if (0 === req.url.indexOf(url)) {
+        self.serve(req, res);
+      } else {
+        for (var i = 0; i < evs.length; i++) {
+          evs[i].call(srv, req, res);
+        }
+      }
+    });
+  }
+
+  /**
+   * Handles a request serving `/socket.io.js`
+   *
+   * @param {http.Request} req
+   * @param {http.Response} res
+   * @api private
+   */
+
+  serve(req, res){
+    var etag = req.headers['if-none-match'];
+    if (etag) {
+      if (clientVersion == etag) {
+        debug('serve client 304');
+        res.writeHead(304);
+        res.end();
+        return;
+      }
+    }
+
+    debug('serve client source');
+    res.setHeader('Content-Type', 'application/javascript');
+    res.setHeader('ETag', clientVersion);
+    res.writeHead(200);
+    res.end(clientSource);
+  }
+
+  /**
+   * Binds socket.io to an engine.io instance.
+   *
+   * @param {engine.Server} engine engine.io (or compatible) server
+   * @return {Server} self
+   * @api public
+   */
+
+  bind(engine){
+    this.engine = engine;
+    this.engine.on('connection', this.onconnection.bind(this));
+    return this;
+  }
+
+  /**
+   * Called with each incoming transport connection.
+   *
+   * @param {engine.Socket} conn
+   * @return {Server} self
+   * @api public
+   */
+
+  onconnection(conn){
+    debug('incoming connection with id %s', conn.id);
+    var client = new Client(this, conn);
+    client.connect('/');
+    return this;
+  }
+
+  /**
+   * Looks up a namespace.
+   *
+   * @param {String} name nsp name
+   * @param {Function} fn optional, nsp `connection` ev handler
+   * @api public
+   */
+
+  of(name, fn){
+    if (String(name)[0] !== '/') name = '/' + name;
+    
+    var nsp = this.nsps[name];
+    if (!nsp) {
+      debug('initializing namespace %s', name);
+      nsp = new Namespace(this, name);
+      this.nsps[name] = nsp;
+    }
+    if (fn) nsp.on('connect', fn);
+    return nsp;
+  }
+
+  /**
+   * Closes server connection
+   *
+   * @api public
+   */
+
+  close(){
+    for (var id in this.nsps['/'].sockets) {
+      if (this.nsps['/'].sockets.hasOwnProperty(id)) {
+        this.nsps['/'].sockets[id].onclose();
+      }
+    }
+
+    this.engine.close();
+
+    if(this.httpServer){
+      this.httpServer.close();
     }
   }
 
-  debug('serve client source');
-  res.setHeader('Content-Type', 'application/javascript');
-  res.setHeader('ETag', clientVersion);
-  res.writeHead(200);
-  res.end(clientSource);
-};
+}
 
 /**
- * Binds socket.io to an engine.io instance.
- *
- * @param {engine.Server} engine engine.io (or compatible) server
- * @return {Server} self
- * @api public
+ * Methods sharing functions
  */
-
-Server.prototype.bind = function(engine){
-  this.engine = engine;
-  this.engine.on('connection', this.onconnection.bind(this));
-  return this;
-};
-
-/**
- * Called with each incoming transport connection.
- *
- * @param {engine.Socket} conn
- * @return {Server} self
- * @api public
- */
-
-Server.prototype.onconnection = function(conn){
-  debug('incoming connection with id %s', conn.id);
-  var client = new Client(this, conn);
-  client.connect('/');
-  return this;
-};
-
-/**
- * Looks up a namespace.
- *
- * @param {String} name nsp name
- * @param {Function} fn optional, nsp `connection` ev handler
- * @api public
- */
-
-Server.prototype.of = function(name, fn){
-  if (String(name)[0] !== '/') name = '/' + name;
-  
-  var nsp = this.nsps[name];
-  if (!nsp) {
-    debug('initializing namespace %s', name);
-    nsp = new Namespace(this, name);
-    this.nsps[name] = nsp;
-  }
-  if (fn) nsp.on('connect', fn);
-  return nsp;
-};
-
-/**
- * Closes server connection
- *
- * @api public
- */
-
-Server.prototype.close = function(){
-  for (var id in this.nsps['/'].sockets) {
-    if (this.nsps['/'].sockets.hasOwnProperty(id)) {
-      this.nsps['/'].sockets[id].onclose();
-    }
-  }
-
-  this.engine.close();
-
-  if(this.httpServer){
-    this.httpServer.close();
-  }
-};
+_Server.prototype.listen = _Server.prototype.attach;
 
 /**
  * Expose main namespace (/).
  */
 
 ['on', 'to', 'in', 'use', 'emit', 'send', 'write', 'clients', 'compress'].forEach(function(fn){
-  Server.prototype[fn] = function(){
+  _Server.prototype[fn] = function(){
     var nsp = this.sockets[fn];
     return nsp.apply(this.sockets, arguments);
   };
 });
 
-Namespace.flags.forEach(function(flag){
-  Server.prototype.__defineGetter__(flag, function(){
+Namespace.flags().forEach(function(flag){
+  _Server.prototype.__defineGetter__(flag, function(){
     this.sockets.flags = this.sockets.flags || {};
     this.sockets.flags[flag] = true;
     return this;
@@ -382,4 +383,22 @@ Namespace.flags.forEach(function(flag){
  * BC with `io.listen`
  */
 
-Server.listen = Server;
+_Server.listen = _Server;
+
+/**
+ * function Server 
+ */
+
+function Server(srv, opts){
+  if (!(this instanceof _Server)) return new _Server(srv, opts);
+}
+
+Server.prototype = _Server.prototype;
+
+/**
+ * Module exports.
+ */
+
+module.exports = Server;
+
+

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -1,3 +1,4 @@
+'use strict';
 
 /**
  * Module dependencies.

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -11,28 +11,13 @@ var debug = require('debug')('socket.io:namespace');
 var hasBin = require('has-binary');
 
 /**
- * Module exports.
- */
-
-module.exports = exports = Namespace;
-
-/**
  * Blacklisted events.
  */
 
-exports.events = [
+var exportsEvents = [
   'connect',    // for symmetry with client
   'connection',
   'newListener'
-];
-
-/**
- * Flags.
- */
-
-exports.flags = [
-  'json',
-  'volatile'
 ];
 
 /**
@@ -49,27 +34,226 @@ var emit = Emitter.prototype.emit;
  * @api private
  */
 
-function Namespace(server, name){
-  this.name = name;
-  this.server = server;
-  this.sockets = {};
-  this.connected = {};
-  this.fns = [];
-  this.ids = 0;
-  this.initAdapter();
+class Namespace extends Emitter {
+  constructor(server, name){
+    super();  
+    this.name = name;
+    this.server = server;
+    this.sockets = {};
+    this.connected = {};
+    this.fns = [];
+    this.ids = 0;
+    this.initAdapter();
+  }	
+
+  /**
+   * Flags.
+   */
+
+  static flags(){
+	  return ['json', 'volatile'];
+  }
+
+  /**
+   * Initializes the `Adapter` for this nsp.
+   * Run upon changing adapter by `Server#adapter`
+   * in addition to the constructor.
+   *
+   * @api private
+   */
+
+  initAdapter(){
+    this.adapter = new (this.server.adapter())(this);
+  };
+
+  /**
+   * Sets up namespace middleware.
+   *
+   * @return {Namespace} self
+   * @api public
+   */
+
+  use(fn){
+    this.fns.push(fn);
+    return this;
+  }
+
+  /**
+   * Executes the middleware for an incoming client.
+   *
+   * @param {Socket} socket that will get added
+   * @param {Function} fn last fn call in the middleware
+   * @api private
+   */
+
+  run(socket, fn){
+    var fns = this.fns.slice(0);
+    if (!fns.length) return fn(null);
+
+    function run(i){
+      fns[i](socket, function(err){
+        // upon error, short-circuit
+        if (err) return fn(err);
+
+        // if no middleware left, summon callback
+        if (!fns[i + 1]) return fn(null);
+
+        // go on to next
+        run(i + 1);
+      });
+    }
+
+    run(0);
+  }
+
+  /**
+   * Targets a room when emitting.
+   *
+   * @param {String} name
+   * @return {Namespace} self
+   * @api public
+   */
+
+  in(name){
+    this.rooms = this.rooms || [];
+    if (!~this.rooms.indexOf(name)) this.rooms.push(name);
+    return this;
+  }
+
+  /**
+   * Adds a new client.
+   *
+   * @return {Socket}
+   * @api private
+   */
+
+  add(client, query, fn){
+    debug('adding socket to nsp %s', this.name);
+    var socket = new Socket(this, client, query);
+    var self = this;
+    this.run(socket, function(err){
+      process.nextTick(function(){
+        if ('open' == client.conn.readyState) {
+          if (err) return socket.error(err.data || err.message);
+
+          // track socket
+          self.sockets[socket.id] = socket;
+
+          // it's paramount that the internal `onconnect` logic
+          // fires before user-set events to prevent state order
+          // violations (such as a disconnection before the connection
+          // logic is complete)
+          socket.onconnect();
+          if (fn) fn();
+
+          // fire user-set events
+          self.emit('connect', socket);
+          self.emit('connection', socket);
+        } else {
+          debug('next called after client was closed - ignoring socket');
+        }
+      });
+    });
+    return socket;
+  }
+
+  /**
+   * Removes a client. Called by each `Socket`.
+   *
+   * @api private
+   */
+
+  remove(socket){
+    if (this.sockets.hasOwnProperty(socket.id)) {
+      delete this.sockets[socket.id];
+    } else {
+      debug('ignoring remove for %s', socket.id);
+    }
+  }
+
+  /**
+   * Emits to all clients.
+   *
+   * @return {Namespace} self
+   * @api public
+   */
+
+  emit(ev){
+    if (~exportsEvents.indexOf(ev)) {
+      emit.apply(this, arguments);
+    } else {
+      // set up packet object
+      var args = Array.prototype.slice.call(arguments);
+      var parserType = parser.EVENT; // default
+      if (hasBin(args)) { parserType = parser.BINARY_EVENT; } // binary
+
+      var packet = { type: parserType, data: args };
+
+      if ('function' == typeof args[args.length - 1]) {
+        throw new Error('Callbacks are not supported when broadcasting');
+      }
+
+      this.adapter.broadcast(packet, {
+        rooms: this.rooms,
+        flags: this.flags
+      });
+
+      delete this.rooms;
+      delete this.flags;
+    }
+    return this;
+  }
+
+  /**
+   * Sends a `message` event to all clients.
+   *
+   * @return {Namespace} self
+   * @api public
+   */
+
+  write(){
+    var args = Array.prototype.slice.call(arguments);
+    args.unshift('message');
+    this.emit.apply(this, args);
+    return this;
+  }
+
+  /**
+   * Gets a list of clients.
+   *
+   * @return {Namespace} self
+   * @api public
+   */
+
+  clients(fn){
+    this.adapter.clients(this.rooms, fn);
+    // delete rooms flag for scenario:
+    // .in('room').clients() (GH-1978)
+    delete this.rooms;
+    return this;
+  }
+
+  /**
+   * Sets the compress flag.
+   *
+   * @param {Boolean} compress if `true`, compresses the sending data
+   * @return {Socket} self
+   * @api public
+   */
+
+  compress(compress){
+    this.flags = this.flags || {};
+    this.flags.compress = compress;
+    return this;
+  }
+
 }
-
-/**
- * Inherits from `EventEmitter`.
- */
-
-Namespace.prototype.__proto__ = Emitter.prototype;
 
 /**
  * Apply flags from `Socket`.
  */
 
-exports.flags.forEach(function(flag){
+Namespace.flags().forEach(function(flag){
   Namespace.prototype.__defineGetter__(flag, function(){
     this.flags = this.flags || {};
     this.flags[flag] = true;
@@ -78,196 +262,15 @@ exports.flags.forEach(function(flag){
 });
 
 /**
- * Initializes the `Adapter` for this nsp.
- * Run upon changing adapter by `Server#adapter`
- * in addition to the constructor.
- *
- * @api private
+ * Methods sharing functions
  */
 
-Namespace.prototype.initAdapter = function(){
-  this.adapter = new (this.server.adapter())(this);
-};
+Namespace.prototype.to = Namespace.prototype.in;
+
+Namespace.prototype.send = Namespace.prototype.write;
 
 /**
- * Sets up namespace middleware.
- *
- * @return {Namespace} self
- * @api public
+ * Module exports.
  */
 
-Namespace.prototype.use = function(fn){
-  this.fns.push(fn);
-  return this;
-};
-
-/**
- * Executes the middleware for an incoming client.
- *
- * @param {Socket} socket that will get added
- * @param {Function} fn last fn call in the middleware
- * @api private
- */
-
-Namespace.prototype.run = function(socket, fn){
-  var fns = this.fns.slice(0);
-  if (!fns.length) return fn(null);
-
-  function run(i){
-    fns[i](socket, function(err){
-      // upon error, short-circuit
-      if (err) return fn(err);
-
-      // if no middleware left, summon callback
-      if (!fns[i + 1]) return fn(null);
-
-      // go on to next
-      run(i + 1);
-    });
-  }
-
-  run(0);
-};
-
-/**
- * Targets a room when emitting.
- *
- * @param {String} name
- * @return {Namespace} self
- * @api public
- */
-
-Namespace.prototype.to =
-Namespace.prototype['in'] = function(name){
-  this.rooms = this.rooms || [];
-  if (!~this.rooms.indexOf(name)) this.rooms.push(name);
-  return this;
-};
-
-/**
- * Adds a new client.
- *
- * @return {Socket}
- * @api private
- */
-
-Namespace.prototype.add = function(client, query, fn){
-  debug('adding socket to nsp %s', this.name);
-  var socket = new Socket(this, client, query);
-  var self = this;
-  this.run(socket, function(err){
-    process.nextTick(function(){
-      if ('open' == client.conn.readyState) {
-        if (err) return socket.error(err.data || err.message);
-
-        // track socket
-        self.sockets[socket.id] = socket;
-
-        // it's paramount that the internal `onconnect` logic
-        // fires before user-set events to prevent state order
-        // violations (such as a disconnection before the connection
-        // logic is complete)
-        socket.onconnect();
-        if (fn) fn();
-
-        // fire user-set events
-        self.emit('connect', socket);
-        self.emit('connection', socket);
-      } else {
-        debug('next called after client was closed - ignoring socket');
-      }
-    });
-  });
-  return socket;
-};
-
-/**
- * Removes a client. Called by each `Socket`.
- *
- * @api private
- */
-
-Namespace.prototype.remove = function(socket){
-  if (this.sockets.hasOwnProperty(socket.id)) {
-    delete this.sockets[socket.id];
-  } else {
-    debug('ignoring remove for %s', socket.id);
-  }
-};
-
-/**
- * Emits to all clients.
- *
- * @return {Namespace} self
- * @api public
- */
-
-Namespace.prototype.emit = function(ev){
-  if (~exports.events.indexOf(ev)) {
-    emit.apply(this, arguments);
-  } else {
-    // set up packet object
-    var args = Array.prototype.slice.call(arguments);
-    var parserType = parser.EVENT; // default
-    if (hasBin(args)) { parserType = parser.BINARY_EVENT; } // binary
-
-    var packet = { type: parserType, data: args };
-
-    if ('function' == typeof args[args.length - 1]) {
-      throw new Error('Callbacks are not supported when broadcasting');
-    }
-
-    this.adapter.broadcast(packet, {
-      rooms: this.rooms,
-      flags: this.flags
-    });
-
-    delete this.rooms;
-    delete this.flags;
-  }
-  return this;
-};
-
-/**
- * Sends a `message` event to all clients.
- *
- * @return {Namespace} self
- * @api public
- */
-
-Namespace.prototype.send =
-Namespace.prototype.write = function(){
-  var args = Array.prototype.slice.call(arguments);
-  args.unshift('message');
-  this.emit.apply(this, args);
-  return this;
-};
-
-/**
- * Gets a list of clients.
- *
- * @return {Namespace} self
- * @api public
- */
-
-Namespace.prototype.clients = function(fn){
-  this.adapter.clients(this.rooms, fn);
-  // delete rooms flag for scenario:
-  // .in('room').clients() (GH-1978)
-  delete this.rooms;
-  return this;
-};
-
-/**
- * Sets the compress flag.
- *
- * @param {Boolean} compress if `true`, compresses the sending data
- * @return {Socket} self
- * @api public
- */
-
-Namespace.prototype.compress = function(compress){
-  this.flags = this.flags || {};
-  this.flags.compress = compress;
-  return this;
-};
+module.exports = Namespace;

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -21,6 +21,15 @@ var exportsEvents = [
 ];
 
 /**
+ * Flags.
+ */
+
+var exportsFlags = [
+  'json', 
+  'volatile'
+];
+
+/**
  * `EventEmitter#emit` reference.
  */
 
@@ -45,14 +54,10 @@ class Namespace extends Emitter {
     this.ids = 0;
     this.initAdapter();
   }	
-
-  /**
-   * Flags.
-   */
-
-  static flags(){
-	  return ['json', 'volatile'];
-  }
+  
+  static flags() {
+    return exportsFlags;
+  }  
 
   /**
    * Initializes the `Adapter` for this nsp.
@@ -253,7 +258,7 @@ class Namespace extends Emitter {
  * Apply flags from `Socket`.
  */
 
-Namespace.flags().forEach(function(flag){
+exportsFlags.forEach(function(flag){
   Namespace.prototype.__defineGetter__(flag, function(){
     this.flags = this.flags || {};
     this.flags[flag] = true;
@@ -266,7 +271,6 @@ Namespace.flags().forEach(function(flag){
  */
 
 Namespace.prototype.to = Namespace.prototype.in;
-
 Namespace.prototype.send = Namespace.prototype.write;
 
 /**

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -1,3 +1,4 @@
+'use strict';
 
 /**
  * Module dependencies.
@@ -10,18 +11,12 @@ var debug = require('debug')('socket.io:socket');
 var hasBin = require('has-binary');
 
 /**
- * Module exports.
- */
-
-module.exports = exports = Socket;
-
-/**
  * Blacklisted events.
  *
  * @api public
  */
 
-exports.events = [
+var exportsEvents = [
   'error',
   'connect',
   'disconnect',
@@ -55,25 +50,405 @@ var emit = Emitter.prototype.emit;
  * @api public
  */
 
-function Socket(nsp, client, query){
-  this.nsp = nsp;
-  this.server = nsp.server;
-  this.adapter = this.nsp.adapter;
-  this.id = nsp.name !== '/' ? nsp.name + '#' + client.id : client.id;
-  this.client = client;
-  this.conn = client.conn;
-  this.rooms = {};
-  this.acks = {};
-  this.connected = true;
-  this.disconnected = false;
-  this.handshake = this.buildHandshake(query);
+class Socket extends Emitter {
+  constructor(nsp, client, query){
+    super();
+    this.nsp = nsp;
+    this.server = nsp.server;
+    this.adapter = this.nsp.adapter;
+    this.id = nsp.name !== '/' ? nsp.name + '#' + client.id : client.id;
+    this.client = client;
+    this.conn = client.conn;
+    this.rooms = {};
+    this.acks = {};
+    this.connected = true;
+    this.disconnected = false;
+    this.handshake = this.buildHandshake(query);
+  }
+
+  /**
+   * Builds the `handshake` BC object
+   *
+   * @api private
+   */
+
+  buildHandshake(query){
+    var self = this;
+    function buildQuery(){
+      var requestQuery = url.parse(self.request.url, true).query;
+      //if socket-specific query exist, replace query strings in requestQuery
+      if(query){
+        query.t = requestQuery.t;
+        query.EIO = requestQuery.EIO;
+        query.transport = requestQuery.transport;
+        return query;
+      }
+      return requestQuery || {};
+    }
+    return {
+      headers: this.request.headers,
+      time: (new Date) + '',
+      address: this.conn.remoteAddress,
+      xdomain: !!this.request.headers.origin,
+      secure: !!this.request.connection.encrypted,
+      issued: +(new Date),
+      url: this.request.url,
+      query: buildQuery()
+    };
+  }
+
+  /**
+   * Emits to this client.
+   *
+   * @return {Socket} self
+   * @api public
+   */
+
+  emit(ev){
+    if (~exportsEvents.indexOf(ev)) {
+      emit.apply(this, arguments);
+    } else {
+      var args = Array.prototype.slice.call(arguments);
+      var packet = {};
+      packet.type = hasBin(args) ? parser.BINARY_EVENT : parser.EVENT;
+      packet.data = args;
+      var flags = this.flags || {};
+
+      // access last argument to see if it's an ACK callback
+      if ('function' == typeof args[args.length - 1]) {
+        if (this._rooms || flags.broadcast) {
+          throw new Error('Callbacks are not supported when broadcasting');
+        }
+
+        debug('emitting packet with ack id %d', this.nsp.ids);
+        this.acks[this.nsp.ids] = args.pop();
+        packet.id = this.nsp.ids++;
+      }
+
+      if (this._rooms || flags.broadcast) {
+        this.adapter.broadcast(packet, {
+          except: [this.id],
+          rooms: this._rooms,
+          flags: flags
+        });
+      } else {
+        // dispatch packet
+        this.packet(packet, {
+          volatile: flags.volatile,
+          compress: flags.compress
+        });
+      }
+
+      // reset flags
+      delete this._rooms;
+      delete this.flags;
+    }
+    return this;
+  }
+
+  /**
+   * Targets a room when broadcasting.
+   *
+   * @param {String} name
+   * @return {Socket} self
+   * @api public
+   */
+
+  in(name){
+    this._rooms = this._rooms || [];
+    if (!~this._rooms.indexOf(name)) this._rooms.push(name);
+    return this;
+  }
+
+  /**
+   * Sends a `message` event.
+   *
+   * @return {Socket} self
+   * @api public
+   */
+
+  send(){
+    var args = Array.prototype.slice.call(arguments);
+    args.unshift('message');
+    this.emit.apply(this, args);
+    return this;
+  }
+
+  /**
+   * Writes a packet.
+   *
+   * @param {Object} packet object
+   * @param {Object} opts options
+   * @api private
+   */
+
+  packet(packet, opts){
+    packet.nsp = this.nsp.name;
+    opts = opts || {};
+    opts.compress = false !== opts.compress;
+    this.client.packet(packet, opts);
+  }
+
+  /**
+   * Joins a room.
+   *
+   * @param {String} room
+   * @param {Function} fn optional, callback
+   * @return {Socket} self
+   * @api private
+   */
+
+  join(room, fn){
+    debug('joining room %s', room);
+    var self = this;
+    if (this.rooms.hasOwnProperty(room)) {
+      fn && fn(null);
+      return this;
+    }
+    this.adapter.add(this.id, room, function(err){
+      if (err) return fn && fn(err);
+      debug('joined room %s', room);
+      self.rooms[room] = room;
+      fn && fn(null);
+    });
+    return this;
+  };
+
+  /**
+   * Leaves a room.
+   *
+   * @param {String} room
+   * @param {Function} fn optional, callback
+   * @return {Socket} self
+   * @api private
+   */
+
+  leave(room, fn){
+    debug('leave room %s', room);
+    var self = this;
+    this.adapter.del(this.id, room, function(err){
+      if (err) return fn && fn(err);
+      debug('left room %s', room);
+      delete self.rooms[room];
+      fn && fn(null);
+    });
+    return this;
+  }
+
+  /**
+   * Leave all rooms.
+   *
+   * @api private
+   */
+
+  leaveAll(){
+    this.adapter.delAll(this.id);
+    this.rooms = {};
+  }
+
+  /**
+   * Called by `Namespace` upon succesful
+   * middleware execution (ie: authorization).
+   *
+   * @api private
+   */
+
+  onconnect(){
+    debug('socket connected - writing packet');
+    this.nsp.connected[this.id] = this;
+    this.join(this.id);
+    this.packet({ type: parser.CONNECT });
+  }
+
+  /**
+   * Called with each packet. Called by `Client`.
+   *
+   * @param {Object} packet
+   * @api private
+   */
+
+  onpacket(packet){
+    debug('got packet %j', packet);
+    switch (packet.type) {
+      case parser.EVENT:
+        this.onevent(packet);
+        break;
+
+      case parser.BINARY_EVENT:
+        this.onevent(packet);
+        break;
+
+      case parser.ACK:
+        this.onack(packet);
+        break;
+
+      case parser.BINARY_ACK:
+        this.onack(packet);
+        break;
+
+      case parser.DISCONNECT:
+        this.ondisconnect();
+        break;
+
+      case parser.ERROR:
+        this.emit('error', packet.data);
+    }
+  }
+
+  /**
+   * Called upon event packet.
+   *
+   * @param {Object} packet object
+   * @api private
+   */
+
+  onevent(packet){
+    var args = packet.data || [];
+    debug('emitting event %j', args);
+
+    if (null != packet.id) {
+      debug('attaching ack callback to event');
+      args.push(this.ack(packet.id));
+    }
+
+    emit.apply(this, args);
+  }
+
+  /**
+   * Produces an ack callback to emit with an event.
+   *
+   * @param {Number} id packet id
+   * @api private
+   */
+
+  ack(id){
+    var self = this;
+    var sent = false;
+    return function(){
+      // prevent double callbacks
+      if (sent) return;
+      var args = Array.prototype.slice.call(arguments);
+      debug('sending ack %j', args);
+
+      var type = hasBin(args) ? parser.BINARY_ACK : parser.ACK;
+      self.packet({
+        id: id,
+        type: type,
+        data: args
+      });
+
+      sent = true;
+    };
+  }
+
+  /**
+   * Called upon ack packet.
+   *
+   * @api private
+   */
+
+  onack(packet){
+    var ack = this.acks[packet.id];
+    if ('function' == typeof ack) {
+      debug('calling ack %s with %j', packet.id, packet.data);
+      ack.apply(this, packet.data);
+      delete this.acks[packet.id];
+    } else {
+      debug('bad ack %s', packet.id);
+    }
+  }
+
+  /**
+   * Called upon client disconnect packet.
+   *
+   * @api private
+   */
+
+  ondisconnect(){
+    debug('got disconnect packet');
+    this.onclose('client namespace disconnect');
+  };
+
+  /**
+   * Handles a client error.
+   *
+   * @api private
+   */
+
+  onerror(err){
+    if (this.listeners('error').length) {
+      this.emit('error', err);
+    } else {
+      console.error('Missing error handler on `socket`.');
+      console.error(err.stack);
+    }
+  }
+
+  /**
+   * Called upon closing. Called by `Client`.
+   *
+   * @param {String} reason
+   * @throw {Error} optional error object
+   * @api private
+   */
+
+  onclose(reason){
+    if (!this.connected) return this;
+    debug('closing socket - reason %s', reason);
+    this.leaveAll();
+    this.nsp.remove(this);
+    this.client.remove(this);
+    this.connected = false;
+    this.disconnected = true;
+    delete this.nsp.connected[this.id];
+    this.emit('disconnect', reason);
+  }
+
+  /**
+   * Produces an `error` packet.
+   *
+   * @param {Object} err error object
+   * @api private
+   */
+
+  error(err){
+    this.packet({ type: parser.ERROR, data: err });
+  }
+
+  /**
+   * Disconnects this client.
+   *
+   * @param {Boolean} close if `true`, closes the underlying connection
+   * @return {Socket} self
+   * @api public
+   */
+
+  disconnect(close){
+    if (!this.connected) return this;
+    if (close) {
+      this.client.disconnect();
+    } else {
+      this.packet({ type: parser.DISCONNECT });
+      this.onclose('server namespace disconnect');
+    }
+    return this;
+  }
+
+  /**
+   * Sets the compress flag.
+   *
+   * @param {Boolean} compress if `true`, compresses the sending data
+   * @return {Socket} self
+   * @api public
+   */
+
+  compress(compress){
+    this.flags = this.flags || {};
+    this.flags.compress = compress;
+    return this;
+  }
+  
 }
-
-/**
- * Inherits from `EventEmitter`.
- */
-
-Socket.prototype.__proto__ = Emitter.prototype;
 
 /**
  * Apply flags from `Socket`.
@@ -98,385 +473,15 @@ Socket.prototype.__defineGetter__('request', function(){
 });
 
 /**
- * Builds the `handshake` BC object
- *
- * @api private
+ * Methods sharing functions
  */
 
-Socket.prototype.buildHandshake = function(query){
-  var self = this;
-  function buildQuery(){
-    var requestQuery = url.parse(self.request.url, true).query;
-    //if socket-specific query exist, replace query strings in requestQuery
-    if(query){
-      query.t = requestQuery.t;
-      query.EIO = requestQuery.EIO;
-      query.transport = requestQuery.transport;
-      return query;
-    }
-    return requestQuery || {};
-  }
-  return {
-    headers: this.request.headers,
-    time: (new Date) + '',
-    address: this.conn.remoteAddress,
-    xdomain: !!this.request.headers.origin,
-    secure: !!this.request.connection.encrypted,
-    issued: +(new Date),
-    url: this.request.url,
-    query: buildQuery()
-  };
-};
+Socket.prototype.to = Socket.prototype.in;
+Socket.prototype.write = Socket.prototype.send;
 
 /**
- * Emits to this client.
- *
- * @return {Socket} self
- * @api public
+ * Module exports.
  */
 
-Socket.prototype.emit = function(ev){
-  if (~exports.events.indexOf(ev)) {
-    emit.apply(this, arguments);
-  } else {
-    var args = Array.prototype.slice.call(arguments);
-    var packet = {};
-    packet.type = hasBin(args) ? parser.BINARY_EVENT : parser.EVENT;
-    packet.data = args;
-    var flags = this.flags || {};
+module.exports = exports = Socket;
 
-    // access last argument to see if it's an ACK callback
-    if ('function' == typeof args[args.length - 1]) {
-      if (this._rooms || flags.broadcast) {
-        throw new Error('Callbacks are not supported when broadcasting');
-      }
-
-      debug('emitting packet with ack id %d', this.nsp.ids);
-      this.acks[this.nsp.ids] = args.pop();
-      packet.id = this.nsp.ids++;
-    }
-
-    if (this._rooms || flags.broadcast) {
-      this.adapter.broadcast(packet, {
-        except: [this.id],
-        rooms: this._rooms,
-        flags: flags
-      });
-    } else {
-      // dispatch packet
-      this.packet(packet, {
-        volatile: flags.volatile,
-        compress: flags.compress
-      });
-    }
-
-    // reset flags
-    delete this._rooms;
-    delete this.flags;
-  }
-  return this;
-};
-
-/**
- * Targets a room when broadcasting.
- *
- * @param {String} name
- * @return {Socket} self
- * @api public
- */
-
-Socket.prototype.to =
-Socket.prototype.in = function(name){
-  this._rooms = this._rooms || [];
-  if (!~this._rooms.indexOf(name)) this._rooms.push(name);
-  return this;
-};
-
-/**
- * Sends a `message` event.
- *
- * @return {Socket} self
- * @api public
- */
-
-Socket.prototype.send =
-Socket.prototype.write = function(){
-  var args = Array.prototype.slice.call(arguments);
-  args.unshift('message');
-  this.emit.apply(this, args);
-  return this;
-};
-
-/**
- * Writes a packet.
- *
- * @param {Object} packet object
- * @param {Object} opts options
- * @api private
- */
-
-Socket.prototype.packet = function(packet, opts){
-  packet.nsp = this.nsp.name;
-  opts = opts || {};
-  opts.compress = false !== opts.compress;
-  this.client.packet(packet, opts);
-};
-
-/**
- * Joins a room.
- *
- * @param {String} room
- * @param {Function} fn optional, callback
- * @return {Socket} self
- * @api private
- */
-
-Socket.prototype.join = function(room, fn){
-  debug('joining room %s', room);
-  var self = this;
-  if (this.rooms.hasOwnProperty(room)) {
-    fn && fn(null);
-    return this;
-  }
-  this.adapter.add(this.id, room, function(err){
-    if (err) return fn && fn(err);
-    debug('joined room %s', room);
-    self.rooms[room] = room;
-    fn && fn(null);
-  });
-  return this;
-};
-
-/**
- * Leaves a room.
- *
- * @param {String} room
- * @param {Function} fn optional, callback
- * @return {Socket} self
- * @api private
- */
-
-Socket.prototype.leave = function(room, fn){
-  debug('leave room %s', room);
-  var self = this;
-  this.adapter.del(this.id, room, function(err){
-    if (err) return fn && fn(err);
-    debug('left room %s', room);
-    delete self.rooms[room];
-    fn && fn(null);
-  });
-  return this;
-};
-
-/**
- * Leave all rooms.
- *
- * @api private
- */
-
-Socket.prototype.leaveAll = function(){
-  this.adapter.delAll(this.id);
-  this.rooms = {};
-};
-
-/**
- * Called by `Namespace` upon succesful
- * middleware execution (ie: authorization).
- *
- * @api private
- */
-
-Socket.prototype.onconnect = function(){
-  debug('socket connected - writing packet');
-  this.nsp.connected[this.id] = this;
-  this.join(this.id);
-  this.packet({ type: parser.CONNECT });
-};
-
-/**
- * Called with each packet. Called by `Client`.
- *
- * @param {Object} packet
- * @api private
- */
-
-Socket.prototype.onpacket = function(packet){
-  debug('got packet %j', packet);
-  switch (packet.type) {
-    case parser.EVENT:
-      this.onevent(packet);
-      break;
-
-    case parser.BINARY_EVENT:
-      this.onevent(packet);
-      break;
-
-    case parser.ACK:
-      this.onack(packet);
-      break;
-
-    case parser.BINARY_ACK:
-      this.onack(packet);
-      break;
-
-    case parser.DISCONNECT:
-      this.ondisconnect();
-      break;
-
-    case parser.ERROR:
-      this.emit('error', packet.data);
-  }
-};
-
-/**
- * Called upon event packet.
- *
- * @param {Object} packet object
- * @api private
- */
-
-Socket.prototype.onevent = function(packet){
-  var args = packet.data || [];
-  debug('emitting event %j', args);
-
-  if (null != packet.id) {
-    debug('attaching ack callback to event');
-    args.push(this.ack(packet.id));
-  }
-
-  emit.apply(this, args);
-};
-
-/**
- * Produces an ack callback to emit with an event.
- *
- * @param {Number} id packet id
- * @api private
- */
-
-Socket.prototype.ack = function(id){
-  var self = this;
-  var sent = false;
-  return function(){
-    // prevent double callbacks
-    if (sent) return;
-    var args = Array.prototype.slice.call(arguments);
-    debug('sending ack %j', args);
-
-    var type = hasBin(args) ? parser.BINARY_ACK : parser.ACK;
-    self.packet({
-      id: id,
-      type: type,
-      data: args
-    });
-
-    sent = true;
-  };
-};
-
-/**
- * Called upon ack packet.
- *
- * @api private
- */
-
-Socket.prototype.onack = function(packet){
-  var ack = this.acks[packet.id];
-  if ('function' == typeof ack) {
-    debug('calling ack %s with %j', packet.id, packet.data);
-    ack.apply(this, packet.data);
-    delete this.acks[packet.id];
-  } else {
-    debug('bad ack %s', packet.id);
-  }
-};
-
-/**
- * Called upon client disconnect packet.
- *
- * @api private
- */
-
-Socket.prototype.ondisconnect = function(){
-  debug('got disconnect packet');
-  this.onclose('client namespace disconnect');
-};
-
-/**
- * Handles a client error.
- *
- * @api private
- */
-
-Socket.prototype.onerror = function(err){
-  if (this.listeners('error').length) {
-    this.emit('error', err);
-  } else {
-    console.error('Missing error handler on `socket`.');
-    console.error(err.stack);
-  }
-};
-
-/**
- * Called upon closing. Called by `Client`.
- *
- * @param {String} reason
- * @throw {Error} optional error object
- * @api private
- */
-
-Socket.prototype.onclose = function(reason){
-  if (!this.connected) return this;
-  debug('closing socket - reason %s', reason);
-  this.leaveAll();
-  this.nsp.remove(this);
-  this.client.remove(this);
-  this.connected = false;
-  this.disconnected = true;
-  delete this.nsp.connected[this.id];
-  this.emit('disconnect', reason);
-};
-
-/**
- * Produces an `error` packet.
- *
- * @param {Object} err error object
- * @api private
- */
-
-Socket.prototype.error = function(err){
-  this.packet({ type: parser.ERROR, data: err });
-};
-
-/**
- * Disconnects this client.
- *
- * @param {Boolean} close if `true`, closes the underlying connection
- * @return {Socket} self
- * @api public
- */
-
-Socket.prototype.disconnect = function(close){
-  if (!this.connected) return this;
-  if (close) {
-    this.client.disconnect();
-  } else {
-    this.packet({ type: parser.DISCONNECT });
-    this.onclose('server namespace disconnect');
-  }
-  return this;
-};
-
-/**
- * Sets the compress flag.
- *
- * @param {Boolean} compress if `true`, compresses the sending data
- * @return {Socket} self
- * @api public
- */
-
-Socket.prototype.compress = function(compress){
-  this.flags = this.flags || {};
-  this.flags.compress = compress;
-  return this;
-};


### PR DESCRIPTION
Hi,

In my PhD research, I am using socket.io in some experiments.

As a result, I detected the existence of 4 main "classes" in the current codebase (Namespace, Client, Server, Socket).

So, I decided to rewrite this code to follow the new syntax for classes provided by ECMAScript 2016, which I think is much more readable. All changes are just syntactical. I was also very careful to preserve the code style.
Finally, all tests are green in the migrated code.

Do you think it is worth to integrate these changes to the project?

Thank you
