### PR TITLE
Make Socket, Namespace inherit EventEmitter properly

### DIFF
--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -50,6 +50,7 @@ var emit = Emitter.prototype.emit;
  */
 
 function Namespace(server, name){
+  Emitter.call(this);
   this.name = name;
   this.server = server;
   this.sockets = {};
@@ -64,8 +65,8 @@ function Namespace(server, name){
 /**
  * Inherits from `EventEmitter`.
  */
-
-Namespace.prototype.__proto__ = Emitter.prototype;
+Namespace.prototype = Object.create(Emitter.prototype);
+Namespace.prototype.constructor = Namespace
 
 /**
  * Apply flags from `Socket`.

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -58,6 +58,7 @@ var emit = Emitter.prototype.emit;
  */
 
 function Socket(nsp, client, query){
+  Emitter.call(this);
   this.nsp = nsp;
   this.server = nsp.server;
   this.adapter = this.nsp.adapter;
@@ -77,8 +78,8 @@ function Socket(nsp, client, query){
 /**
  * Inherits from `EventEmitter`.
  */
-
-Socket.prototype.__proto__ = Emitter.prototype;
+Socket.prototype = Object.create(Emitter.prototype);
+Socket.prototype.constructor = Socket
 
 /**
  * Apply flags from `Socket`.


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a code change that improves performance

### Other information (e.g. related issues)

Setting an object's prototype is discouraged, and `__proto__` is not required to exist outside of browsers.

Use the standard way of making a class inherit from another