### PR TITLE
Exports the Namespace and Socket type v3

### DIFF
--- a/wrapper.mjs
+++ b/wrapper.mjs
@@ -1,3 +1,3 @@
 import io from "./dist/index.js";
 
-export const Server = io.Server;
+export const {Server, Namespace, Socket} = io;


### PR DESCRIPTION
Exports the Namespace and Socket type from MJS wrapper


### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behavior
MJS wrapper only exports Server

### New behavior
MJS wrapper exports Server, Namaspace and Socket types 

### Other information (e.g. related issues)

I would say is a continuation of PR https://github.com/socketio/socket.io/pull/3684 and my comment there
https://github.com/socketio/socket.io/pull/3684#issuecomment-729396811
