### PR TITLE
Bump engine.io to 1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "engine.io": "1.7.1",
+    "engine.io": "1.7.2",
     "socket.io-parser": "2.3.0",
     "socket.io-client": "1.5.0",
     "socket.io-adapter": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "engine.io": "1.7.0",
+    "engine.io": "1.7.1",
     "socket.io-parser": "2.3.0",
     "socket.io-client": "1.5.0",
     "socket.io-adapter": "0.4.0",

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -1647,11 +1647,10 @@ describe('socket.io', function(){
         var clientSocket = client(srv, { reconnectionAttempts: 10, reconnectionDelay: 100 });
         clientSocket.once('connect', function(){
           srv.close(function(){
-            srv.listen(port, function(){
-              clientSocket.on('reconnect', function(){
-                clientSocket.emit('ev', 'payload');
-              });
+            clientSocket.on('reconnect', function(){
+              clientSocket.emit('ev', 'payload');
             });
+            sio.listen(port);
           });
         });
       });


### PR DESCRIPTION
Tests seem to fail due to https://github.com/socketio/engine.io/pull/393.