### PR TITLE
Enables disabling autojoin to a room with the socket's id

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -143,6 +143,11 @@ interface ServerOptions extends EngineAttachOptions {
    * @default 45000
    */
   connectTimeout: number;
+  /**
+   * whether or not to automatically join clients to a room bearing the name of the client's id
+   * @default true
+   */
+  autoJoin: boolean;
 }
 
 export class Server extends EventEmitter {
@@ -152,6 +157,8 @@ export class Server extends EventEmitter {
   readonly _parser;
   /** @private */
   readonly encoder: Encoder;
+  /** @private */
+  readonly autoJoin: boolean;
 
   /**
    * @private
@@ -202,6 +209,7 @@ export class Server extends EventEmitter {
     this._parser = opts.parser || parser;
     this.encoder = new this._parser.Encoder();
     this.adapter(opts.adapter || Adapter);
+    this.autoJoin = opts.autoJoin ?? true;
     this.sockets = this.of("/");
     if (srv) this.attach(srv, opts);
   }

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -283,7 +283,9 @@ export class Socket extends EventEmitter {
    */
   _onconnect(): void {
     debug("socket connected - writing packet");
-    this.join(this.id);
+    if (this.server.autoJoin) {
+      this.join(this.id);
+    }
     this.packet({ type: PacketType.CONNECT, data: { sid: this.id } });
   }
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

Upon connection, sockets automatically join a room based on their id.

### New behaviour

Upon connection, sockets only automatically join a room based on their id if the autojoin option is enabled. (It defaults to `true` for backward compatibility.)

### Other information (e.g. related issues)

Our use case of socket.io doesn't require this "convenience room." However, its existence is a major issue for us because it has allowed a DOS attack -- each room creation is causing allocation of AWS resources via our socket.io adapter, which can't be immediately released. We hit our AWS quota for SNS topic resources and then crash.

