### PR TITLE
fix(typings): expose additional needed types

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -712,4 +712,4 @@ emitterMethods.forEach(function(fn) {
 module.exports = (srv?, opts?) => new Server(srv, opts);
 module.exports.Server = Server;
 
-export { Socket }; // for "connect" event typing
+export { Socket, ServerOptions, Namespace };


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour

Needed interfaces/types are not exposed. `@types/socket.io` used to export these.

### New behaviour

Exported needed types.

### Other information (e.g. related issues)

Noticed while upgrading. Will create a similar PR to `socket.io-client`.
May want to consider adding the type modifier to the export, so that the actual abstractions won't be exposed. Downside: it will make the `.d.ts` only compatible with ts@2.8+.

### Off-topic
You using TypeScript and publishing built-in `.d.ts` is awesome.