### PR TITLE
fix(Node v6.9.1) process.EventEmitter was deprecated

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -21,7 +21,7 @@ var fs = require('fs')
   , MemoryStore = require('./stores/memory')
   , SocketNamespace = require('./namespace')
   , Static = require('./static')
-  , EventEmitter = process.EventEmitter;
+  , EventEmitter = require('events');
 
 /**
  * Export the constructor.
@@ -146,7 +146,7 @@ function Manager (server, options) {
   });
 
   this.sequenceNumber = Date.now() | 0;
- 
+
   this.log.info('socket.io started');
 };
 

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -3,7 +3,7 @@
  */
 
 var Socket = require('./socket')
-  , EventEmitter = process.EventEmitter
+  , EventEmitter = require('events')
   , parser = require('./parser')
   , util = require('./util');
 

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -11,7 +11,7 @@
 
 var parser = require('./parser')
   , util = require('./util')
-  , EventEmitter = process.EventEmitter
+  , EventEmitter = require('events')
 
 /**
  * Export the constructor.
@@ -31,7 +31,7 @@ var defaultError = function () {};
  * @param {Manager} manager instance
  * @param {String} session id
  * @param {Namespace} namespace the socket belongs to
- * @param {Boolean} whether the 
+ * @param {Boolean} whether the
  * @api public
  */
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -15,7 +15,7 @@ exports = module.exports = Store;
  * Module dependencies.
  */
 
-var EventEmitter = process.EventEmitter;
+var EventEmitter = require('events');
 
 /**
  * Store interface

--- a/lib/transports/websocket/default.js
+++ b/lib/transports/websocket/default.js
@@ -9,7 +9,7 @@
  */
 
 var Transport = require('../../transport')
-  , EventEmitter = process.EventEmitter
+  , EventEmitter = require('events')
   , crypto = require('crypto')
   , parser = require('../../parser');
 

--- a/lib/transports/websocket/hybi-07-12.js
+++ b/lib/transports/websocket/hybi-07-12.js
@@ -4,13 +4,13 @@
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
  * MIT Licensed
  */
- 
+
 /**
  * Module requirements.
  */
 
 var Transport = require('../../transport')
-  , EventEmitter = process.EventEmitter
+  , EventEmitter = require('events')
   , crypto = require('crypto')
   , url = require('url')
   , parser = require('../../parser')
@@ -96,7 +96,7 @@ WebSocket.prototype.protocolVersion = '07-12';
 WebSocket.prototype.onSocketConnect = function () {
   var self = this;
 
-  if (typeof this.req.headers.upgrade === 'undefined' || 
+  if (typeof this.req.headers.upgrade === 'undefined' ||
       this.req.headers.upgrade.toLowerCase() !== 'websocket') {
     this.log.warn(this.name + ' connection invalid');
     this.end();
@@ -108,23 +108,23 @@ WebSocket.prototype.onSocketConnect = function () {
                       origin.match(/^https/) : this.socket.encrypted) ?
                         'wss' : 'ws')
                + '://' + this.req.headers.host + this.req.url;
-  
+
   if (!this.verifyOrigin(origin)) {
     this.log.warn(this.name + ' connection invalid: origin mismatch');
     this.end();
-    return;    
+    return;
   }
-  
+
   if (!this.req.headers['sec-websocket-key']) {
     this.log.warn(this.name + ' connection invalid: received no key');
     this.end();
     return;
   }
-    
+
   // calc key
-  var key = this.req.headers['sec-websocket-key'];  
-  var shasum = crypto.createHash('sha1');  
-  shasum.update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11");  
+  var key = this.req.headers['sec-websocket-key'];
+  var shasum = crypto.createHash('sha1');
+  shasum.update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
   key = shasum.digest('base64');
 
   var headers = [
@@ -178,7 +178,7 @@ WebSocket.prototype.verifyOrigin = function (origin) {
     }
   }
   else {
-    this.log.warn('origin missing from websocket call, yet required by config');        
+    this.log.warn('origin missing from websocket call, yet required by config');
   }
   return false;
 };
@@ -270,7 +270,7 @@ WebSocket.prototype.doClose = function () {
  *
  * @api public
  */
- 
+
 function Parser (opts) {
   this.state = {
     activeFragmentedOperation: null,
@@ -286,7 +286,7 @@ function Parser (opts) {
   this._maxBuffer = (opts && opts.maxBuffer) || 10E7;
   this._dataLength = 0;
 
-  var self = this;  
+  var self = this;
   this.opcodeHandlers = {
     // text
     '1': function(data) {
@@ -309,10 +309,10 @@ function Parser (opts) {
           });
         }
         else {
-          self.expect('Data', length, function(data) { 
+          self.expect('Data', length, function(data) {
             finish(null, data);
           });
-        } 
+        }
       }
 
       // decode length
@@ -334,7 +334,7 @@ function Parser (opts) {
           var lengthBytes = data.slice(4); // note: cap to 32 bit length
           expectData(util.unpack(data));
         });
-      }      
+      }
     },
     // binary
     '2': function(data) {
@@ -358,10 +358,10 @@ function Parser (opts) {
           });
         }
         else {
-          self.expect('Data', length, function(data) { 
+          self.expect('Data', length, function(data) {
             finish(null, data);
           });
-        } 
+        }
       }
 
       // decode length
