### PR TITLE
fixed typo in pingTimeout doc string from 'pong' to 'ping'

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -26,7 +26,7 @@ type Transport = "polling" | "websocket";
 
 interface EngineOptions {
   /**
-   * how many ms without a pong packet to consider the connection closed
+   * how many ms without a ping packet to consider the connection closed
    * @default 5000
    */
   pingTimeout: number;


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
type in doc string

### New behaviour
no longer a typo in the doc string

### Other information (e.g. related issues)
Saw this when I was reading the docs thought I'd give it a fix :) 

