### PR TITLE
Fixed "Getting Started" not being bold

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -117,7 +117,7 @@ See [above](#new-serverhttpserver-options) for available options.
 
 The default (`/`) namespace.
 
-#### server.serveClient([value])
+#### server.serveClient([value])
 
   - `value` _(Boolean)_
   - **Returns** `Server|Boolean`
@@ -134,14 +134,14 @@ io.serveClient(false);
 io.attach(http);
 ```
 
-#### server.path([value])
+#### server.path([value])
 
   - `value` _(String)_
   - **Returns** `Server|String`
 
 Sets the path `value` under which `engine.io` and the static files will be served. Defaults to `/socket.io`. If no arguments are supplied this method returns the current value.
 
-#### server.adapter([value])
+#### server.adapter([value])
 
   - `value` _(Adapter)_
   - **Returns** `Server|Adapter`
@@ -181,7 +181,7 @@ Attaches the `Server` to an engine.io instance on `httpServer` with the supplied
 
 Attaches the `Server` to an engine.io instance on a new http.Server with the supplied `options` (optionally).
 
-#### server.listen(httpServer[, options])
+#### server.listen(httpServer[, options])
 
 Synonym of [server.attach(httpServer[, options])](#serverattachhttpserver-options).
 
@@ -189,7 +189,7 @@ Synonym of [server.attach(httpServer[, options])](#serverattachhttpserver-option
 
 Synonym of [server.attach(port[, options])](#serverattachport-options).
 
-#### server.bind(engine)
+#### server.bind(engine)
 
   - `engine` _(engine.Server)_
   - **Returns** `Server`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 
 ## Table of Contents
 
-#### Getting started
+#### Getting started
 
   - [Write a chat application](http://socket.io/get-started/chat/)
 


### PR DESCRIPTION
It had showed four pound signs, now it is bold. I fixed it by deleting and re-adding the space in between the pounds and the text. Not sure why that was the issue, but I fixed it nonetheless.


### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
Showed four pound signs

### New behaviour
It's bold now

### Other information (e.g. related issues)  
None