@@ -383,7 +383,7 @@ function Parser (opts) {
           var lengthBytes = data.slice(4); // note: cap to 32 bit length
           expectData(util.unpack(data));
         });
-      }      
+      }
     },
     // close
     '8': function(data) {
@@ -396,7 +396,7 @@ function Parser (opts) {
         self.error('fragmented ping is not supported');
         return;
       }
-      
+
       var finish = function(mask, data) {
         self.emit('ping', self.unmask(mask, data));
         self.endPacket();
@@ -412,16 +412,16 @@ function Parser (opts) {
           });
         }
         else {
-          self.expect('Data', length, function(data) { 
+          self.expect('Data', length, function(data) {
             finish(null, data);
           });
-        } 
+        }
       }
 
       // decode length
       var firstLength = data[1] & 0x7f;
       if (firstLength == 0) {
-        finish(null, null);        
+        finish(null, null);
       }
       else if (firstLength < 126) {
         expectData(firstLength);
@@ -435,11 +435,11 @@ function Parser (opts) {
         self.expect('Length', 8, function(data) {
           expectData(util.unpack(data));
         });
-      }      
+      }
     }
   }
 
-  this.expect('Opcode', 2, this.processPacket);  
+  this.expect('Opcode', 2, this.processPacket);
 };
 
 /**
@@ -497,7 +497,7 @@ Parser.prototype.addToOverflow = function(data) {
     this.overflow = new Buffer(this.overflow.length + data.length);
     prevOverflow.copy(this.overflow, 0);
     data.copy(this.overflow, prevOverflow.length);
-  }  
+  }
 }
 
 /**
@@ -531,10 +531,10 @@ Parser.prototype.processPacket = function (data) {
   if ((data[0] & 0x70) != 0) {
     this.error('reserved fields must be empty');
   }
-  this.state.lastFragment = (data[0] & 0x80) == 0x80; 
+  this.state.lastFragment = (data[0] & 0x80) == 0x80;
   this.state.masked = (data[1] & 0x80) == 0x80;
   var opcode = data[0] & 0xf;
-  if (opcode == 0) { 
+  if (opcode == 0) {
     // continuation frame
     this.state.opcode = this.state.activeFragmentedOperation;
     if (!(this.state.opcode == 1 || this.state.opcode == 2)) {
@@ -542,7 +542,7 @@ Parser.prototype.processPacket = function (data) {
       return;
     }
   }
-  else {    
+  else {
     this.state.opcode = opcode;
     if (this.state.lastFragment === false) {
         this.state.activeFragmentedOperation = opcode;
@@ -570,7 +570,7 @@ Parser.prototype.endPacket = function() {
   this.state.lastFragment = false;
   this.state.opcode = this.state.activeFragmentedOperation != null ? this.state.activeFragmentedOperation : 0;
   this.state.masked = false;
-  this.expect('Opcode', 2, this.processPacket);  
+  this.expect('Opcode', 2, this.processPacket);
 }
 
 /**
@@ -603,7 +603,7 @@ Parser.prototype.unmask = function (mask, buf, binary) {
   if (mask != null) {
     for (var i = 0, ll = buf.length; i < ll; i++) {
       buf[i] ^= mask[i % 4];
-    }    
+    }
   }
   if (binary) return buf;
   return buf != null ? buf.toString('utf8') : '';

--- a/lib/transports/websocket/hybi-16.js
+++ b/lib/transports/websocket/hybi-16.js
@@ -3,13 +3,13 @@
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
  * MIT Licensed
  */
