### PR TITLE
Assign the peerCertificate before Node.js closes the connection

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -28,6 +28,13 @@ function Client(server, conn){
   this.decoder = new server.parser.Decoder();
   this.id = conn.id;
   this.request = conn.request;
+  if(conn.request.client && conn.request.client.getPeerCertificate){
+    this.peerCertificate = conn.request.client.getPeerCertificate();
+  }else
+  {
+    this.peerCertificate = null;
+  }
+  this.request = conn.request;
   this.setup();
   this.sockets = {};
   this.nsps = {};


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
socket.client.request.client.getPeerCertificate() always returns null

### New behaviour
socket.client.peerCertificate is populated before the underlying TLS is closed so it is available 
on socket.on("connection")

I belive this is the result of a change in node tls functionality.

[https://github.com/nodejs/node/commit/eff8c3e02417652b78436eaa10d049e8c60e5275](https://github.com/nodejs/node/commit/eff8c3e02417652b78436eaa10d049e8c60e5275)

### Other information (e.g. related issues)

[https://github.com/socketio/socket.io/issues/3567](https://github.com/socketio/socket.io/issues/3567)
