### PR TITLE
Add badge to display install size

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,7 @@
 [![devDependency Status](https://david-dm.org/socketio/socket.io/dev-status.svg)](https://david-dm.org/socketio/socket.io#info=devDependencies)
 [![NPM version](https://badge.fury.io/js/socket.io.svg)](https://www.npmjs.com/package/socket.io)
 ![Downloads](https://img.shields.io/npm/dm/socket.io.svg?style=flat)
+[![Install Size](https://packagephobia.now.sh/badge?p=socket.io)](https://packagephobia.now.sh/result?p=socket.io)
 [![](https://slackin-socketio.now.sh/badge.svg)](https://slackin-socketio.now.sh)
 
 ## Features


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

No badge

### New behaviour

Badge that displays the npm install size


### Other information (e.g. related issues)


