### PR TITLE
Update to Babel 7

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,7 @@ const TRANSPILE_DEST_DIR = './dist';
 // By default, individual js files are transformed by babel and exported to /dist
 gulp.task('transpile', function () {
   return gulp.src("lib/*.js")
-    .pipe(babel({ "presets": ["es2015"] }))
+    .pipe(babel({ "presets": ["env"] }))
     .pipe(gulp.dest(TRANSPILE_DEST_DIR));
 });
 

--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
     "socket.io-parser": "~3.1.1"
   },
   "devDependencies": {
-    "babel-preset-es2015": "^6.24.1",
+    "babel-core": "^7.0.0-beta.0",
+    "babel-preset-env": "2.0.0-beta.0",
     "del": "^2.2.2",
     "expect.js": "0.3.1",
     "gulp": "^3.9.1",
-    "gulp-babel": "^6.1.2",
+    "gulp-babel": "^7.0.0",
     "gulp-istanbul": "^1.1.1",
     "gulp-mocha": "^4.3.1",
     "gulp-task-listing": "1.0.1",


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

Update build tool

### Current behaviour

Uses preset-es2015

### New behaviour

Uses https://github.com/babel/babel-preset-env, has the same functionality without options but is future facing.

### Other information (e.g. related issues)

> Babel 7 post: http://babeljs.io/blog/2017/09/12/planning-for-7.0
