### PR TITLE
Update slack badge as it's broken.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@
 [![devDependency Status](https://david-dm.org/socketio/socket.io/dev-status.svg)](https://david-dm.org/socketio/socket.io#info=devDependencies)
 [![NPM version](https://badge.fury.io/js/socket.io.svg)](https://www.npmjs.com/package/socket.io)
 ![Downloads](https://img.shields.io/npm/dm/socket.io.svg?style=flat)
-[![](http://slack.socket.io/badge.svg?)](http://slack.socket.io)
+[![](https://img.shields.io/badge/Slack-socket.io-brightgreen.svg?style=flat)](https://slackin-socketio.now.sh)
 
 ## Features
 

--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@
 [![devDependency Status](https://david-dm.org/socketio/socket.io/dev-status.svg)](https://david-dm.org/socketio/socket.io#info=devDependencies)
 [![NPM version](https://badge.fury.io/js/socket.io.svg)](https://www.npmjs.com/package/socket.io)
 ![Downloads](https://img.shields.io/npm/dm/socket.io.svg?style=flat)
-[![](https://img.shields.io/badge/Slack-socket.io-brightgreen.svg?style=flat)](https://slackin-socketio.now.sh)
+[![](https://slackin-socketio.now.sh/badge.svg)](https://slackin-socketio.now.sh)
 
 ## Features
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
![capture d ecran 2017-06-03 a 18 09 51](https://cloud.githubusercontent.com/assets/38223/26757403/2de08896-4888-11e7-880e-d857c1b2a23e.png)
![capture d ecran 2017-06-03 a 18 07 10](https://cloud.githubusercontent.com/assets/38223/26757404/2de28164-4888-11e7-9e8d-53f83d76472e.png)
![capture d ecran 2017-06-03 a 18 07 04](https://cloud.githubusercontent.com/assets/38223/26757407/2de7efb4-4888-11e7-8e69-91bb0a6d20d7.png)
![capture d ecran 2017-06-03 a 18 06 37](https://cloud.githubusercontent.com/assets/38223/26757406/2de68728-4888-11e7-9abb-7813c88ab981.png)


### New behaviour
1. Update URL of badge to [https://slackin-socketio.now.sh/badge.svg](https://slackin-socketio.now.sh/badge.svg)
1. Update URL To slack channel [https://slackin-socketio.now.sh](https://slackin-socketio.now.sh)
![capture d ecran 2017-06-03 a 18 12 25](https://cloud.githubusercontent.com/assets/38223/26757422/8f9fd3de-4888-11e7-9efd-f9a30439d5a0.png)

### Other information (e.g. related issues)