- 
+
 /**
  * Module requirements.
  */
 
 var Transport = require('../../transport')
-  , EventEmitter = process.EventEmitter
+  , EventEmitter = require('events')
   , crypto = require('crypto')
   , url = require('url')
   , parser = require('../../parser')
@@ -95,7 +95,7 @@ WebSocket.prototype.protocolVersion = '16';
 WebSocket.prototype.onSocketConnect = function () {
   var self = this;
 
-  if (typeof this.req.headers.upgrade === 'undefined' || 
+  if (typeof this.req.headers.upgrade === 'undefined' ||
       this.req.headers.upgrade.toLowerCase() !== 'websocket') {
     this.log.warn(this.name + ' connection invalid');
     this.end();
@@ -107,23 +107,23 @@ WebSocket.prototype.onSocketConnect = function () {
                       origin.match(/^https/) : this.socket.encrypted) ?
                         'wss' : 'ws')
                + '://' + this.req.headers.host + this.req.url;
-  
+
   if (!this.verifyOrigin(origin)) {
     this.log.warn(this.name + ' connection invalid: origin mismatch');
     this.end();
-    return;    
+    return;
   }
-  
+
   if (!this.req.headers['sec-websocket-key']) {
     this.log.warn(this.name + ' connection invalid: received no key');
     this.end();
     return;
   }
-    
+
   // calc key
-  var key = this.req.headers['sec-websocket-key'];  
-  var shasum = crypto.createHash('sha1');  
-  shasum.update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11");  
+  var key = this.req.headers['sec-websocket-key'];
+  var shasum = crypto.createHash('sha1');
+  shasum.update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
   key = shasum.digest('base64');
 
   var headers = [
@@ -177,7 +177,7 @@ WebSocket.prototype.verifyOrigin = function (origin) {
     }
   }
   else {
-    this.log.warn('origin missing from websocket call, yet required by config');        
+    this.log.warn('origin missing from websocket call, yet required by config');
   }
   return false;
 };
@@ -269,7 +269,7 @@ WebSocket.prototype.doClose = function () {
  *
  * @api public
  */
- 
+
 function Parser (opts) {
   this.state = {
     activeFragmentedOperation: null,
@@ -285,7 +285,7 @@ function Parser (opts) {
   this._maxBuffer = (opts && opts.maxBuffer) || 10E7;
   this._dataLength = 0;
 
-  var self = this;  
+  var self = this;
   this.opcodeHandlers = {
     // text
     '1': function(data) {
@@ -308,10 +308,10 @@ function Parser (opts) {
           });
         }
         else {
-          self.expect('Data', length, function(data) { 
+          self.expect('Data', length, function(data) {
             finish(null, data);
           });
-        } 
+        }
       }
 
       // decode length
@@ -333,7 +333,7 @@ function Parser (opts) {
           var lengthBytes = data.slice(4); // note: cap to 32 bit length
           expectData(util.unpack(data));
         });
-      }      
+      }
     },
     // binary
     '2': function(data) {
@@ -357,10 +357,10 @@ function Parser (opts) {
           });
         }
         else {
-          self.expect('Data', length, function(data) { 
+          self.expect('Data', length, function(data) {
             finish(null, data);
           });
-        } 
+        }
       }
 
       // decode length
