### PR TITLE
fix middleware initialization

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -245,29 +245,43 @@ Server.prototype.attach = function(srv, opts){
   // set origins verification
   opts.allowRequest = opts.allowRequest || this.checkRequest.bind(this);
 
-  var self = this;
+  if (this.sockets.fns.length > 0) {
+    this.initEngine(srv, opts);
+    return this;
+  }
 
+  var self = this;
   var connectPacket = { type: parser.CONNECT, nsp: '/' };
   this.encoder.encode(connectPacket, function (encodedPacket){
     // the CONNECT packet will be merged with Engine.IO handshake,
     // to reduce the number of round trips
     opts.initialPacket = encodedPacket;
 
-    // initialize engine
-    debug('creating engine.io instance with opts %j', opts);
-    self.eio = engine.attach(srv, opts);
-
-    // attach static file serving
-    if (self._serveClient) self.attachServe(srv);
-
-    // Export http server
-    self.httpServer = srv;
-
-    // bind to engine events
-    self.bind(self.eio);
+    self.initEngine(srv, opts);
   });
-
   return this;
+};
+
+/**
+ * Initialize engine
+ *
+ * @param {Object} options passed to engine.io
+ * @api private
+ */
+
+Server.prototype.initEngine = function(srv, opts){
+  // initialize engine
+  debug('creating engine.io instance with opts %j', opts);
+  this.eio = engine.attach(srv, opts);
+
+  // attach static file serving
+  if (this._serveClient) this.attachServe(srv);
+
+  // Export http server
+  this.httpServer = srv;
+
+  // bind to engine events
+  this.bind(this.eio);
 };
 
 /**

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -99,8 +99,10 @@ Namespace.prototype.initAdapter = function(){
  */
 
 Namespace.prototype.use = function(fn){
-  debug('removing initial packet');
-  delete this.server.eio.initialPacket;
+  if (this.server.eio) {
+    debug('removing initial packet');
+    delete this.server.eio.initialPacket;
+  }
   this.fns.push(fn);
   return this;
 };

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -2268,6 +2268,19 @@ describe('socket.io', function(){
         });
       });
     });
+
+    it('should disable the merge of handshake packets', function(done){
+      var srv = http();
+      var sio = io();
+      sio.use(function(socket, next){
+        next();
+      });
+      sio.listen(srv);
+      var socket = client(srv);
+      socket.on('connect', function(){
+        done();
+      });
+    });
   });
 
   describe('socket middleware', function(done){


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour


### New behaviour

Fix `TypeError: Cannot convert undefined or null to object` when a middleware is added before the engine is properly attached.
 
### Other information (e.g. related issues)

Closes https://github.com/socketio/socket.io/issues/2963.
