### PR TITLE
0.9: Remove process.EventEmitter usage for Node 7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 node_js:
-  - 0.6
+  - 0.12
+
+install:
+  - npm install -g npm
+  - npm install
 
 notifications:
   irc: "irc.freenode.org#socket.io"

--- a/examples/irc-output/irc.js
+++ b/examples/irc-output/irc.js
@@ -39,7 +39,7 @@ var Client = irc.Client = function(host, port) {
   this.user = null;
   this.real = null;
 }
-sys.inherits(Client, process.EventEmitter);
+sys.inherits(Client, require('events'));
 
 Client.prototype.connect = function(nick, user, real) {
   var connection = tcp.createConnection(this.port, this.host);

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -21,7 +21,7 @@ var fs = require('fs')
   , MemoryStore = require('./stores/memory')
   , SocketNamespace = require('./namespace')
   , Static = require('./static')
-  , EventEmitter = process.EventEmitter;
+  , EventEmitter = require('events');
 
 /**
  * Export the constructor.

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -3,7 +3,7 @@
  */
 
 var Socket = require('./socket')
-  , EventEmitter = process.EventEmitter
+  , EventEmitter = require('events')
   , parser = require('./parser')
   , util = require('./util');
 

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -11,7 +11,7 @@
 
 var parser = require('./parser')
   , util = require('./util')
-  , EventEmitter = process.EventEmitter
+  , EventEmitter = require('events')
 
 /**
  * Export the constructor.

--- a/lib/store.js
+++ b/lib/store.js
@@ -15,7 +15,7 @@ exports = module.exports = Store;
  * Module dependencies.
  */
 
-var EventEmitter = process.EventEmitter;
+var EventEmitter = require('events');
 
 /**
  * Store interface

--- a/lib/transports/websocket/default.js
+++ b/lib/transports/websocket/default.js
@@ -9,7 +9,7 @@
  */
 
 var Transport = require('../../transport')
-  , EventEmitter = process.EventEmitter
+  , EventEmitter = require('events')
   , crypto = require('crypto')
   , parser = require('../../parser');
 

--- a/lib/transports/websocket/hybi-07-12.js
+++ b/lib/transports/websocket/hybi-07-12.js
@@ -10,7 +10,7 @@
  */
 
 var Transport = require('../../transport')
-  , EventEmitter = process.EventEmitter
+  , EventEmitter = require('events')
   , crypto = require('crypto')
   , url = require('url')
   , parser = require('../../parser')

--- a/lib/transports/websocket/hybi-16.js
+++ b/lib/transports/websocket/hybi-16.js
@@ -9,7 +9,7 @@
  */
 
 var Transport = require('../../transport')
-  , EventEmitter = process.EventEmitter
+  , EventEmitter = require('events')
   , crypto = require('crypto')
   , url = require('url')
   , parser = require('../../parser')

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "expresso": "0.9.2"
       , "should": "*"
       , "benchmark": "0.2.2"
-      , "microtime": "0.1.3-1"
+      , "microtime": "1.4.2"
       , "colors": "0.5.1"
     }
   , "optionalDependencies": {


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
Socket.IO 0.9.x does not work in Node.JS 7.0 due to the removal of `process.EventEmitter`. A myriad of existing software depends on Socket.IO 0.9.x, therefore it will either be necessary to update Socket.IO 0.9.x, or fork it. Some existing software still using 0.9.x includes the Yez extension for Google Chrome + corresponding Node.JS application.

### New behaviour
This patch changes usages of `process.EventEmitter` to `require('events')`.