### PR TITLE
Add note in docs for `origins(fn)` about `error` needing to be a string.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -155,7 +155,7 @@ Sets the allowed origins `value`. Defaults to any origins being allowed. If no a
   - `fn` _(Function)_
   - **Returns** `Server`
 
-Provides a function taking two arguments `origin:String` and `callback(error, success)`, where `success` is a boolean value indicating whether origin is allowed or not.
+Provides a function taking two arguments `origin:String` and `callback(error, success)`, where `success` is a boolean value indicating whether origin is allowed or not.  If `success` is set to `false`, `error` must be provided as a string value that will be appended to the server response, e.g. "Origin not allowed".
 
 __Potential drawbacks__:
 * in some situations, when it is not possible to determine `origin` it may have value of `*`


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

The docs for `origins(fn)` currently don't mention that `error` has to be supplied as a string.  This really tripped me up as I was supplying an Error instance as I usually do for callbacks, which crashes w/ certain versions of Node.

### New behaviour

Added line to documentation indicating that `error` should be a string.

### Other information (e.g. related issues)

An alternative to this would be to patch `engine.io` to allow an Error instance in its [abortConnection method](https://github.com/socketio/engine.io/blob/bd1e81ec3d11f18c5fc09c55745d5ff66d037cc1/lib/server.js#L497), using its `message` property as the error message.
