### PR TITLE
Fix query when multiplexing (#3495)

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -116,7 +116,7 @@ Socket.prototype.buildHandshake = function(query){
   function buildQuery(){
     var requestQuery = url.parse(self.request.url, true).query;
     //if socket-specific query exist, replace query strings in requestQuery
-    return Object.assign({}, query, requestQuery);
+    return Object.assign({}, requestQuery, query);
   }
   return {
     headers: this.request.headers,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket.io",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "node.js realtime framework server",
   "keywords": [
     "realtime",


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

When multiplexing is turned on - which is the default - the query sent to the server when connecting to another namespace is incorrectly processed (as described in #3495).

### New behaviour

The query params are correctly overriden on the server.

### Other information (e.g. related issues)

See #3495.

