### PR TITLE
Adding Socket ID to disconnecting and disconnect event callbacks

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -96,7 +96,9 @@ var server = require('http').createServer();
 var io = require('socket.io')(server);
 io.on('connection', function(client){
   client.on('event', function(data){});
-  client.on('disconnect', function(){});
+  client.on('disconnect', function(id){
+    console.log("Socket with ID ",id," Disconnected");
+  });
 });
 server.listen(3000);
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -96,7 +96,7 @@ var server = require('http').createServer();
 var io = require('socket.io')(server);
 io.on('connection', function(client){
   client.on('event', function(data){});
-  client.on('disconnect', function(id){
+  client.on('disconnect', function(reason, id){
     console.log("Socket with ID ",id," Disconnected");
   });
 });

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -443,14 +443,14 @@ Socket.prototype.onerror = function(err){
 Socket.prototype.onclose = function(reason){
   if (!this.connected) return this;
   debug('closing socket - reason %s', reason);
-  this.emit('disconnecting', reason);
+  this.emit('disconnecting', this.id, reason);
   this.leaveAll();
   this.nsp.remove(this);
   this.client.remove(this);
   this.connected = false;
   this.disconnected = true;
   delete this.nsp.connected[this.id];
-  this.emit('disconnect', reason);
+  this.emit('disconnect', this.id, reason);
 };
 
 /**

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -443,14 +443,14 @@ Socket.prototype.onerror = function(err){
 Socket.prototype.onclose = function(reason){
   if (!this.connected) return this;
   debug('closing socket - reason %s', reason);
-  this.emit('disconnecting', this.id, reason);
+  this.emit('disconnecting', reason, this.id);
   this.leaveAll();
   this.nsp.remove(this);
   this.client.remove(this);
   this.connected = false;
   this.disconnected = true;
   delete this.nsp.connected[this.id];
-  this.emit('disconnect', this.id, reason);
+  this.emit('disconnect', reason, this.id);
 };
 
 /**


### PR DESCRIPTION
Needed a way to determine which socket disconnected.  Updated the emit() callbacks for "disconnecting" and "disconnected" to return the unique ID of the socket connection.

### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ]  other

### Current behaviour

    client.on('disconnect',()=>{
       // returns no useful information
    });

### New behaviour

    client.on('disconnect',(reason,id)=>{
        console.log(`The user with socket ID ${id} just disconnected`);
    });

### Other information (e.g. related issues)


