### PR TITLE
docs: added to readme reference to fastify integration

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -138,6 +138,19 @@ io.on('connection', () => { /* … */ });
 server.listen(3000);
 ```
 
+### In conjunction with Fastify
+
+To integrate Socket.io in your Fastify application you just need to
+register `fastify-socket.io` plugin. It will create a `decorator`
+called `io`.
+
+```js
+const app = require('fastify')();
+app.register(require('fastify-socket.io'));
+app.io.on('connection', () => { /* … */ });
+app.listen(3000);
+```
+
 ## Documentation
 
 Please see the documentation [here](https://socket.io/docs/).


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

I just found out that there is no reference on the Readme about how to integrate Socket.io on [Fastify](https://www.fastify.io/).
Here is the plugin [link](https://github.com/alemagio/fastify-socket.io).

