### PR TITLE
fix: Buffer() is deprecated

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -635,7 +635,11 @@ Emits an event to the socket identified by the string name. Any other parameters
 
 ```js
 socket.emit('hello', 'world');
+<<<<<<< HEAD
 socket.emit('with-binary', 1, '2', { 3: '4', 5: new Buffer(6) });
+=======
+socket.emit('with-binary', 1, '2', { 3: '4', 5: new Buffer.alloc(6) });
+>>>>>>> e210a60... fix: Buffer() is deprecated
 ```
 
 The `ack` argument is optional and will be called with the client's answer.

--- a/examples/custom-parsers/README.md
+++ b/examples/custom-parsers/README.md
@@ -14,7 +14,11 @@ They are tested with various payloads:
 
 - string: `['1', '2', ... '1000']`
 - numeric: `[1, 2, ... 1000]`
+<<<<<<< HEAD
 - binary: `new Buffer(1000), where buf[i] = i`
+=======
+- binary: `new Buffer.alloc(1000), where buf[i] = i`
+>>>>>>> e210a60... fix: Buffer() is deprecated
 
 ## How to use
 

--- a/examples/custom-parsers/src/server.js
+++ b/examples/custom-parsers/src/server.js
@@ -27,7 +27,11 @@ let server4 = io(3004, {
 
 let string = [];
 let numeric = [];
+<<<<<<< HEAD
 let binary = new Buffer(1e3);
+=======
+let binary = new Buffer.alloc(1e3);
+>>>>>>> e210a60... fix: Buffer() is deprecated
 for (var i = 0; i < 1e3; i++) {
   string.push('' + i);
   numeric.push(i);

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -1496,7 +1496,11 @@ describe('socket.io', function(){
             expect(Buffer.isBuffer(buf)).to.be(true);
             fn(1, 2);
           });
+<<<<<<< HEAD
           socket.emit('woot', new Buffer(3), function(a, b){
+=======
+          socket.emit('woot', new Buffer.alloc(3), function(a, b){
+>>>>>>> e210a60... fix: Buffer() is deprecated
             expect(a).to.be(1);
             expect(b).to.be(2);
             done();
@@ -1515,7 +1519,11 @@ describe('socket.io', function(){
             expect(Buffer.isBuffer(a)).to.be(true);
             fn();
           });
+<<<<<<< HEAD
           s.emit('hi', new Buffer(4), function(){
+=======
+          s.emit('hi', new Buffer.alloc(4), function(){
+>>>>>>> e210a60... fix: Buffer() is deprecated
             done();
           });
         });
@@ -1529,7 +1537,11 @@ describe('socket.io', function(){
         var socket = client(srv);
         sio.on('connection', function(s){
           socket.on('hi', function(fn){
+<<<<<<< HEAD
             fn(new Buffer(1));
+=======
+            fn(new Buffer.alloc(1));
+>>>>>>> e210a60... fix: Buffer() is deprecated
           });
           s.emit('hi', function(a){
             expect(Buffer.isBuffer(a)).to.be(true);
@@ -1546,7 +1558,11 @@ describe('socket.io', function(){
         var socket = client(srv);
         sio.on('connection', function(s){
           s.on('woot', function(fn){
+<<<<<<< HEAD
             fn(new Buffer(2));
+=======
+            fn(new Buffer.alloc(2));
+>>>>>>> e210a60... fix: Buffer() is deprecated
           });
           socket.emit('woot', function(a){
             expect(Buffer.isBuffer(a)).to.be(true);
@@ -1899,7 +1915,11 @@ describe('socket.io', function(){
         });
 
         function emit(){
+<<<<<<< HEAD
           sio.emit('bin', new Buffer(10));
+=======
+          sio.emit('bin', new Buffer.alloc(10));
+>>>>>>> e210a60... fix: Buffer() is deprecated
         }
       });
     });
@@ -2083,8 +2103,13 @@ describe('socket.io', function(){
             socket.join(room, fn);
           });
           socket.on('broadcast', function(){
+<<<<<<< HEAD
             socket.broadcast.to('test').emit('bin', new Buffer(5));
             socket.emit('bin2', new Buffer(5));
+=======
+            socket.broadcast.to('test').emit('bin', new Buffer.alloc(5));
+            socket.emit('bin2', new Buffer.alloc(5));
+>>>>>>> e210a60... fix: Buffer() is deprecated
           });
         });
       });


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [x] a code change that improves performance
* [ ] other

### Current behaviour
Buffer() is deprecated warning in tests

### New behaviour
No deprecated warning

### Other information (e.g. related issues)


