### PR TITLE
[docs] Update emit cheatsheet

### DIFF
--- a/docs/emit.md
+++ b/docs/emit.md
@@ -25,6 +25,9 @@ function onConnect(socket){
   // sending to all clients in namespace 'myNamespace', including sender
   io.of('myNamespace').emit('bigger-announcement', 'the tournament will start soon');
 
+  // sending to a specific room in a specific namespace, including sender
+  io.of('myNamespace').in('room').emit('event', 'message');
+
   // sending to individual socketid (private message)
   socket.to(<socketid>).emit('hey', 'I just met you');
 

--- a/docs/emit.md
+++ b/docs/emit.md
@@ -26,7 +26,7 @@ function onConnect(socket){
   io.of('myNamespace').emit('bigger-announcement', 'the tournament will start soon');
 
   // sending to a specific room in a specific namespace, including sender
-  io.of('myNamespace').in('room').emit('event', 'message');
+  io.of('myNamespace').to('room').emit('event', 'message');
 
   // sending to individual socketid (private message)
   socket.to(<socketid>).emit('hey', 'I just met you');


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

- The information currently present in the cheat sheet does not show users how they can emit to a room that is within a namespace.

### New behaviour

- Adds an example of how someone would emit to a room within a namespace.

### Other information (e.g. related issues)


