### PR TITLE
[assets] confirm a weak but matching ETag

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -358,10 +358,11 @@ Server.prototype.serve = function(req, res){
   // Per the standard, ETags must be quoted:
   // https://tools.ietf.org/html/rfc7232#section-2.3
   var expectedEtag = '"' + clientVersion + '"';
+  var weakEtag = 'W/' + expectedEtag;
 
   var etag = req.headers['if-none-match'];
   if (etag) {
-    if (expectedEtag == etag) {
+    if (expectedEtag == etag || weakEtag == etag) {
       debug('serve client 304');
       res.writeHead(304);
       res.end();

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -182,6 +182,19 @@ describe('socket.io', function(){
         });
       });
 
+      it('should handle 304 from weak etag', function(done){
+        var srv = http();
+        io(srv);
+        request(srv)
+            .get('/socket.io/socket.io.js')
+            .set('If-None-Match', 'W/"' + clientVersion + '"')
+            .end(function(err, res){
+              if (err) return done(err);
+              expect(res.statusCode).to.be(304);
+              done();
+            });
+      });
+
       it('should not serve static files', function(done){
         var srv = http();
         io(srv, { serveClient: false });


### PR DESCRIPTION
When handling compression at the proxy server level, the client receives a weak ETag.
Weak ETags are prefixed with `W/`, e.g. `W/"2.2.0"`.
Upon cache validation we should take care of these too.


### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
Server responds with a 200 + full payload for a weak but matching etag.

### New behaviour
Server responds with 304.

### Other information (e.g. related issues)
See linked rfc https://tools.ietf.org/html/rfc7232#section-2.3