@@ -382,7 +382,7 @@ function Parser (opts) {
           var lengthBytes = data.slice(4); // note: cap to 32 bit length
           expectData(util.unpack(data));
         });
-      }      
+      }
     },
     // close
     '8': function(data) {
@@ -395,7 +395,7 @@ function Parser (opts) {
         self.error('fragmented ping is not supported');
         return;
       }
-      
+
       var finish = function(mask, data) {
         self.emit('ping', self.unmask(mask, data));
         self.endPacket();
@@ -411,16 +411,16 @@ function Parser (opts) {
           });
         }
         else {
-          self.expect('Data', length, function(data) { 
+          self.expect('Data', length, function(data) {
             finish(null, data);
           });
-        } 
+        }
       }
 
       // decode length
       var firstLength = data[1] & 0x7f;
       if (firstLength == 0) {
-        finish(null, null);        
+        finish(null, null);
       }
       else if (firstLength < 126) {
         expectData(firstLength);
@@ -434,11 +434,11 @@ function Parser (opts) {
         self.expect('Length', 8, function(data) {
           expectData(util.unpack(data));
         });
-      }      
+      }
     }
   }
 
-  this.expect('Opcode', 2, this.processPacket);  
+  this.expect('Opcode', 2, this.processPacket);
 };
 
 /**
@@ -496,7 +496,7 @@ Parser.prototype.addToOverflow = function(data) {
     this.overflow = new Buffer(this.overflow.length + data.length);
     prevOverflow.copy(this.overflow, 0);
     data.copy(this.overflow, prevOverflow.length);
-  }  
+  }
 }
 
 /**
@@ -530,11 +530,11 @@ Parser.prototype.processPacket = function (data) {
   if ((data[0] & 0x70) != 0) {
     this.error('reserved fields must be empty');
     return;
-  } 
-  this.state.lastFragment = (data[0] & 0x80) == 0x80; 
+  }
+  this.state.lastFragment = (data[0] & 0x80) == 0x80;
   this.state.masked = (data[1] & 0x80) == 0x80;
   var opcode = data[0] & 0xf;
-  if (opcode == 0) { 
+  if (opcode == 0) {
     // continuation frame
     this.state.opcode = this.state.activeFragmentedOperation;
     if (!(this.state.opcode == 1 || this.state.opcode == 2)) {
@@ -542,7 +542,7 @@ Parser.prototype.processPacket = function (data) {
       return;
     }
   }
-  else {    
+  else {
     this.state.opcode = opcode;
     if (this.state.lastFragment === false) {
         this.state.activeFragmentedOperation = opcode;
@@ -570,7 +570,7 @@ Parser.prototype.endPacket = function() {
   this.state.lastFragment = false;
   this.state.opcode = this.state.activeFragmentedOperation != null ? this.state.activeFragmentedOperation : 0;
   this.state.masked = false;
-  this.expect('Opcode', 2, this.processPacket);  
+  this.expect('Opcode', 2, this.processPacket);
 }
 
 /**
@@ -603,7 +603,7 @@ Parser.prototype.unmask = function (mask, buf, binary) {
   if (mask != null) {
     for (var i = 0, ll = buf.length; i < ll; i++) {
       buf[i] ^= mask[i % 4];
-    }    
+    }
   }
   if (binary) return buf;
   return buf != null ? buf.toString('utf8') : '';

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "expresso": "0.9.2"
       , "should": "*"
       , "benchmark": "0.2.2"
-      , "microtime": "0.1.3-1"
+      , "microtime": "2.1.3"
       , "colors": "0.5.1"
     }
   , "optionalDependencies": {


### PR DESCRIPTION
Make version v0.9 compatible with Node ^v6.9.1 by using require('events') instead of process.EventEmitter

* [x] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

