### PR TITLE
add local flag to the socket object

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -39,7 +39,8 @@ exports.events = [
 var flags = [
   'json',
   'volatile',
-  'broadcast'
+  'broadcast',
+  'local'
 ];
 
 /**


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour

Currently, the only way to set the local flag when in socket context is as follow

```js
socket.flags['local'] = true;
```

### New behaviour

Now we can add the local flag the same way we do it on the Namespace object

```js
socket.local...
```
### Other information (e.g. related issues)

https://github.com/socketio/socket.io/issues/3217
