### PR TITLE
Don't drop query variables on handshake

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -110,13 +110,7 @@ Socket.prototype.buildHandshake = function(query){
   function buildQuery(){
     var requestQuery = url.parse(self.request.url, true).query;
     //if socket-specific query exist, replace query strings in requestQuery
-    if(query){
-      query.t = requestQuery.t;
-      query.EIO = requestQuery.EIO;
-      query.transport = requestQuery.transport;
-      return query;
-    }
-    return requestQuery || {};
+    return Object.assign({}, query, requestQuery);
   }
   return {
     headers: this.request.headers,

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -8,6 +8,7 @@ var parser = require('socket.io-parser');
 var url = require('url');
 var debug = require('debug')('socket.io:socket');
 var hasBin = require('has-binary');
+var assign = require('object-assign');
 
 /**
  * Module exports.
@@ -110,7 +111,7 @@ Socket.prototype.buildHandshake = function(query){
   function buildQuery(){
     var requestQuery = url.parse(self.request.url, true).query;
     //if socket-specific query exist, replace query strings in requestQuery
-    return Object.assign({}, query, requestQuery);
+    return assign({}, query, requestQuery);
   }
   return {
     headers: this.request.headers,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "debug": "2.2.0",
     "engine.io": "1.7.2",
     "has-binary": "0.1.7",
-    "object-assign": "^4.1.0",
+    "object-assign": "4.1.0",
     "socket.io-adapter": "0.4.0",
     "socket.io-client": "1.5.1",
     "socket.io-parser": "2.3.1"

--- a/package.json
+++ b/package.json
@@ -24,12 +24,13 @@
     "test": "gulp test"
   },
   "dependencies": {
+    "debug": "2.2.0",
     "engine.io": "1.7.2",
-    "socket.io-parser": "2.3.1",
-    "socket.io-client": "1.5.1",
-    "socket.io-adapter": "0.4.0",
     "has-binary": "0.1.7",
-    "debug": "2.2.0"
+    "object-assign": "^4.1.0",
+    "socket.io-adapter": "0.4.0",
+    "socket.io-client": "1.5.1",
+    "socket.io-parser": "2.3.1"
   },
   "devDependencies": {
     "babel-preset-es2015": "6.3.13",


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
Right now parameters passed during handshake, such as tokens, are being dropped.

### New behaviour
Parameters are preserved as intended

### Other information (e.g. related issues)
Fixes #2712


