### PR TITLE
Fix incorrect apply argument type

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -500,7 +500,7 @@ Socket.prototype.dispatch = function(event){
       if (err) {
         return self.error(err.data || err.message);
       }
-      emit.apply(self, event);
+      emit.call(self, event);
     });
   }
   this.run(event, dispatchSocket);


### PR DESCRIPTION
### Fix an incorrect `emit` call

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

Sorry if the PR is not what you expect. However, I don't think the call is correct at all.

It keeps throwing this error on a *certain page* (I can't share the code):

```
bs_1         | /code/node_modules/browser-sync/node_modules/socket.io/lib/socket.js:501
bs_1         |       emit.apply(self, event);
bs_1         |            ^
bs_1         | TypeError: Function.prototype.apply: Arguments list has wrong type
bs_1         |     at /code/node_modules/browser-sync/node_modules/socket.io/lib/socket.js:501:12
bs_1         |     at process._tickCallback (node.js:355:11)
app_bs_1 exited with code 1
```

It's totally fine if you close this PR. I just don't know what is the source of the issue, and I'm now sure how to reproduce it :worried:

Anyway, this is [just a one-line fix](http://www.catb.org/jargon/html/O/one-line-fix.html) :wink: 