### PR TITLE
Serve slim client

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,8 +28,7 @@ module.exports = Server;
  */
 
 var clientRoot;
-var strClientPath = '/socket\\.io(\\.slim)?\\.js(\\.map)?$';
-var clientPaths = new RegExp('^\/socket\.io' + strClientPath);
+var clientPathRegex;
 var dotMap = /\.map/;
 
 /**
@@ -156,8 +155,7 @@ Server.prototype.path = function(v){
   this._path = v.replace(/\/$/, '');
 
   var escPath = this._path.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
-  // console.log(escPath + strClientPath);
-  clientPaths = new RegExp('^' + escPath + strClientPath);
+  clientPathRegex = new RegExp('^' + escPath + '/socket\\.io(\\.slim)?\\.js(\\.map)?$');
   return this;
 };
 
@@ -264,7 +262,7 @@ Server.prototype.attachServe = function(srv){
   var self = this;
   srv.removeAllListeners('request');
   srv.on('request', function(req, res) {
-    if (clientPaths.test(req.url)) {
+    if (clientPathRegex.test(req.url)) {
       self.serve(req, res, req.url);
     } else {
       for (var i = 0; i < evs.length; i++) {
@@ -275,7 +273,7 @@ Server.prototype.attachServe = function(srv){
 };
 
 /**
- * Handles a request serving `/socket.io.js`
+ * Handles a request serving of client source and map
  *
  * @param {http.Request} req
  * @param {http.Response} res
@@ -311,6 +309,19 @@ Server.prototype.serve = function(req, res, url) {
     file = file.replace('.js', '.min.js');
   }
 
+  this.sendFile(file, req, res);
+};
+
+/**
+ * Writes (and gzippes) a file to the response.
+ *
+ * @param {String} file The file to write (relative the client dist directory).
+ * @param {http.Request} req
+ * @param {http.Response} res
+ * @api private
+ */
+
+Server.prototype.sendFile = function(file, req, res) {
   if (!clientRoot) {
     clientRoot = require.resolve('socket.io-client/dist' + file).replace(file, '/');
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -306,7 +306,7 @@ Server.prototype.serve = function(req, res, file) {
   res.setHeader('Content-Type', 'application/' + (isMap ? 'json' : 'javascript'));
   res.setHeader('ETag', expectedEtag);
   if (!isMap) {
-    res.setHeader('X-SourceMap', file + '.map');
+    res.setHeader('X-SourceMap', file.substring(1).replace('.min', '') + '.map');
   }
 
   if (!clientRoot) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ module.exports = Server;
  */
 
 var clientRoot;
-var strClientPath = '/socket\\.io(\\.slim)?(\\.map)?.js$';
+var strClientPath = '/socket\\.io(\\.slim)?\\.js(\\.map)?$';
 var clientPaths = new RegExp('^\/socket\.io' + strClientPath);
 var dotMap = /\.map/;
 
@@ -265,8 +265,7 @@ Server.prototype.attachServe = function(srv){
   srv.removeAllListeners('request');
   srv.on('request', function(req, res) {
     if (clientPaths.test(req.url)) {
-      var file = req.url.replace(self._path, '').replace('.js', '.min.js');
-      self.serve(req, res, file);
+      self.serve(req, res, req.url);
     } else {
       for (var i = 0; i < evs.length; i++) {
         evs[i].call(srv, req, res);
@@ -283,7 +282,8 @@ Server.prototype.attachServe = function(srv){
  * @api private
  */
 
-Server.prototype.serve = function(req, res, file) {
+Server.prototype.serve = function(req, res, url) {
+  var file = url.replace(this._path, '');
   var isMap = dotMap.test(file);
   var message = (isMap ? 'map' : 'source');
 
@@ -305,8 +305,10 @@ Server.prototype.serve = function(req, res, file) {
 
   res.setHeader('Content-Type', 'application/' + (isMap ? 'json' : 'javascript'));
   res.setHeader('ETag', expectedEtag);
+
   if (!isMap) {
-    res.setHeader('X-SourceMap', file.substring(1).replace('.min', '') + '.map');
+    res.setHeader('X-SourceMap', file.substring(1) + '.map');
+    file = file.replace('.js', '.min.js');
   }
 
   if (!clientRoot) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,8 @@
  */
 
 var http = require('http');
-var read = require('fs').readFileSync;
+var createReadStream = require('fs').createReadStream;
+var path = require('path');
 var engine = require('engine.io');
 var client = require('socket.io-client');
 var clientVersion = require('socket.io-client/package').version;
@@ -14,6 +15,7 @@ var Namespace = require('./namespace');
 var Adapter = require('socket.io-adapter');
 var debug = require('debug')('socket.io:server');
 var url = require('url');
+var zlib = require('zlib');
 
 /**
  * Module exports.
@@ -25,8 +27,10 @@ module.exports = Server;
  * Socket.IO client source.
  */
 
-var clientSource = undefined;
-var clientSourceMap = undefined;
+var clientRoot;
+var strClientPath = '/socket\\.io(\\.slim)?(\\.map)?.js$';
+var clientPaths = new RegExp('^\/socket\.io' + strClientPath);
+var dotMap = /\.map/;
 
 /**
  * Server constructor.
@@ -97,15 +101,6 @@ Server.prototype.serveClient = function(v){
   if (!arguments.length) return this._serveClient;
   this._serveClient = v;
 
-  if (v && !clientSource) {
-    clientSource = read(require.resolve('socket.io-client/dist/socket.io.min.js'), 'utf-8');
-    try {
-      clientSourceMap = read(require.resolve('socket.io-client/dist/socket.io.js.map'), 'utf-8');
-    } catch(err) {
-      debug('could not load sourcemap file');
-    }
-  }
-
   return this;
 };
 
@@ -159,6 +154,10 @@ Server.prototype.set = function(key, val){
 Server.prototype.path = function(v){
   if (!arguments.length) return this._path;
   this._path = v.replace(/\/$/, '');
+
+  var escPath = this._path.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
+  // console.log(escPath + strClientPath);
+  clientPaths = new RegExp('^' + escPath + strClientPath);
   return this;
 };
 
@@ -260,16 +259,14 @@ Server.prototype.attach = function(srv, opts){
 
 Server.prototype.attachServe = function(srv){
   debug('attaching client serving req handler');
-  var url = this._path + '/socket.io.js';
-  var urlMap = this._path + '/socket.io.js.map';
+
   var evs = srv.listeners('request').slice(0);
   var self = this;
   srv.removeAllListeners('request');
   srv.on('request', function(req, res) {
-    if (0 === req.url.indexOf(urlMap)) {
-      self.serveMap(req, res);
-    } else if (0 === req.url.indexOf(url)) {
-      self.serve(req, res);
+    if (clientPaths.test(req.url)) {
+      var file = req.url.replace(self._path, '').replace('.js', '.min.js');
+      self.serve(req, res, file);
     } else {
       for (var i = 0; i < evs.length; i++) {
         evs[i].call(srv, req, res);
@@ -286,57 +283,47 @@ Server.prototype.attachServe = function(srv){
  * @api private
  */
 
-Server.prototype.serve = function(req, res){
+Server.prototype.serve = function(req, res, file) {
+  var isMap = dotMap.test(file);
+  var message = (isMap ? 'map' : 'source');
+
   // Per the standard, ETags must be quoted:
   // https://tools.ietf.org/html/rfc7232#section-2.3
   var expectedEtag = '"' + clientVersion + '"';
 
   var etag = req.headers['if-none-match'];
   if (etag) {
-    if (expectedEtag == etag) {
-      debug('serve client 304');
+    if (expectedEtag === etag) {
+      debug('serve client %s 304', message);
       res.writeHead(304);
       res.end();
       return;
     }
   }
 
-  debug('serve client source');
-  res.setHeader('Content-Type', 'application/javascript');
+  debug('serve client %s', message);
+
+  res.setHeader('Content-Type', 'application/' + (isMap ? 'json' : 'javascript'));
   res.setHeader('ETag', expectedEtag);
-  res.setHeader('X-SourceMap', 'socket.io.js.map');
-  res.writeHead(200);
-  res.end(clientSource);
-};
-
-/**
- * Handles a request serving `/socket.io.js.map`
- *
- * @param {http.Request} req
- * @param {http.Response} res
- * @api private
- */
-
-Server.prototype.serveMap = function(req, res){
-  // Per the standard, ETags must be quoted:
-  // https://tools.ietf.org/html/rfc7232#section-2.3
-  var expectedEtag = '"' + clientVersion + '"';
-
-  var etag = req.headers['if-none-match'];
-  if (etag) {
-    if (expectedEtag == etag) {
-      debug('serve client 304');
-      res.writeHead(304);
-      res.end();
-      return;
-    }
+  if (!isMap) {
+    res.setHeader('X-SourceMap', file + '.map');
   }
 
-  debug('serve client sourcemap');
-  res.setHeader('Content-Type', 'application/json');
-  res.setHeader('ETag', expectedEtag);
-  res.writeHead(200);
-  res.end(clientSourceMap);
+  if (!clientRoot) {
+    clientRoot = require.resolve('socket.io-client/dist' + file).replace(file, '/');
+  }
+
+  var readStream = createReadStream(path.join(clientRoot, file));
+  if (~req.headers['accept-encoding'].indexOf('gzip')) {
+    res.setHeader('content-encoding', 'gzip');
+    res.writeHead(200);
+
+    var gzip = zlib.createGzip();
+    readStream.pipe(gzip).pipe(res);
+  } else {
+    res.writeHead(200);
+    readStream.pipe(res);
+  }
 };
 
 /**
@@ -378,7 +365,7 @@ Server.prototype.onconnection = function(conn){
 
 Server.prototype.of = function(name, fn){
   if (String(name)[0] !== '/') name = '/' + name;
-  
+
   var nsp = this.nsps[name];
   if (!nsp) {
     debug('initializing namespace %s', name);
@@ -392,7 +379,7 @@ Server.prototype.of = function(name, fn){
 /**
  * Closes server connection
  *
- * @param {Function} [fn] optional, called as `fn([err])` on error OR all conns closed 
+ * @param {Function} [fn] optional, called as `fn([err])` on error OR all conns closed
  * @api public
  */
 

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -177,8 +177,29 @@ describe('socket.io', function(){
         };
       }
 
+      function clientMapTest(file) {
+        return function(done){
+          var srv = http();
+          io(srv);
+          request(srv)
+          .get('/socket.io/' + file)
+          .buffer(true)
+          .end(function(err, res){
+            if (err) return done(err);
+            var ctype = res.headers['content-type'];
+            expect(ctype).to.be('application/json');
+            expect(res.headers.etag).to.be('"' + clientVersion + '"');
+            expect(res.text).to.match(/engine\.io/);
+            expect(res.status).to.be(200);
+            done();
+          });
+        };
+      }
+
       it('should serve client', clientSourceTest('socket.io.js'));
+      it('should serve client', clientMapTest('socket.io.js.map'));
       it('should serve slim client', clientSourceTest('socket.io.slim.js'));
+      it('should serve slim client', clientMapTest('socket.io.slim.js.map'));
 
       it('should handle 304', function(done){
         var srv = http();


### PR DESCRIPTION
### The kind of change this PR does introduce

A code change that improves performance.

### Current behaviour
The slim client is not served.

### New behaviour
The new slim client (and its source map) are served.

### Other information (e.g. related issues)
This refactor also:

1. Gzips the response.
2. Streams the files as binary, instead of buffering strings on init and converting the strings back to binary on each request.
3. Removes code duplication for source map serving.

I also added test for serving the source maps and slim client.