### PR TITLE
Move binary detection to the parser

### DIFF
--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -7,7 +7,6 @@ var Socket = require('./socket');
 var Emitter = require('events').EventEmitter;
 var parser = require('socket.io-parser');
 var debug = require('debug')('socket.io:namespace');
-var hasBin = require('has-binary');
 
 /**
  * Module exports.
@@ -210,10 +209,7 @@ Namespace.prototype.emit = function(ev){
   } else {
     // set up packet object
     var args = Array.prototype.slice.call(arguments);
-    var parserType = parser.EVENT; // default
-    if (hasBin(args)) { parserType = parser.BINARY_EVENT; } // binary
-
-    var packet = { type: parserType, data: args };
+    var packet = { type: parser.EVENT, data: args };
 
     if ('function' == typeof args[args.length - 1]) {
       throw new Error('Callbacks are not supported when broadcasting');

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -7,7 +7,6 @@ var Emitter = require('events').EventEmitter;
 var parser = require('socket.io-parser');
 var url = require('url');
 var debug = require('debug')('socket.io:socket');
-var hasBin = require('has-binary');
 var assign = require('object-assign');
 
 /**
@@ -143,7 +142,7 @@ Socket.prototype.emit = function(ev){
   } else {
     var args = Array.prototype.slice.call(arguments);
     var packet = {
-      type: hasBin(args) ? parser.BINARY_EVENT : parser.EVENT,
+      type: parser.EVENT,
       data: args
     };
 
@@ -375,10 +374,9 @@ Socket.prototype.ack = function(id){
     var args = Array.prototype.slice.call(arguments);
     debug('sending ack %j', args);
 
-    var type = hasBin(args) ? parser.BINARY_ACK : parser.ACK;
     self.packet({
       id: id,
-      type: type,
+      type: parser.ACK,
       data: args
     });
 

--- a/package.json
+++ b/package.json
@@ -26,11 +26,10 @@
   "dependencies": {
     "debug": "2.3.3",
     "engine.io": "2.0.2",
-    "has-binary": "0.1.7",
     "object-assign": "4.1.0",
     "socket.io-adapter": "~1.1.0",
     "socket.io-client": "socketio/socket.io-client",
-    "socket.io-parser": "2.3.1"
+    "socket.io-parser": "~3.1.1"
   },
   "devDependencies": {
     "babel-preset-es2015": "6.3.13",

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -1730,8 +1730,10 @@ describe('socket.io', function(){
       });
     });
 
-    it('should not crash when messing with Object prototype', function(done){
+    it('should not crash when messing with Object prototype (and other globals)', function(done){
       Object.prototype.foo = 'bar';
+      global.File = '';
+      global.Blob = [];
       var srv = http();
       var sio = io(srv);
       srv.listen(function(){


### PR DESCRIPTION
Following https://github.com/socketio/socket.io-parser/pull/66 and https://github.com/socketio/socket.io-client/pull/1103.

Because the `hasBinary` check may be useless for some parser (like [socket.io-msgpack-parser](https://github.com/darrachequesne/socket.io-msgpack-parser)).

Also closes https://github.com/socketio/socket.io/issues/2871