### PR TITLE
reset rooms object before broadcasting

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -139,38 +139,42 @@ Socket.prototype.buildHandshake = function(query){
 Socket.prototype.emit = function(ev){
   if (~exports.events.indexOf(ev)) {
     emit.apply(this, arguments);
-  } else {
-    var args = Array.prototype.slice.call(arguments);
-    var packet = {
-      type: parser.EVENT,
-      data: args
-    };
+    return this;
+  }
 
-    // access last argument to see if it's an ACK callback
-    if (typeof args[args.length - 1] === 'function') {
-      if (this._rooms.length || this.flags.broadcast) {
-        throw new Error('Callbacks are not supported when broadcasting');
-      }
+  var args = Array.prototype.slice.call(arguments);
+  var packet = {
+    type: parser.EVENT,
+    data: args
+  };
 
-      debug('emitting packet with ack id %d', this.nsp.ids);
-      this.acks[this.nsp.ids] = args.pop();
-      packet.id = this.nsp.ids++;
-    }
-
+  // access last argument to see if it's an ACK callback
+  if (typeof args[args.length - 1] === 'function') {
     if (this._rooms.length || this.flags.broadcast) {
-      this.adapter.broadcast(packet, {
-        except: [this.id],
-        rooms: this._rooms,
-        flags: this.flags
-      });
-    } else {
-      // dispatch packet
-      this.packet(packet, this.flags);
+      throw new Error('Callbacks are not supported when broadcasting');
     }
 
-    // reset flags
-    this._rooms = [];
-    this.flags = {};
+    debug('emitting packet with ack id %d', this.nsp.ids);
+    this.acks[this.nsp.ids] = args.pop();
+    packet.id = this.nsp.ids++;
+  }
+
+  var rooms = this._rooms.slice(0);
+  var flags = assign({}, this.flags);
+
+  // reset flags
+  this._rooms = [];
+  this.flags = {};
+
+  if (rooms.length || flags.broadcast) {
+    this.adapter.broadcast(packet, {
+      except: [this.id],
+      rooms: rooms,
+      flags: flags
+    });
+  } else {
+    // dispatch packet
+    this.packet(packet, flags);
   }
   return this;
 };


### PR DESCRIPTION

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

It seems packets could be delivered to wrong room in some case, if the `_rooms` array was not reset before the next emit.

### New behaviour


### Other information (e.g. related issues)

Closes https://github.com/socketio/socket.io/issues/2962.

