### PR TITLE
Allow the use of a custom parser

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -68,6 +68,7 @@ Exposed by `require('socket.io')`.
     - `adapter` _(Adapter)_: the adapter to use. Defaults to an instance of the `Adapter` that ships with socket.io which is memory based. See [socket.io-adapter](https://github.com/socketio/socket.io-adapter)
     - `origins` _(String)_: the allowed origins (`*`)
     - `allowRequest` _(Function)_: A function that receives a given handshake or upgrade request as its first parameter, and can decide whether to continue or not. The second argument is a function that needs to be called with the decided information: `fn(err, success)`, where `success` is a boolean value where false means that the request is rejected, and err is an error code.
+    - `parser` _(Parser)_: the parser to use. Defaults to an instance of the `Parser` that ships with socket.io. See [socket.io-parser](https://github.com/socketio/socket.io-parser).
 
 Works with and without `new`:
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -14,12 +14,6 @@ var url = require('url');
 module.exports = Client;
 
 /**
- * Packet encoder
- */
-
-var encoder = new parser.Encoder();
-
-/**
  * Client constructor.
  *
  * @param {Server} server instance
@@ -30,7 +24,8 @@ var encoder = new parser.Encoder();
 function Client(server, conn){
   this.server = server;
   this.conn = conn;
-  this.decoder = new parser.Decoder();
+  this.encoder = server.encoder;
+  this.decoder = new server.parser.Decoder();
   this.id = conn.id;
   this.request = conn.request;
   this.setup();
@@ -158,7 +153,7 @@ Client.prototype.packet = function(packet, opts){
   if ('open' == this.conn.readyState) {
     debug('writing packet %j', packet);
     if (!opts.preEncoded) { // not broadcasting, need to encode
-      encoder.encode(packet, writeToEngine); // encode, then write results to engine
+      this.encoder.encode(packet, writeToEngine); // encode, then write results to engine
     } else { // a broadcast pre-encodes a packet
       writeToEngine(packet);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ var Client = require('./client');
 var Emitter = require('events').EventEmitter;
 var Namespace = require('./namespace');
 var Adapter = require('socket.io-adapter');
+var parser = require('socket.io-parser');
 var debug = require('debug')('socket.io:server');
 var url = require('url');
 
@@ -49,6 +50,8 @@ function Server(srv, opts){
   this.adapter(opts.adapter || Adapter);
   this.origins(opts.origins || '*:*');
   this.sockets = this.of('/');
+  this.parser = opts.parser || parser;
+  this.encoder = new this.parser.Encoder();
   if (srv) this.attach(srv, opts);
 }
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* a new feature

### New behaviour

This would enable the use of some custom parsers, like the following based on msgpack:
```js
const msgpack = require('notepack.io');
const Emitter = require('component-emitter');

class Encoder {
  encode(obj, callback){
    var encoded = msgpack.encode(obj);
    callback([encoded]);
  }
}

class Decoder extends Emitter {
  add(obj){
    var decoded = msgpack.decode(obj);
    this.emit('decoded', decoded);
  }
  destroy(){}
}

exports.Encoder = Encoder;
exports.Decoder = Decoder;
```

And then:
```js
const server = require('http').createServer();
const myCustomParser = require('./my-custom-parser');
const io = require('socket.io')(server, {
  parser: myCustomParser
});
```
That would also provide a workaround for https://github.com/socketio/socket.io-parser/issues/61.

Related: https://github.com/socketio/socket.io/issues/1652 https://github.com/socketio/socket.io/issues/1946

Note: that would need to update `socket.io-client` and `socket.io-adapter` too.