### PR TITLE
Add failing test for #3555 + the fix itself

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -106,7 +106,8 @@ Server.prototype.serveClient = function(v){
   if (!arguments.length) return this._serveClient;
   this._serveClient = v;
   var resolvePath = function(file){
-    var clientPath = require.resolve('socket.io-client'); // resolve the client dep. end in lib/index
+    // resolve the client dep. The resulting string ends with `lib/index.js`
+    var clientPath = require.resolve('socket.io-client');
     return path.normalize(path.join(path.dirname(clientPath), '..', '..', file));
   };
   if (v && !clientSource) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -106,11 +106,8 @@ Server.prototype.serveClient = function(v){
   if (!arguments.length) return this._serveClient;
   this._serveClient = v;
   var resolvePath = function(file){
-    var filepath = path.resolve(__dirname, './../../', file);
-    if (exists(filepath)) {
-      return filepath;
-    }
-    return require.resolve(file);
+    var clientPath = require.resolve('socket.io-client'); // resolve the client dep. end in lib/index
+    return path.normalize(path.join(path.dirname(clientPath), '..', '..', file));
   };
   if (v && !clientSource) {
     clientSource = read(resolvePath( 'socket.io-client/dist/socket.io.js'), 'utf-8');

--- a/lib/index.js
+++ b/lib/index.js
@@ -124,6 +124,15 @@ Server.prototype.serveClient = function(v){
 };
 
 /**
+ * Empties cache of client code.
+ * @api public
+ */
+Server.prototype.clearClientCodeCache = function(){
+  clientSource = undefined;
+  clientSourceMap = undefined;
+}
+
+/**
  * Old settings for backwards compatibility
  */
 

--- a/test/fixtures/create-fake-socket.io-client-module.js
+++ b/test/fixtures/create-fake-socket.io-client-module.js
@@ -1,0 +1,65 @@
+var fs = require('fs');
+var join = require('path').join;
+var io = require('../../lib');
+
+var testHadToCreateFakeModule = false
+var fakeModuleLocation = '../socket.io-client'
+var socketIOClientMainFilePath = fakeModuleLocation + '/dist/socket.io.js'
+
+before(function(){
+    // set up at fake socket.io-client module sitting at ../.. (sibling to socket.io folder). Emulates being on the same level inside a node_modules folder
+    // http.Server should ignore the fake module, and use the one in socket.io/node_modules/socket.io-client
+    try {
+        fs.mkdirSync(fakeModuleLocation);
+        testHadToCreateFakeModule = true;
+    } catch (_) {}
+
+    // load fake package.json
+    var fakePackageFixture = fs.readFileSync('./test/fixtures/package.json');
+    // place fake package.json, if necessary
+    try {
+        fs.writeFileSync(fakeModuleLocation + '/package.json', fakePackageFixture, { flag: 'wx' });
+        // 'wx' mode fails if the file exists
+    } catch (_) {}
+
+    try {
+        fs.mkdirSync(fakeModuleLocation + '/dist');
+    } catch (_) {}
+
+    // temporarily put away the real main file, if it exists
+    try {
+        fs.renameSync(socketIOClientMainFilePath, socketIOClientMainFilePath + '.temp')
+    } catch (_) {}
+    // write in the fake main file
+    fs.writeFileSync(socketIOClientMainFilePath, '\'im a fake socket.io-client\'');
+
+    io().clearClientCodeCache();
+})
+
+after(function(){
+    // put the temp file back into place, if it exists
+    try {
+        fs.renameSync(socketIOClientMainFilePath + '.temp', socketIOClientMainFilePath)
+    } catch (_) {}
+
+    if (testHadToCreateFakeModule) {
+        // delete whole folder
+        var deleteFolderRecursive = function(path) {
+            if (fs.existsSync(path)) {
+            fs.readdirSync(path).forEach((file, index) => {
+                var curPath = join(path, file);
+                if (fs.lstatSync(curPath).isDirectory()) { // recurse
+                deleteFolderRecursive(curPath);
+                } else { // delete file
+                fs.unlinkSync(curPath);
+                }
+            });
+            fs.rmdirSync(path);
+            }
+        };
+        
+        deleteFolderRecursive(fakeModuleLocation);
+    }
+
+    io().clearClientCodeCache();
+});

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "socket.io-client",
+    "version": "2.3.0",
+    "keywords": [
+      "this package.json is a fixture for a socket.io test"
+    ],
+    "main": "./lib/index"
+  }

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -205,6 +205,23 @@ describe('socket.io', function(){
           done();
         });
       });
+
+      describe('when serving the socket.io-client lib', function(){
+        require('./fixtures/create-fake-socket.io-client-module.js')
+
+        it('should serve the closest socket.io-client module it can find', function(done){
+          var srv = http();
+          io(srv);
+          request(srv)
+          .get('/socket.io/socket.io.js')
+          .buffer(true)
+          .end(function(err, res){
+            if (err) return done(err);
+            expect(res.text).to.not.match(/im a fake socket\.io-client/);
+            done();
+          })
+        });
+      });
     });
 
     describe('port', function(done){


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

Socket.io server ignores 'socket.io-client' module installed inside `socket.io` when there's an installation of 'socket.io-client' sibling to 'socket.io'.

### New behaviour

Now uses closest 'socket.io-client' installation.

### Other information (e.g. related issues)

Fix is by @Apollon77, taken from PR #3557. Their fix fixes #3555.

I added a failing test to show it actually had a behavior issue prior to the fix, and give an example of how it fails. Plus to prevent a regression in the future.


