### PR TITLE
Feature - added support for Server#close(callback)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -198,9 +198,14 @@ server.listen(3000);
 
   For other available methods, see `Namespace` below.
 
-### Server#close
+### Server#close([fn:Function])
 
-  Closes socket.io server
+  Closes socket.io server.
+  
+  The optional `fn` is passed to the `server.close([callback])` method of the 
+  core `net` module and is called on error or when all connections are closed. 
+  The callback is expected to implement the common single argument `err` 
+  signature (if any).
 
   ```js
   var Server = require('socket.io');

--- a/lib/index.js
+++ b/lib/index.js
@@ -352,6 +352,7 @@ Server.prototype.of = function(name, fn){
 /**
  * Closes server connection
  *
+ * @param {Function} [fn] optional, called as `fn([err])` on error OR all conns closed 
  * @api public
  */
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -364,7 +364,7 @@ Server.prototype.close = function(fn){
 
   this.engine.close();
 
-  if(this.httpServer) {
+  if (this.httpServer) {
     this.httpServer.close(fn);
   } else {
     fn && fn();

--- a/lib/index.js
+++ b/lib/index.js
@@ -355,7 +355,7 @@ Server.prototype.of = function(name, fn){
  * @api public
  */
 
-Server.prototype.close = function(){
+Server.prototype.close = function(fn){
   for (var id in this.nsps['/'].sockets) {
     if (this.nsps['/'].sockets.hasOwnProperty(id)) {
       this.nsps['/'].sockets[id].onclose();
@@ -364,8 +364,10 @@ Server.prototype.close = function(){
 
   this.engine.close();
 
-  if(this.httpServer){
-    this.httpServer.close();
+  if(this.httpServer) {
+    this.httpServer.close(fn);
+  } else {
+    fn && fn();
   }
 };
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
Previously unable to pass a `done` callback to the `Server#close()` method.

### New behaviour
Now able to pass a `done` callback to the `Server#close()` method.

### Other information (e.g. related issues)
candidate for #2739