### PR TITLE
Bump engine.io to version 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "debug": "2.3.3",
-    "engine.io": "2.0.0",
+    "engine.io": "2.0.2",
     "has-binary": "0.1.7",
     "object-assign": "4.1.0",
     "socket.io-adapter": "0.5.0",


### PR DESCRIPTION
Includes the following (from engine.io changelog):

* [fix] Initialize the WebSocket server in the Server constructor ([#476](https://github.com/socketio/engine.io/issues/476))
* [chore] Bump ws to version 1.1.2 (vulnerability fix) ([#480](https://github.com/socketio/engine.io/issues/480))


### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour

Socket.io installs version 2.0.0 of the engine.io dependency.

### New behaviour

Socket.io installs version 2.0.2 of the engine.io dependency.

### Other information (e.g. related issues)

IMHO it's worth considering changing this dependency to `'engine-io': '~2.0.0'` to avoid having to make new releases of `socket.io` every time `engine.io` is patched, since both modules are maintained by the same group.  But I can appreciate the desire to lock things down hard.
