### PR TITLE
Use fs.readFileSync instead of require.resolve

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,8 @@
 
 var http = require('http');
 var read = require('fs').readFileSync;
+var path = require('path');
+var exists = require('fs').existsSync;
 var engine = require('engine.io');
 var client = require('socket.io-client');
 var clientVersion = require('socket.io-client/package').version;
@@ -98,11 +100,22 @@ Server.prototype.serveClient = function(v){
   this._serveClient = v;
 
   if (v && !clientSource) {
-    clientSource = read(require.resolve('socket.io-client/dist/socket.io.min.js'), 'utf-8');
-    try {
-      clientSourceMap = read(require.resolve('socket.io-client/dist/socket.io.js.map'), 'utf-8');
-    } catch(err) {
-      debug('could not load sourcemap file');
+
+    var clientSourcePath = path.resolve(__dirname, './../../socket.io-client/dist/socket.io.min.js');
+    var clientSourceMapPath = path.resolve(__dirname, './../../socket.io-client/dist/socket.io.min.js.map');
+    if(!exists(clientSourcePath)) {
+      clientSource = read(require.resolve('socket.io-client/dist/socket.io.min.js'), 'utf-8');
+    } else {
+      clientSource = read(clientSourcePath);
+    }
+    if(!exists(clientSourceMapPath)) {
+      try {
+        clientSourceMap = read(require.resolve('socket.io-client/dist/socket.io.js.map'), 'utf-8');
+      } catch(err) {
+        debug('could not load sourcemap file');
+      }
+    } else {
+      clientSourceMap = read(clientSourceMapPath);
     }
   }
 
@@ -378,7 +391,7 @@ Server.prototype.onconnection = function(conn){
 
 Server.prototype.of = function(name, fn){
   if (String(name)[0] !== '/') name = '/' + name;
-  
+
   var nsp = this.nsps[name];
   if (!nsp) {
     debug('initializing namespace %s', name);
@@ -392,7 +405,7 @@ Server.prototype.of = function(name, fn){
 /**
  * Closes server connection
  *
- * @param {Function} [fn] optional, called as `fn([err])` on error OR all conns closed 
+ * @param {Function} [fn] optional, called as `fn([err])` on error OR all conns closed
  * @api public
  */
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -98,27 +98,21 @@ Server.prototype.checkRequest = function(req, fn) {
 Server.prototype.serveClient = function(v){
   if (!arguments.length) return this._serveClient;
   this._serveClient = v;
-
-  if (v && !clientSource) {
-
-    var clientSourcePath = path.resolve(__dirname, './../../socket.io-client/dist/socket.io.min.js');
-    var clientSourceMapPath = path.resolve(__dirname, './../../socket.io-client/dist/socket.io.min.js.map');
-    if(!exists(clientSourcePath)) {
-      clientSource = read(require.resolve('socket.io-client/dist/socket.io.min.js'), 'utf-8');
-    } else {
-      clientSource = read(clientSourcePath);
+  var resolvePath = function(file){
+    var filepath = path.resolve(__dirname, './../../', file);
+    if (exists(filepath)) {
+      return filepath;
     }
-    if(!exists(clientSourceMapPath)) {
-      try {
-        clientSourceMap = read(require.resolve('socket.io-client/dist/socket.io.js.map'), 'utf-8');
-      } catch(err) {
-        debug('could not load sourcemap file');
-      }
-    } else {
-      clientSourceMap = read(clientSourceMapPath);
+    return require.resolve(file);
+  };
+  if (v && !clientSource) {
+    clientSource = read(resolvePath( 'socket.io-client/dist/socket.io.min.js'), 'utf-8');
+    try {
+      clientSourceMap = read(resolvePath( 'socket.io-client/dist/socket.io.js.map'), 'utf-8');
+    } catch(err) {
+      debug('could not load sourcemap file');
     }
   }
-
   return this;
 };
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour

Browserify doesn't supports require.resolve, and as a consequence, makes nexe fails the compilation : 

### New behaviour

This PR attempts to read the content of the socket.io-client file via fs.readFileSync and falls back to the original require.resolve if this file cannot be found. 

### Other information (e.g. related issues)

https://github.com/nexe/nexe/issues/289
