### PR TITLE
fix(socket): Fixes socket.use error packet which drops nodejs due to …

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -498,7 +498,7 @@ Socket.prototype.dispatch = function(event){
   this.run(event, function(err){
     process.nextTick(function(){
       if (err) {
-        return self.emit('error', err.data || err.message);
+        return self.error(err.data || err.message);
       }
       emit.apply(self, event);
     });

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -498,7 +498,6 @@ Socket.prototype.dispatch = function(event){
   this.run(event, function(err){
     process.nextTick(function(){
       if (err) {
-        self.emit('error', err.data || err.message);
         return self.error(err.data || err.message);
       }
       emit.apply(self, event);

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -498,6 +498,7 @@ Socket.prototype.dispatch = function(event){
   this.run(event, function(err){
     process.nextTick(function(){
       if (err) {
+        self.emit('error', err.data || err.message);
         return self.error(err.data || err.message);
       }
       emit.apply(self, event);

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -2277,6 +2277,11 @@ describe('socket.io', function(){
 
         clientSocket.emit('join', 'woot');
 
+        clientSocket.on('error', function(err){
+          expect(err).to.be('Authentication error');
+          done();
+        });
+
         sio.on('connection', function(socket){
           socket.use(function(event, next){
             next(new Error('Authentication error'));
@@ -2287,10 +2292,6 @@ describe('socket.io', function(){
 
           socket.on('join', function(){
             done(new Error('nope'));
-          });
-          clientSocket.on('error', function(err){
-            expect(err).to.be('Authentication error');
-            done();
           });
         });
       });
@@ -2305,6 +2306,11 @@ describe('socket.io', function(){
 
         clientSocket.emit('join', 'woot');
 
+        clientSocket.on('error', function(err){
+          expect(err).to.eql({ a: 'b', c: 3 });
+          done();
+        });
+
         sio.on('connection', function(socket){
           socket.use(function(event, next){
             var err = new Error('Authentication error');
@@ -2314,10 +2320,6 @@ describe('socket.io', function(){
 
           socket.on('join', function(){
             done(new Error('nope'));
-          });
-          clientSocket.on('error', function(err){
-            expect(err).to.eql({ a: 'b', c: 3 });
-            done();
           });
         });
       });

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -2273,9 +2273,9 @@ describe('socket.io', function(){
       var sio = io(srv);
 
       srv.listen(function(){
-        var socket = client(srv, { multiplex: false });
+        var clientSocket = client(srv, { multiplex: false });
 
-        socket.emit('join', 'woot');
+        clientSocket.emit('join', 'woot');
 
         sio.on('connection', function(socket){
           socket.use(function(event, next){
@@ -2288,7 +2288,7 @@ describe('socket.io', function(){
           socket.on('join', function(){
             done(new Error('nope'));
           });
-          socket.on('error', function(err){
+          clientSocket.on('error', function(err){
             expect(err).to.be('Authentication error');
             done();
           });
@@ -2301,9 +2301,9 @@ describe('socket.io', function(){
       var sio = io(srv);
 
       srv.listen(function(){
-        var socket = client(srv, { multiplex: false });
+        var clientSocket = client(srv, { multiplex: false });
 
-        socket.emit('join', 'woot');
+        clientSocket.emit('join', 'woot');
 
         sio.on('connection', function(socket){
           socket.use(function(event, next){
@@ -2315,7 +2315,7 @@ describe('socket.io', function(){
           socket.on('join', function(){
             done(new Error('nope'));
           });
-          socket.on('error', function(err){
+          clientSocket.on('error', function(err){
             expect(err).to.eql({ a: 'b', c: 3 });
             done();
           });


### PR DESCRIPTION
This PR fixes https://github.com/socketio/socket.io/issues/2771

### The kind of change this PR does introduce

* [x] a bug fix

### Current behaviour
Socket.use middleware drops nodejs process if error thrown in next function


### New behaviour
Socket.use middleware sends ```error``` packet correctly without dropping nodejs instance.


### Other information (e.g. related issues)
Socket cannot emit ```error``` event, because default behavior of EventEmitter will drop nodejs instance.
Details: https://nodejs.org/api/events.html#events_error_events