### PR TITLE
fix timing issues with middleware

### DIFF
--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -99,6 +99,8 @@ Namespace.prototype.initAdapter = function(){
  */
 
 Namespace.prototype.use = function(fn){
+  debug('removing initial packet');
+  delete this.server.eio.initialPacket;
   this.fns.push(fn);
   return this;
 };

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -297,9 +297,10 @@ Socket.prototype.onconnect = function(){
   debug('socket connected - writing packet');
   this.nsp.connected[this.id] = this;
   this.join(this.id);
-  // the CONNECT packet for the default namespace
-  // has already been sent as an `initialPacket`
-  if (this.nsp.name !== '/') {
+  var skip = this.nsp.name === '/' && this.nsp.fns.length === 0;
+  if (skip) {
+    debug('packet already sent in initial handshake');
+  } else {
     this.packet({ type: parser.CONNECT });
   }
 };

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -87,6 +87,9 @@ describe('socket.io', function(){
       srv.set('authorization', function(o, f) { f(null, false); });
 
       var socket = client(httpSrv);
+      socket.on('connect', function(){
+        expect().fail();
+      });
       socket.on('error', function(err) {
         expect(err).to.be('Not authorized');
         done();
@@ -2145,6 +2148,9 @@ describe('socket.io', function(){
       });
       srv.listen(function(){
         var socket = client(srv);
+        socket.on('connect', function(){
+          done(new Error('nope'));
+        });
         socket.on('error', function(err){
           expect(err).to.be('Authentication error');
           done();
@@ -2163,6 +2169,9 @@ describe('socket.io', function(){
       });
       srv.listen(function(){
         var socket = client(srv);
+        socket.on('connect', function(){
+          done(new Error('nope'));
+        });
         socket.on('error', function(err){
           expect(err).to.eql({ a: 'b', c: 3 });
           done();
@@ -2181,6 +2190,26 @@ describe('socket.io', function(){
         var socket = client(srv);
         sio.on('connection', function(socket){
           expect(socket.name).to.be('guillermo');
+          done();
+        });
+      });
+    });
+
+    it('should only call connection after (lengthy) fns', function(done){
+      var srv = http();
+      var sio = io(srv);
+      var authenticated = false;
+
+      sio.use(function(socket, next){
+        setTimeout(function () {
+          authenticated = true;
+          next();
+        }, 300);
+      });
+      srv.listen(function(){
+        var socket = client(srv);
+        socket.on('connect', function(){
+          expect(authenticated).to.be(true);
           done();
         });
       });


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

Using a middleware could previously lead to a connecting client
receiving a connect event from the server before the server triggers
its own connect event.

### New behaviour


### Other information (e.g. related issues)

Fixes https://github.com/socketio/socket.io/issues/2935.
