### PR TITLE
Avoid swallowing exceptions thrown by user event handlers

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -191,7 +191,9 @@ Client.prototype.ondecoded = function(packet) {
   } else {
     var socket = this.nsps[packet.nsp];
     if (socket) {
-      socket.onpacket(packet);
+      process.nextTick(function() {
+        socket.onpacket(packet);
+      });
     } else {
       debug('no socket for namespace %s', packet.nsp);
     }


### PR DESCRIPTION
Currently these are caught by socket.io and treated as client errors. See https://github.com/socketio/socket.io/issues/2544#issuecomment-247599752