### PR TITLE
add cache-control header to client source

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -321,6 +321,7 @@ Server.prototype.serve = function(req, res){
   }
 
   debug('serve client source');
+  res.setHeader("Cache-Control", "public, max-age=0");
   res.setHeader('Content-Type', 'application/javascript');
   res.setHeader('ETag', expectedEtag);
   res.setHeader('X-SourceMap', 'socket.io.js.map');


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [x] a code change that improves performance
* [ ] other

### Current behaviour
No cache-control header is sent when requesting clien script

### New behaviour
Server will send cache-control header with value "public, max-age=0"


### Other information (e.g. related issues)


