### PR TITLE
[fix] Include the protocol in the origins check

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -225,13 +225,13 @@ io.adapter(redis({ host: 'localhost', port: 6379 }));
 
 #### server.origins([value])
 
-  - `value` _(String)_
+  - `value` _(String|String[])_
   - **Returns** `Server|String`
 
 Sets the allowed origins `value`. Defaults to any origins being allowed. If no arguments are supplied this method returns the current value.
 
 ```js
-io.origins(['foo.example.com:443']);
+io.origins(['https://foo.example.com:443']);
 ```
 
 #### server.origins(fn)

--- a/lib/index.js
+++ b/lib/index.js
@@ -80,9 +80,11 @@ Server.prototype.checkRequest = function(req, fn) {
         ? parts.port
         : defaultPort;
       var ok =
+        ~this._origins.indexOf(parts.protocol + '//' + parts.hostname + ':' + parts.port) ||
         ~this._origins.indexOf(parts.hostname + ':' + parts.port) ||
         ~this._origins.indexOf(parts.hostname + ':*') ||
         ~this._origins.indexOf('*:' + parts.port);
+      debug('origin %s is %svalid', origin, !!ok ? '' : 'not ');
       return fn(null, !!ok);
     } catch (ex) {
     }
@@ -241,7 +243,7 @@ Server.prototype.adapter = function(v){
 /**
  * Sets the allowed origins for requests.
  *
- * @param {String} v origins
+ * @param {String|String[]} v origins
  * @return {Server|Adapter} self when setting or value when getting
  * @api public
  */

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -354,6 +354,17 @@ describe('socket.io', function(){
           done();
         });
     });
+
+    it('should allow request when using an array of origins', function(done) {
+      io({ origins: [ 'http://foo.example:54024' ] }).listen('54024');
+      request.get('http://localhost:54024/socket.io/default/')
+        .set('origin', 'http://foo.example:54024')
+        .query({ transport: 'polling' })
+        .end(function (err, res) {
+          expect(res.status).to.be(200);
+          done();
+        });
+    });
   });
 
   describe('close', function(){


### PR DESCRIPTION
Previously, the protocol was not taken in account, which caused the following behaviour:

```js
io.origins('https://foo.example.com:443'); // ok as a string
io.origins(['https://foo.example.com:443'); // not ok as an array
```

Fixes #3190


### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour


### New behaviour


### Other information (e.g. related issues)


