### PR TITLE
Add the "loopback" flag.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -163,6 +163,11 @@ Client.prototype.packet = function(packet, opts){
   opts = opts || {};
   var self = this;
 
+  if ('open' != this.conn.readyState) {
+    debug('ignoring packet write %j', packet);
+    return;
+  }
+
   // this writes to the actual connection
   function writeToEngine(encodedPackets) {
     if (opts.volatile && !self.conn.transport.writable) return;
@@ -171,15 +176,23 @@ Client.prototype.packet = function(packet, opts){
     }
   }
 
-  if ('open' == this.conn.readyState) {
+  if (opts.loopback) {
+    debug('writing loopback packet %j', packet);
+    // handle loopback packets as though they came in off the wire.
+    if (opts.preEncoded) { // a broadcast pre-encodes a packet
+      for (var i = 0; i < packet.length; i++) {
+        this.decoder.add(packet[i]);
+      }
+    } else { // no broadcasting, no need to decode
+      this.ondecoded(packet);
+    }
+  } else {
     debug('writing packet %j', packet);
     if (!opts.preEncoded) { // not broadcasting, need to encode
       this.encoder.encode(packet, writeToEngine); // encode, then write results to engine
     } else { // a broadcast pre-encodes a packet
       writeToEngine(packet);
     }
-  } else {
-    debug('ignoring packet write %j', packet);
   }
 };
 

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -30,6 +30,7 @@ exports.events = [
  */
 
 exports.flags = [
+  'loopback',
   'json',
   'volatile',
   'local'

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -37,6 +37,7 @@ exports.events = [
  */
 
 var flags = [
+  'loopback',
   'json',
   'volatile',
   'broadcast',
@@ -153,6 +154,10 @@ Socket.prototype.emit = function(ev){
   if (typeof args[args.length - 1] === 'function') {
     if (this._rooms.length || this.flags.broadcast) {
       throw new Error('Callbacks are not supported when broadcasting');
+    }
+
+    if (this.flags.loopback) {
+      throw new Error('Callbacks are not supported when emitting loopback messages');
     }
 
     debug('emitting packet with ack id %d', this.nsp.ids);


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

It is not possible to send messages to the local (server) endpoint. In scenarios where rooms/broadcasts are used, this requires the server to maintain a separate room->socket mapping so that administrative actions can be performed (e.g., close all sockets in room 'foo').

### New behaviour

With this change (and related PR https://github.com/socketio/socket.io-adapter/pull/56), it is possible to emit/broadcast messages that are handled by the local (server) endpoint by inserting `.loopback` into the emit syntax. On connect, the server can add handlers for messages that originate server-side, and later broadcast those messages in order to effect administrative actions (e.g., close all sockets in room 'foo') without maintaining independent mappings.

### Other information (e.g. related issues)

https://github.com/socketio/socket.io-adapter/pull/56 must be committed before this change, as `socket.io-adapter` is used in tests and must honour the `loopback` flag.
