### PR TITLE
Throws an error when trying to access the clients of a dynamic namespace

### DIFF
--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -262,6 +262,9 @@ Namespace.prototype.write = function(){
  */
 
 Namespace.prototype.clients = function(fn){
+  if(!this.adapter){
+    throw new Error('No adapter for this namespace, are you trying to get the list of clients of a dynamic namespace?')
+  }
   this.adapter.clients(this.rooms, fn);
   // reset rooms for scenario:
   // .in('room').clients() (GH-1978)


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
Accessing the clients of a dynamic namespace throws because doing io.of(/your-regex/g) returns a namespace with no adapter and the clients methods tries to access namespace.adapter.clients

### New behaviour
Clearer error 

