### PR TITLE
Outgoing packet interceptor

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -29,6 +29,7 @@
     - [namespace.emit(eventName[, ...args])](#namespaceemiteventname-args)
     - [namespace.clients(callback)](#namespaceclientscallback)
     - [namespace.use(fn)](#namespaceusefn)
+    - [namespace.useinterceptor(fn)](#namespaceuseinterceptorfn)
     - [Event: 'connect'](#event-connect)
     - [Event: 'connection'](#event-connect)
     - [Flag: 'volatile'](#flag-volatile)
@@ -42,6 +43,7 @@
     - [socket.request](#socketrequest)
     - [socket.handshake](#sockethandshake)
     - [socket.use(fn)](#socketusefn)
+    - [socket.useinterceptor(fn)](#socketuseinterceptorfn)
     - [socket.send([...args][, ack])](#socketsendargs-ack)
     - [socket.emit(eventName[, ...args][, ack])](#socketemiteventname-args-ack)
     - [socket.on(eventName, callback)](#socketoneventname-callback)
@@ -472,6 +474,22 @@ io.use((socket, next) => {
 });
 ```
 
+#### namespace.useinterceptor(fn)
+
+  - `fn` _(Function)_
+
+Registers a middleware, which is a function that gets executed for every outgoing message that was initiated via `emit`, and receives as parameters the packet and a function to optionally defer execution to the next registered middleware.
+
+Errors passed to middleware callbacks are sent as special `error` packets to clients.
+
+```js
+io.useinterceptor((packet, next) => {
+  let authenticated = checkAuth();
+  if (authenticated) return next();
+  next(new Error('Authentication error'));
+});
+```
+
 #### Event: 'connect'
 
   - `socket` _(Socket)_ socket connection with client
@@ -612,6 +630,22 @@ io.on('connection', (socket) => {
     if (packet.doge === true) return next();
     next(new Error('Not a doge error'));
   });
+});
+```
+
+#### socket.useinterceptor(fn)
+
+  - `fn` _(Function)_
+
+Registers a middleware, which is a function that gets executed for every outgoing message that was initiated via `emit`, and receives as parameters the packet and a function to optionally defer execution to the next registered middleware.
+
+Errors passed to middleware callbacks are sent as special `error` packets to clients.
+
+```js
+io.useinterceptor((packet, next) => {
+  let authenticated = checkAuth();
+  if (authenticated) return next();
+  next(new Error('Authentication error'));
 });
 ```
 

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -55,6 +55,7 @@ function Namespace(server, name){
   this.sockets = {};
   this.connected = {};
   this.fns = [];
+  this.interceptfns = [];
   this.ids = 0;
   this.rooms = [];
   this.flags = {};
@@ -105,6 +106,18 @@ Namespace.prototype.use = function(fn){
     delete this.server.eio.initialPacket;
   }
   this.fns.push(fn);
+  return this;
+};
+
+/**
+ * Sets up namespace interceptor middleware.
+ *
+ * @return {Namespace} self
+ * @api public
+ */
+
+Namespace.prototype.useinterceptor = function(fn){
+  this.interceptfns.push(fn);
   return this;
 };
 

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -70,6 +70,7 @@ function Socket(nsp, client, query){
   this.disconnected = false;
   this.handshake = this.buildHandshake(query);
   this.fns = [];
+  this.interceptfns = [];
   this.flags = {};
   this._rooms = [];
 }
@@ -221,7 +222,14 @@ Socket.prototype.packet = function(packet, opts){
   packet.nsp = this.nsp.name;
   opts = opts || {};
   opts.compress = false !== opts.compress;
-  this.client.packet(packet, opts);
+
+  var self = this;
+  this.runout(packet, opts, function(err){
+    process.nextTick(function(){
+      if (err) return self.error(err.data || err.message);
+      self.client.packet(packet, opts);
+    });
+  });
 };
 
 /**
@@ -545,6 +553,18 @@ Socket.prototype.use = function(fn){
 };
 
 /**
+ * Sets up namespace interceptor middleware.
+ *
+ * @return {Namespace} self
+ * @api public
+ */
+
+Socket.prototype.useinterceptor = function(fn){
+  this.interceptfns.push(fn);
+  return this;
+};
+
+/**
  * Executes the middleware for an incoming event.
  *
  * @param {Array} event that will get emitted
@@ -569,4 +589,48 @@ Socket.prototype.run = function(event, fn){
   }
 
   run(0);
+};
+
+/**
+ * Executes the middleware for an outgoing message.
+ *
+ * @param {Socket} packet that is to be sent
+ * @param {Function} fn last fn call in the middleware
+ * @api private
+ */
+
+Socket.prototype.runout = function(packet, opts, fn){
+  var combinedfns = this.interceptfns.concat(this.nsp.interceptfns);
+  var fns = combinedfns.slice(0);
+  var decodedPacket;
+
+  if (!fns.length) return fn(null);
+
+  function run(i){
+    fns[i](decodedPacket, function(err){
+      // upon error, short-circuit
+      if (err) return fn(err);
+
+      // if no middleware left, summon callback
+      if (!fns[i + 1]) return fn(null);
+
+      // go on to next
+      run(i + 1);
+    });
+  }
+
+  new Promise(resolve => {
+    if(opts.preEncoded) {
+      var decoder = new parser.Decoder();
+      decoder.on('decoded', function (decodedPacket) {
+        resolve(decodedPacket);
+      });
+      decoder.add(packet[0]);
+    } else {
+      resolve(packet);
+    }
+  }).then((p) => {
+    decodedPacket = p
+    run(0);
+  });
 };

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -606,8 +606,9 @@ Socket.prototype.runout = function(packet, opts, fn){
 
   if (!fns.length) return fn(null);
 
+  var self = this;
   function run(i){
-    fns[i](decodedPacket, function(err){
+    fns[i](self, decodedPacket, function(err){
       // upon error, short-circuit
       if (err) return fn(err);
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [X] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
Outgoing packets cannot be intercepted in an easy way (i.e. for checking authentication before sending).

### New behaviour
Interceptors (middleware) can be registered on a namespace and socket in a similar way the connection middleware is registered. When Socket.packet is called to send a packet, all middleware is called, similar to the connection middleware. If no error occurred, the underlying client's packet() method is called. If one middleware returned an error, the error is sent to the client.

### Other information (e.g. related issues)

