### PR TITLE
[fix] Properly emit 'connect' when using a custom namespace

### DIFF
--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -100,7 +100,7 @@ Namespace.prototype.initAdapter = function(){
  */
 
 Namespace.prototype.use = function(fn){
-  if (this.server.eio) {
+  if (this.server.eio && this.name === '/') {
     debug('removing initial packet');
     delete this.server.eio.initialPacket;
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "engine.io": "~3.2.0",
     "has-binary2": "~1.0.2",
     "socket.io-adapter": "~1.1.0",
-    "socket.io-client": "2.0.4",
+    "socket.io-client": "socketio/socket.io-client",
     "socket.io-parser": "~3.2.0"
   },
   "devDependencies": {

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -2352,6 +2352,23 @@ describe('socket.io', function(){
         done();
       });
     });
+
+    it('should work with a custom namespace', (done) => {
+      var srv = http();
+      var sio = io();
+      sio.listen(srv);
+      sio.of('/chat').use(function(socket, next){
+        next();
+      });
+
+      var count = 0;
+      client(srv, '/').on('connect', () => {
+        if (++count === 2) done();
+      });
+      client(srv, '/chat').on('connect', () => {
+        if (++count === 2) done();
+      });
+    });
   });
 
   describe('socket middleware', function(done){


### PR DESCRIPTION
When using a custom namespace with a middleware, the client did not receive the 'connect' event.


### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour


### New behaviour


### Other information (e.g. related issues)


