### PR TITLE
FIX Flaky test: Clean up a clientSocket

### DIFF
--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -399,7 +399,7 @@ describe('socket.io', function(){
       var net    = require('net');
       var server = net.createServer();
 
-      var clientSocket = ioc('ws://0.0.0.0:' + PORT);
+      var clientSocket = ioc('ws://0.0.0.0:' + PORT, { reconnection: false });
 
       clientSocket.on('disconnect', function init() {
         expect(Object.keys(sio.nsps['/'].sockets).length).to.equal(0);


### PR DESCRIPTION
Test 'should be able to close sio sending a port' defined a clientSocket
but didn't set 'reconnection: false'.

Now, the default behavior of a clientSocket is 'reconnection: true'.
As a result, the clientSocket was "leaked" from the test case
and seemed to intermittently connect to the servers in subsequent
test cases. This would cause other tests to timeout unexpectedly.

It's not clear to me why this would happen, since the test case
assigns a unique port number to the socket.
However, if you go into socket.io-client and assign and log
unique IDs to each socket, then you'll see that this clientSocket
shows up in other test cases if the reconnectionDelay strikes
unluckily.

A better fix might be to close the socket before exiting the test, but I'm not 100% sure how to do that since I don't see a call to done() anywhere.
