### PR TITLE
fix cannot catch error where error in a listener

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -510,7 +510,11 @@ Socket.prototype.dispatch = function(event){
       if (err) {
         return self.error(err.data || err.message);
       }
-      emit.apply(self, event);
+      try {
+          emit.apply(self, event);
+      } catch(e) {
+          emit.call(self, 'error', e);
+      }
     });
   }
   this.run(event, dispatchSocket);


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix

### Current behaviour
client.on('error', (err) => {
    console.log(err);
});

client.on('entter', () => {
    try {
       throw new Error('test');
   } catch (err) {
      client.emit('error', err);
  }    
});

i must try catch error in a listener,otherwise the error listener does not work.
### New behaviour
client.on('error', (err) => {
    console.log(err);
});
client.on('entter', () => {
    throw new Error('test');
});
### Other information (e.g. related issues)


