### PR TITLE
Make sure correct client files are served, fixes #3555

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -106,7 +106,8 @@ Server.prototype.serveClient = function(v){
   if (!arguments.length) return this._serveClient;
   this._serveClient = v;
   var resolvePath = function(file){
-    var clientPath = require.resolve('socket.io-client'); // resolve the client dep. end in lib/index
+    // resolve the client dep. The resulting string ends with `lib/index.js`
+    var clientPath = require.resolve('socket.io-client');
     return path.normalize(path.join(path.dirname(clientPath), '..', '..', file));
   };
   if (v && !clientSource) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -106,11 +106,8 @@ Server.prototype.serveClient = function(v){
   if (!arguments.length) return this._serveClient;
   this._serveClient = v;
   var resolvePath = function(file){
-    var filepath = path.resolve(__dirname, './../../', file);
-    if (exists(filepath)) {
-      return filepath;
-    }
-    return require.resolve(file);
+    var clientPath = require.resolve('socket.io-client'); // resolve the client dep. end in lib/index
+    return path.normalize(path.join(path.dirname(clientPath), '..', '..', file));
   };
   if (v && !clientSource) {
     clientSource = read(resolvePath( 'socket.io-client/dist/socket.io.js'), 'utf-8');


### PR DESCRIPTION
The old logic missed some places and was not able to look into the node_modules of the socket.io library itself.

The new logic always uses require.resolve to lookup the "correct" location for the socker.io-client library and then construct the path correctly

This fixes #3555 

A fast release of a fixed version would be awesome!


### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour


### New behaviour


### Other information (e.g. related issues)


