### PR TITLE
Fix documentation about default origins value. Update API.md

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -78,7 +78,7 @@ Exposed by `require('socket.io')`.
     - `path` _(String)_: name of the path to capture (`/socket.io`)
     - `serveClient` _(Boolean)_: whether to serve the client files (`true`)
     - `adapter` _(Adapter)_: the adapter to use. Defaults to an instance of the `Adapter` that ships with socket.io which is memory based. See [socket.io-adapter](https://github.com/socketio/socket.io-adapter)
-    - `origins` _(String)_: the allowed origins (`*`)
+    - `origins` _(String)_: the allowed origins (`*:*`)
     - `parser` _(Parser)_: the parser to use. Defaults to an instance of the `Parser` that ships with socket.io. See [socket.io-parser](https://github.com/socketio/socket.io-parser).
 
 Works with and without `new`:


### PR DESCRIPTION
I was struggling with CORS issues using explicitly the default origins value `*` on development, a value that is retrieved from a `.env` file, but turns out that the default is actually `*:*`.

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current documentation
origins (String): the allowed origins (`*`)

### New documentation
origins (String): the allowed origins (`*:*`)

### Other information (e.g. related issues)
