### PR TITLE
add more typing info and upgrade prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2083,9 +2083,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true
     },
     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,15 @@
   "files": [
     "dist/",
     "client-dist/",
-    "wrapper.mjs"
+    "wrapper.mjs",
+    "!**/*.tsbuildinfo"
   ],
+  "directories": {
+    "doc": "docs/",
+    "example": "example/",
+    "lib": "lib/",
+    "test": "test/"
+  },
   "type": "commonjs",
   "main": "./dist/index.js",
   "exports": {
@@ -54,7 +61,7 @@
     "expect.js": "0.3.1",
     "mocha": "^3.5.3",
     "nyc": "^15.1.0",
-    "prettier": "^1.19.1",
+    "prettier": "^2.2.0",
     "rimraf": "^3.0.2",
     "socket.io-client": "3.0.4",
     "superagent": "^3.8.2",

--- a/test/socket.io.ts
+++ b/test/socket.io.ts
@@ -7,7 +7,7 @@ import { join } from "path";
 import { exec } from "child_process";
 import request from "supertest";
 import expect from "expect.js";
-import { AddressInfo } from "net";
+import type { AddressInfo } from "net";
 
 const ioc = require("socket.io-client");
 
@@ -17,7 +17,7 @@ import "./support/util";
 function client(srv, nsp?: string | object, opts?: object) {
   if ("object" == typeof nsp) {
     opts = nsp;
-    nsp = null;
+    nsp = undefined;
   }
   let addr = srv.address();
   if (!addr) addr = srv.listen().address();
@@ -35,7 +35,7 @@ describe("socket.io", () => {
     describe("http.Server", () => {
       const clientVersion = require("socket.io-client/package.json").version;
 
-      const testSource = filename => done => {
+      const testSource = (filename) => (done) => {
         const srv = createServer();
         new Server(srv);
         request(srv)
@@ -52,7 +52,7 @@ describe("socket.io", () => {
           });
       };
 
-      const testSourceMap = filename => done => {
+      const testSourceMap = (filename) => (done) => {
         const srv = createServer();
         new Server(srv);
         request(srv)
@@ -77,7 +77,7 @@ describe("socket.io", () => {
         testSourceMap("socket.io.min.js.map")
       );
 
-      it("should serve client (gzip)", done => {
+      it("should serve client (gzip)", (done) => {
         const srv = createServer();
         new Server(srv);
         request(srv)
@@ -102,7 +102,7 @@ describe("socket.io", () => {
         testSourceMap("socket.io.msgpack.min.js.map")
       );
 
-      it("should handle 304", done => {
+      it("should handle 304", (done) => {
         const srv = createServer();
         new Server(srv);
         request(srv)
@@ -115,15 +115,13 @@ describe("socket.io", () => {
           });
       });
 
-      it("should not serve static files", done => {
+      it("should not serve static files", (done) => {
         const srv = createServer();
         new Server(srv, { serveClient: false });
-        request(srv)
-          .get("/socket.io/socket.io.js")
-          .expect(400, done);
+        request(srv).get("/socket.io/socket.io.js").expect(400, done);
       });
 
-      it("should work with #attach", done => {
+      it("should work with #attach", (done) => {
         const srv = createServer((req, res) => {
           res.writeHead(404);
           res.end();
@@ -145,10 +143,10 @@ describe("socket.io", () => {
           res.end();
         });
         const server = new Server({
-          pingTimeout: 6000
+          pingTimeout: 6000,
         });
         server.attach(srv, {
-          pingInterval: 24000
+          pingInterval: 24000,
         });
         // @ts-ignore
         expect(server.eio.opts.pingTimeout).to.eql(6000);
@@ -159,28 +157,28 @@ describe("socket.io", () => {
     });
 
     describe("port", () => {
-      it("should be bound", done => {
+      it("should be bound", (done) => {
         const sockets = new Server(54010);
         request("http://localhost:54010")
           .get("/socket.io/socket.io.js")
           .expect(200, done);
       });
 
-      it("should be bound as a string", done => {
+      it("should be bound as a string", (done) => {
         const sockets = new Server(54020);
         request("http://localhost:54020")
           .get("/socket.io/socket.io.js")
           .expect(200, done);
       });
 
-      it("with listen", done => {
+      it("with listen", (done) => {
         const sockets = new Server().listen(54011);
         request("http://localhost:54011")
           .get("/socket.io/socket.io.js")
           .expect(200, done);
       });
 
-      it("as a string", done => {
+      it("as a string", (done) => {
         const sockets = new Server().listen(54012);
         request("http://localhost:54012")
           .get("/socket.io/socket.io.js")
@@ -192,14 +190,14 @@ describe("socket.io", () => {
   describe("handshake", () => {
     const request = require("superagent");
 
-    it("should send the Access-Control-Allow-xxx headers on OPTIONS request", done => {
+    it("should send the Access-Control-Allow-xxx headers on OPTIONS request", (done) => {
       const sockets = new Server(54013, {
         cors: {
           origin: "http://localhost:54023",
           methods: ["GET", "POST"],
           allowedHeaders: ["content-type"],
-          credentials: true
-        }
+          credentials: true,
+        },
       });
       request
         .options("http://localhost:54013/socket.io/default/")
@@ -220,14 +218,14 @@ describe("socket.io", () => {
         });
     });
 
-    it("should send the Access-Control-Allow-xxx headers on GET request", done => {
+    it("should send the Access-Control-Allow-xxx headers on GET request", (done) => {
       const sockets = new Server(54014, {
         cors: {
           origin: "http://localhost:54024",
           methods: ["GET", "POST"],
           allowedHeaders: ["content-type"],
-          credentials: true
-        }
+          credentials: true,
+        },
       });
       request
         .get("http://localhost:54014/socket.io/default/")
@@ -244,9 +242,9 @@ describe("socket.io", () => {
         });
     });
 
-    it("should allow request if custom function in opts.allowRequest returns true", done => {
+    it("should allow request if custom function in opts.allowRequest returns true", (done) => {
       const sockets = new Server(createServer().listen(54022), {
-        allowRequest: (req, callback) => callback(null, true)
+        allowRequest: (req, callback) => callback(null, true),
       });
 
       request
@@ -258,9 +256,9 @@ describe("socket.io", () => {
         });
     });
 
-    it("should disallow request if custom function in opts.allowRequest returns false", done => {
+    it("should disallow request if custom function in opts.allowRequest returns false", (done) => {
       const sockets = new Server(createServer().listen(54023), {
-        allowRequest: (req, callback) => callback(null, false)
+        allowRequest: (req, callback) => callback(null, false),
       });
       request
         .get("http://localhost:54023/socket.io/default/")
@@ -295,7 +293,7 @@ describe("socket.io", () => {
 
       server.once("listening", () => {
         // PORT should be free
-        server.close(error => {
+        server.close((error) => {
           expect(error).to.be(undefined);
         });
       });
@@ -321,7 +319,7 @@ describe("socket.io", () => {
 
       server.once("listening", () => {
         // PORT should be free
-        server.close(error => {
+        server.close((error) => {
           expect(error).to.be(undefined);
         });
       });
@@ -338,7 +336,7 @@ describe("socket.io", () => {
         );
       }
 
-      it("should stop socket and timers", done => {
+      it("should stop socket and timers", (done) => {
         exec(fixture("server-close.ts"), done);
       });
     });
@@ -369,7 +367,7 @@ describe("socket.io", () => {
       delete sio.sockets._flags;
     });
 
-    it("should automatically connect", done => {
+    it("should automatically connect", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
@@ -380,7 +378,7 @@ describe("socket.io", () => {
       });
     });
 
-    it("should fire a `connection` event", done => {
+    it("should fire a `connection` event", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
@@ -392,19 +390,19 @@ describe("socket.io", () => {
       });
     });
 
-    it("should fire a `connect` event", done => {
+    it("should fire a `connect` event", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connect", socket => {
+        sio.on("connect", (socket) => {
           expect(socket).to.be.a(Socket);
           done();
         });
       });
     });
 
-    it("should work with many sockets", done => {
+    it("should work with many sockets", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
@@ -422,7 +420,7 @@ describe("socket.io", () => {
       });
     });
 
-    it('should be able to equivalently start with "" or "/" on server', done => {
+    it('should be able to equivalently start with "" or "/" on server', (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       let total = 2;
@@ -436,7 +434,7 @@ describe("socket.io", () => {
       const c2 = client(srv, "/abc");
     });
 
-    it('should be equivalent for "" and "/" on client', done => {
+    it('should be equivalent for "" and "/" on client', (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       sio.of("/").on("connection", () => {
@@ -445,43 +443,43 @@ describe("socket.io", () => {
       const c1 = client(srv, "");
     });
 
-    it("should work with `of` and many sockets", done => {
+    it("should work with `of` and many sockets", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const chat = client(srv, "/chat");
         const news = client(srv, "/news");
         let total = 2;
-        sio.of("/news").on("connection", socket => {
+        sio.of("/news").on("connection", (socket) => {
           expect(socket).to.be.a(Socket);
           --total || done();
         });
-        sio.of("/news").on("connection", socket => {
+        sio.of("/news").on("connection", (socket) => {
           expect(socket).to.be.a(Socket);
           --total || done();
         });
       });
     });
 
-    it("should work with `of` second param", done => {
+    it("should work with `of` second param", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const chat = client(srv, "/chat");
         const news = client(srv, "/news");
         let total = 2;
-        sio.of("/news", socket => {
+        sio.of("/news", (socket) => {
           expect(socket).to.be.a(Socket);
           --total || done();
         });
-        sio.of("/news", socket => {
+        sio.of("/news", (socket) => {
           expect(socket).to.be.a(Socket);
           --total || done();
         });
       });
     });
 
-    it("should disconnect upon transport disconnection", done => {
+    it("should disconnect upon transport disconnection", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
@@ -490,15 +488,15 @@ describe("socket.io", () => {
         let total = 2;
         let totald = 2;
         let s;
-        sio.of("/news", socket => {
-          socket.on("disconnect", reason => {
+        sio.of("/news", (socket) => {
+          socket.on("disconnect", (reason) => {
             --totald || done();
           });
           --total || close();
         });
-        sio.of("/chat", socket => {
+        sio.of("/chat", (socket) => {
           s = socket;
-          socket.on("disconnect", reason => {
+          socket.on("disconnect", (reason) => {
             --totald || done();
           });
           --total || close();
@@ -509,24 +507,24 @@ describe("socket.io", () => {
       });
     });
 
-    it("should fire a `disconnecting` event just before leaving all rooms", done => {
+    it("should fire a `disconnecting` event just before leaving all rooms", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
 
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           s.join("a");
           // FIXME not sure why process.nextTick() is needed here
           process.nextTick(() => s.disconnect());
 
           let total = 2;
-          s.on("disconnecting", reason => {
+          s.on("disconnecting", (reason) => {
             expect(s.rooms).to.contain(s.id, "a");
             total--;
           });
 
-          s.on("disconnect", reason => {
+          s.on("disconnect", (reason) => {
             expect(s.rooms.size).to.eql(0);
             --total || done();
           });
@@ -534,19 +532,19 @@ describe("socket.io", () => {
       });
     });
 
-    it("should return error connecting to non-existent namespace", done => {
+    it("should return error connecting to non-existent namespace", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv, "/doesnotexist");
-        socket.on("connect_error", err => {
+        socket.on("connect_error", (err) => {
           expect(err.message).to.be("Invalid namespace");
           done();
         });
       });
     });
 
-    it("should not reuse same-namespace connections", done => {
+    it("should not reuse same-namespace connections", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       let connections = 0;
@@ -563,21 +561,21 @@ describe("socket.io", () => {
       });
     });
 
-    it("should find all clients in a namespace", done => {
+    it("should find all clients in a namespace", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
-      const chatSids = [];
+      const chatSids: string[] = [];
       let otherSid = null;
       srv.listen(() => {
         const c1 = client(srv, "/chat");
         const c2 = client(srv, "/chat", { forceNew: true });
         const c3 = client(srv, "/other", { forceNew: true });
         let total = 3;
-        sio.of("/chat").on("connection", socket => {
+        sio.of("/chat").on("connection", (socket) => {
           chatSids.push(socket.id);
           --total || getSockets();
         });
-        sio.of("/other").on("connection", socket => {
+        sio.of("/other").on("connection", (socket) => {
           otherSid = socket.id;
           --total || getSockets();
         });
@@ -591,7 +589,7 @@ describe("socket.io", () => {
       }
     });
 
-    it("should find all clients in a namespace room", done => {
+    it("should find all clients in a namespace room", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       let chatFooSid = null;
@@ -603,7 +601,7 @@ describe("socket.io", () => {
         const c3 = client(srv, "/other", { forceNew: true });
         let chatIndex = 0;
         let total = 3;
-        sio.of("/chat").on("connection", socket => {
+        sio.of("/chat").on("connection", (socket) => {
           if (chatIndex++) {
             socket.join("foo");
             chatFooSid = socket.id;
@@ -614,17 +612,14 @@ describe("socket.io", () => {
             --total || getSockets();
           }
         });
-        sio.of("/other").on("connection", socket => {
+        sio.of("/other").on("connection", (socket) => {
           socket.join("foo");
           otherSid = socket.id;
           --total || getSockets();
         });
       });
       async function getSockets() {
-        const sids = await sio
-          .of("/chat")
-          .in("foo")
-          .allSockets();
+        const sids = await sio.of("/chat").in("foo").allSockets();
 
         expect(sids).to.contain(chatFooSid);
         expect(sids).to.not.contain(chatBarSid);
@@ -633,7 +628,7 @@ describe("socket.io", () => {
       }
     });
 
-    it("should find all clients across namespace rooms", done => {
+    it("should find all clients across namespace rooms", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       let chatFooSid = null;
@@ -645,7 +640,7 @@ describe("socket.io", () => {
         const c3 = client(srv, "/other", { forceNew: true });
         let chatIndex = 0;
         let total = 3;
-        sio.of("/chat").on("connection", socket => {
+        sio.of("/chat").on("connection", (socket) => {
           if (chatIndex++) {
             socket.join("foo");
             chatFooSid = socket.id;
@@ -656,7 +651,7 @@ describe("socket.io", () => {
             --total || getSockets();
           }
         });
-        sio.of("/other").on("connection", socket => {
+        sio.of("/other").on("connection", (socket) => {
           socket.join("foo");
           otherSid = socket.id;
           --total || getSockets();
@@ -670,13 +665,13 @@ describe("socket.io", () => {
       }
     });
 
-    it("should not emit volatile event after regular event", done => {
+    it("should not emit volatile event after regular event", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
 
       let counter = 0;
       srv.listen(() => {
-        sio.of("/chat").on("connection", s => {
+        sio.of("/chat").on("connection", (s) => {
           // Wait to make sure there are no packets being sent for opening the connection
           setTimeout(() => {
             sio.of("/chat").emit("ev", "data");
@@ -696,13 +691,13 @@ describe("socket.io", () => {
       }, 500);
     });
 
-    it("should emit volatile event", done => {
+    it("should emit volatile event", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
 
       let counter = 0;
       srv.listen(() => {
-        sio.of("/chat").on("connection", s => {
+        sio.of("/chat").on("connection", (s) => {
           // Wait to make sure there are no packets being sent for opening the connection
           setTimeout(() => {
             sio.of("/chat").volatile.emit("ev", "data");
@@ -721,13 +716,13 @@ describe("socket.io", () => {
       }, 500);
     });
 
-    it("should enable compression by default", done => {
+    it("should enable compression by default", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv, "/chat");
-        sio.of("/chat").on("connection", s => {
-          s.conn.once("packetCreate", packet => {
+        sio.of("/chat").on("connection", (s) => {
+          s.conn.once("packetCreate", (packet) => {
             expect(packet.options.compress).to.be(true);
             done();
           });
@@ -736,20 +731,17 @@ describe("socket.io", () => {
       });
     });
 
-    it("should disable compression", done => {
+    it("should disable compression", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv, "/chat");
-        sio.of("/chat").on("connection", s => {
-          s.conn.once("packetCreate", packet => {
+        sio.of("/chat").on("connection", (s) => {
+          s.conn.once("packetCreate", (packet) => {
             expect(packet.options.compress).to.be(false);
             done();
           });
-          sio
-            .of("/chat")
-            .compress(false)
-            .emit("woot", "hi");
+          sio.of("/chat").compress(false).emit("woot", "hi");
         });
       });
     });
@@ -762,10 +754,10 @@ describe("socket.io", () => {
       );
     });
 
-    it("should close a client without namespace", done => {
+    it("should close a client without namespace", (done) => {
       const srv = createServer();
       const sio = new Server(srv, {
-        connectTimeout: 10
+        connectTimeout: 10,
       });
 
       srv.listen(() => {
@@ -782,7 +774,7 @@ describe("socket.io", () => {
     });
 
     describe("dynamic namespaces", () => {
-      it("should allow connections to dynamic namespaces with a regex", done => {
+      it("should allow connections to dynamic namespaces with a regex", (done) => {
         const srv = createServer();
         const sio = new Server(srv);
         let count = 0;
@@ -790,7 +782,7 @@ describe("socket.io", () => {
           const socket = client(srv, "/dynamic-101");
           let dynamicNsp = sio
             .of(/^\/dynamic-\d+$/)
-            .on("connect", socket => {
+            .on("connect", (socket) => {
               expect(socket.nsp.name).to.be("/dynamic-101");
               dynamicNsp.emit("hello", 1, "2", { 3: "4" });
               if (++count === 4) done();
@@ -799,7 +791,7 @@ describe("socket.io", () => {
               next();
               if (++count === 4) done();
             });
-          socket.on("connect_error", err => {
+          socket.on("connect_error", (err) => {
             expect().fail();
           });
           socket.on("connect", () => {
@@ -814,7 +806,7 @@ describe("socket.io", () => {
         });
       });
 
-      it("should allow connections to dynamic namespaces with a function", done => {
+      it("should allow connections to dynamic namespaces with a function", (done) => {
         const srv = createServer();
         const sio = new Server(srv);
         srv.listen(() => {
@@ -824,14 +816,14 @@ describe("socket.io", () => {
         });
       });
 
-      it("should disallow connections when no dynamic namespace matches", done => {
+      it("should disallow connections when no dynamic namespace matches", (done) => {
         const srv = createServer();
         const sio = new Server(srv);
         srv.listen(() => {
           const socket = client(srv, "/abc");
           sio.of(/^\/dynamic-\d+$/);
           sio.of((name, query, next) => next(null, "/dynamic-101" === name));
-          socket.on("connect_error", err => {
+          socket.on("connect_error", (err) => {
             expect(err.message).to.be("Invalid namespace");
             done();
           });
@@ -841,7 +833,7 @@ describe("socket.io", () => {
   });
 
   describe("socket", () => {
-    it("should not fire events more than once after manually reconnecting", done => {
+    it("should not fire events more than once after manually reconnecting", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
@@ -858,13 +850,13 @@ describe("socket.io", () => {
       });
     });
 
-    it("should not fire reconnect_failed event more than once when server closed", done => {
+    it("should not fire reconnect_failed event more than once when server closed", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const clientSocket = client(srv, {
           reconnectionAttempts: 3,
-          reconnectionDelay: 10
+          reconnectionDelay: 10,
         });
         clientSocket.on("connect", () => {
           srv.close();
@@ -876,12 +868,12 @@ describe("socket.io", () => {
       });
     });
 
-    it("should receive events", done => {
+    it("should receive events", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           s.on("random", (a, b, c) => {
             expect(a).to.be(1);
             expect(b).to.be("2");
@@ -893,13 +885,13 @@ describe("socket.io", () => {
       });
     });
 
-    it("should receive message events through `send`", done => {
+    it("should receive message events through `send`", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
-          s.on("message", a => {
+        sio.on("connection", (s) => {
+          s.on("message", (a) => {
             expect(a).to.be(1337);
             done();
           });
@@ -908,13 +900,13 @@ describe("socket.io", () => {
       });
     });
 
-    it("should error with null messages", done => {
+    it("should error with null messages", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
-          s.on("message", a => {
+        sio.on("connection", (s) => {
+          s.on("message", (a) => {
             expect(a).to.be(null);
             done();
           });
@@ -923,15 +915,15 @@ describe("socket.io", () => {
       });
     });
 
-    it("should handle transport null messages", done => {
+    it("should handle transport null messages", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv, { reconnection: false });
-        sio.on("connection", s => {
-          s.on("error", err => {
+        sio.on("connection", (s) => {
+          s.on("error", (err) => {
             expect(err).to.be.an(Error);
-            s.on("disconnect", reason => {
+            s.on("disconnect", (reason) => {
               expect(reason).to.be("forced close");
               done();
             });
@@ -941,28 +933,28 @@ describe("socket.io", () => {
       });
     });
 
-    it("should emit events", done => {
+    it("should emit events", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
-        socket.on("woot", a => {
+        socket.on("woot", (a) => {
           expect(a).to.be("tobi");
           done();
         });
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           s.emit("woot", "tobi");
         });
       });
     });
 
-    it("should emit events with utf8 multibyte character", done => {
+    it("should emit events with utf8 multibyte character", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
         let i = 0;
-        socket.on("hoot", a => {
+        socket.on("hoot", (a) => {
           expect(a).to.be("utf8 — string");
           i++;
 
@@ -970,7 +962,7 @@ describe("socket.io", () => {
             done();
           }
         });
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           s.emit("hoot", "utf8 — string");
           s.emit("hoot", "utf8 — string");
           s.emit("hoot", "utf8 — string");
@@ -978,20 +970,20 @@ describe("socket.io", () => {
       });
     });
 
-    it("should emit events with binary data", done => {
+    it("should emit events with binary data", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
         let imageData;
-        socket.on("doge", a => {
+        socket.on("doge", (a) => {
           expect(Buffer.isBuffer(a)).to.be(true);
           expect(imageData.length).to.equal(a.length);
           expect(imageData[0]).to.equal(a[0]);
           expect(imageData[imageData.length - 1]).to.equal(a[a.length - 1]);
           done();
         });
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           fs.readFile(join(__dirname, "support", "doge.jpg"), (err, data) => {
             if (err) return done(err);
             imageData = data;
@@ -1001,7 +993,7 @@ describe("socket.io", () => {
       });
     });
 
-    it("should emit events with several types of data (including binary)", done => {
+    it("should emit events with several types of data (including binary)", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
@@ -1017,7 +1009,7 @@ describe("socket.io", () => {
           expect(Buffer.isBuffer(f[2])).to.be(true);
           done();
         });
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           fs.readFile(join(__dirname, "support", "doge.jpg"), (err, data) => {
             if (err) return done(err);
             const buf = Buffer.from("asdfasdf", "utf8");
@@ -1027,13 +1019,13 @@ describe("socket.io", () => {
       });
     });
 
-    it("should receive events with binary data", done => {
+    it("should receive events with binary data", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
-          s.on("buff", a => {
+        sio.on("connection", (s) => {
+          s.on("buff", (a) => {
             expect(Buffer.isBuffer(a)).to.be(true);
             done();
           });
@@ -1043,12 +1035,12 @@ describe("socket.io", () => {
       });
     });
 
-    it("should receive events with several types of data (including binary)", done => {
+    it("should receive events with several types of data (including binary)", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           s.on("multiple", (a, b, c, d, e, f) => {
             expect(a).to.be(1);
             expect(Buffer.isBuffer(b)).to.be(true);
@@ -1066,20 +1058,20 @@ describe("socket.io", () => {
             socket.emit("multiple", 1, data, "3", [4], buf, [
               data,
               "swag",
-              buf
+              buf,
             ]);
           });
         });
       });
     });
 
-    it("should not emit volatile event after regular event (polling)", done => {
+    it("should not emit volatile event after regular event (polling)", (done) => {
       const srv = createServer();
       const sio = new Server(srv, { transports: ["polling"] });
 
       let counter = 0;
       srv.listen(() => {
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           s.emit("ev", "data");
           s.volatile.emit("ev", "data");
         });
@@ -1096,13 +1088,13 @@ describe("socket.io", () => {
       }, 200);
     });
 
-    it("should not emit volatile event after regular event (ws)", done => {
+    it("should not emit volatile event after regular event (ws)", (done) => {
       const srv = createServer();
       const sio = new Server(srv, { transports: ["websocket"] });
 
       let counter = 0;
       srv.listen(() => {
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           s.emit("ev", "data");
           s.volatile.emit("ev", "data");
         });
@@ -1119,13 +1111,13 @@ describe("socket.io", () => {
       }, 200);
     });
 
-    it("should emit volatile event (polling)", done => {
+    it("should emit volatile event (polling)", (done) => {
       const srv = createServer();
       const sio = new Server(srv, { transports: ["polling"] });
 
       let counter = 0;
       srv.listen(() => {
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           // Wait to make sure there are no packets being sent for opening the connection
           setTimeout(() => {
             s.volatile.emit("ev", "data");
@@ -1144,13 +1136,13 @@ describe("socket.io", () => {
       }, 500);
     });
 
-    it("should emit volatile event (ws)", done => {
+    it("should emit volatile event (ws)", (done) => {
       const srv = createServer();
       const sio = new Server(srv, { transports: ["websocket"] });
 
       let counter = 0;
       srv.listen(() => {
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           // Wait to make sure there are no packets being sent for opening the connection
           setTimeout(() => {
             s.volatile.emit("ev", "data");
@@ -1169,13 +1161,13 @@ describe("socket.io", () => {
       }, 200);
     });
 
-    it("should emit only one consecutive volatile event (polling)", done => {
+    it("should emit only one consecutive volatile event (polling)", (done) => {
       const srv = createServer();
       const sio = new Server(srv, { transports: ["polling"] });
 
       let counter = 0;
       srv.listen(() => {
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           // Wait to make sure there are no packets being sent for opening the connection
           setTimeout(() => {
             s.volatile.emit("ev", "data");
@@ -1195,13 +1187,13 @@ describe("socket.io", () => {
       }, 500);
     });
 
-    it("should emit only one consecutive volatile event (ws)", done => {
+    it("should emit only one consecutive volatile event (ws)", (done) => {
       const srv = createServer();
       const sio = new Server(srv, { transports: ["websocket"] });
 
       let counter = 0;
       srv.listen(() => {
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           // Wait to make sure there are no packets being sent for opening the connection
           setTimeout(() => {
             s.volatile.emit("ev", "data");
@@ -1221,13 +1213,13 @@ describe("socket.io", () => {
       }, 200);
     });
 
-    it("should emit regular events after trying a failed volatile event (polling)", done => {
+    it("should emit regular events after trying a failed volatile event (polling)", (done) => {
       const srv = createServer();
       const sio = new Server(srv, { transports: ["polling"] });
 
       let counter = 0;
       srv.listen(() => {
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           // Wait to make sure there are no packets being sent for opening the connection
           setTimeout(() => {
             s.emit("ev", "data");
@@ -1248,13 +1240,13 @@ describe("socket.io", () => {
       }, 200);
     });
 
-    it("should emit regular events after trying a failed volatile event (ws)", done => {
+    it("should emit regular events after trying a failed volatile event (ws)", (done) => {
       const srv = createServer();
       const sio = new Server(srv, { transports: ["websocket"] });
 
       let counter = 0;
       srv.listen(() => {
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           // Wait to make sure there are no packets being sent for opening the connection
           setTimeout(() => {
             s.emit("ev", "data");
@@ -1275,28 +1267,28 @@ describe("socket.io", () => {
       }, 200);
     });
 
-    it("should emit message events through `send`", done => {
+    it("should emit message events through `send`", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
-        socket.on("message", a => {
+        socket.on("message", (a) => {
           expect(a).to.be("a");
           done();
         });
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           s.send("a");
         });
       });
     });
 
-    it("should receive event with callbacks", done => {
+    it("should receive event with callbacks", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
-          s.on("woot", fn => {
+        sio.on("connection", (s) => {
+          s.on("woot", (fn) => {
             fn(1, 2);
           });
           socket.emit("woot", (a, b) => {
@@ -1308,13 +1300,13 @@ describe("socket.io", () => {
       });
     });
 
-    it("should receive all events emitted from namespaced client immediately and in order", done => {
+    it("should receive all events emitted from namespaced client immediately and in order", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       let total = 0;
       srv.listen(() => {
-        sio.of("/chat", s => {
-          s.on("hi", letter => {
+        sio.of("/chat", (s) => {
+          s.on("hi", (letter) => {
             total++;
             if (total == 2 && letter == "b") {
               done();
@@ -1332,13 +1324,13 @@ describe("socket.io", () => {
       });
     });
 
-    it("should emit events with callbacks", done => {
+    it("should emit events with callbacks", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
-          socket.on("hi", fn => {
+        sio.on("connection", (s) => {
+          socket.on("hi", (fn) => {
             fn();
           });
           s.emit("hi", () => {
@@ -1348,12 +1340,12 @@ describe("socket.io", () => {
       });
     });
 
-    it("should receive events with args and callback", done => {
+    it("should receive events with args and callback", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           s.on("woot", (a, b, fn) => {
             expect(a).to.be(1);
             expect(b).to.be(2);
@@ -1366,12 +1358,12 @@ describe("socket.io", () => {
       });
     });
 
-    it("should emit events with args and callback", done => {
+    it("should emit events with args and callback", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           socket.on("hi", (a, b, fn) => {
             expect(a).to.be(1);
             expect(b).to.be(2);
@@ -1384,12 +1376,12 @@ describe("socket.io", () => {
       });
     });
 
-    it("should receive events with binary args and callbacks", done => {
+    it("should receive events with binary args and callbacks", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           s.on("woot", (buf, fn) => {
             expect(Buffer.isBuffer(buf)).to.be(true);
             fn(1, 2);
@@ -1403,12 +1395,12 @@ describe("socket.io", () => {
       });
     });
 
-    it("should emit events with binary args and callback", done => {
+    it("should emit events with binary args and callback", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           socket.on("hi", (a, fn) => {
             expect(Buffer.isBuffer(a)).to.be(true);
             fn();
@@ -1420,16 +1412,16 @@ describe("socket.io", () => {
       });
     });
 
-    it("should emit events and receive binary data in a callback", done => {
+    it("should emit events and receive binary data in a callback", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
-          socket.on("hi", fn => {
+        sio.on("connection", (s) => {
+          socket.on("hi", (fn) => {
             fn(Buffer.alloc(1));
           });
-          s.emit("hi", a => {
+          s.emit("hi", (a) => {
             expect(Buffer.isBuffer(a)).to.be(true);
             done();
           });
@@ -1437,16 +1429,16 @@ describe("socket.io", () => {
       });
     });
 
-    it("should receive events and pass binary data in a callback", done => {
+    it("should receive events and pass binary data in a callback", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
-          s.on("woot", fn => {
+        sio.on("connection", (s) => {
+          s.on("woot", (fn) => {
             fn(Buffer.alloc(2));
           });
-          socket.emit("woot", a => {
+          socket.emit("woot", (a) => {
             expect(Buffer.isBuffer(a)).to.be(true);
             done();
           });
@@ -1454,24 +1446,24 @@ describe("socket.io", () => {
       });
     });
 
-    it("should have access to the client", done => {
+    it("should have access to the client", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           expect(s.client).to.be.an("object");
           done();
         });
       });
     });
 
-    it("should have access to the connection", done => {
+    it("should have access to the connection", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           expect(s.client.conn).to.be.an("object");
           expect(s.conn).to.be.an("object");
           done();
@@ -1479,12 +1471,12 @@ describe("socket.io", () => {
       });
     });
 
-    it("should have access to the request", done => {
+    it("should have access to the request", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           expect(s.client.request.headers).to.be.an("object");
           expect(s.request.headers).to.be.an("object");
           done();
@@ -1492,12 +1484,12 @@ describe("socket.io", () => {
       });
     });
 
-    it("should see query parameters in the request", done => {
+    it("should see query parameters in the request", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv, { query: { key1: 1, key2: 2 } });
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           const parsed = require("url").parse(s.request.url);
           const query = require("querystring").parse(parsed.query);
           expect(query.key1).to.be("1");
@@ -1507,15 +1499,15 @@ describe("socket.io", () => {
       });
     });
 
-    it("should see query parameters sent from secondary namespace connections in handshake object", done => {
+    it("should see query parameters sent from secondary namespace connections in handshake object", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       const client1 = client(srv);
       const client2 = client(srv, "/connection2", {
-        auth: { key1: "aa", key2: "&=bb" }
+        auth: { key1: "aa", key2: "&=bb" },
       });
-      sio.on("connection", s => {});
-      sio.of("/connection2").on("connection", s => {
+      sio.on("connection", (s) => {});
+      sio.of("/connection2").on("connection", (s) => {
         expect(s.handshake.query.key1).to.be(undefined);
         expect(s.handshake.query.EIO).to.be("4");
         expect(s.handshake.auth.key1).to.be("aa");
@@ -1524,19 +1516,19 @@ describe("socket.io", () => {
       });
     });
 
-    it("should handle very large json", function(done) {
+    it("should handle very large json", function (done) {
       this.timeout(30000);
       const srv = createServer();
       const sio = new Server(srv, { perMessageDeflate: false });
       let received = 0;
       srv.listen(() => {
         const socket = client(srv);
-        socket.on("big", a => {
+        socket.on("big", (a) => {
           expect(Buffer.isBuffer(a.json)).to.be(false);
           if (++received == 3) done();
           else socket.emit("big", a);
         });
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           fs.readFile(
             join(__dirname, "fixtures", "big.json"),
             (err, data: any) => {
@@ -1545,31 +1537,31 @@ describe("socket.io", () => {
               s.emit("big", { hello: "friend", json: data });
             }
           );
-          s.on("big", a => {
+          s.on("big", (a) => {
             s.emit("big", a);
           });
         });
       });
     });
 
-    it("should handle very large binary data", function(done) {
+    it("should handle very large binary data", function (done) {
       this.timeout(30000);
       const srv = createServer();
       const sio = new Server(srv, { perMessageDeflate: false });
       let received = 0;
       srv.listen(() => {
         const socket = client(srv);
-        socket.on("big", a => {
+        socket.on("big", (a) => {
           expect(Buffer.isBuffer(a.image)).to.be(true);
           if (++received == 3) done();
           else socket.emit("big", a);
         });
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           fs.readFile(join(__dirname, "fixtures", "big.jpg"), (err, data) => {
             if (err) return done(err);
             s.emit("big", { hello: "friend", image: data });
           });
-          s.on("big", a => {
+          s.on("big", (a) => {
             expect(Buffer.isBuffer(a.image)).to.be(true);
             s.emit("big", a);
           });
@@ -1577,12 +1569,12 @@ describe("socket.io", () => {
       });
     });
 
-    it("should be able to emit after server close and restart", done => {
+    it("should be able to emit after server close and restart", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
 
-      sio.on("connection", socket => {
-        socket.on("ev", data => {
+      sio.on("connection", (socket) => {
+        socket.on("ev", (data) => {
           expect(data).to.be("payload");
           done();
         });
@@ -1592,7 +1584,7 @@ describe("socket.io", () => {
         const { port } = srv.address() as AddressInfo;
         const clientSocket = client(srv, {
           reconnectionAttempts: 10,
-          reconnectionDelay: 100
+          reconnectionDelay: 100,
         });
         clientSocket.once("connect", () => {
           srv.close(() => {
@@ -1605,13 +1597,13 @@ describe("socket.io", () => {
       });
     });
 
-    it("should enable compression by default", done => {
+    it("should enable compression by default", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv, "/chat");
-        sio.of("/chat").on("connection", s => {
-          s.conn.once("packetCreate", packet => {
+        sio.of("/chat").on("connection", (s) => {
+          s.conn.once("packetCreate", (packet) => {
             expect(packet.options.compress).to.be(true);
             done();
           });
@@ -1620,30 +1612,27 @@ describe("socket.io", () => {
       });
     });
 
-    it("should disable compression", done => {
+    it("should disable compression", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv, "/chat");
-        sio.of("/chat").on("connection", s => {
-          s.conn.once("packetCreate", packet => {
+        sio.of("/chat").on("connection", (s) => {
+          s.conn.once("packetCreate", (packet) => {
             expect(packet.options.compress).to.be(false);
             done();
           });
-          sio
-            .of("/chat")
-            .compress(false)
-            .emit("woot", "hi");
+          sio.of("/chat").compress(false).emit("woot", "hi");
         });
       });
     });
 
-    it("should error with raw binary and warn", done => {
+    it("should error with raw binary and warn", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv, { reconnection: false });
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           s.conn.on("upgrade", () => {
             console.log(
               "\u001b[96mNote: warning expected and normal in test.\u001b[39m"
@@ -1657,12 +1646,12 @@ describe("socket.io", () => {
       });
     });
 
-    it("should not crash when receiving an error packet without handler", done => {
+    it("should not crash when receiving an error packet without handler", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv, { reconnection: false });
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           s.conn.on("upgrade", () => {
             console.log(
               "\u001b[96mNote: warning expected and normal in test.\u001b[39m"
@@ -1676,13 +1665,13 @@ describe("socket.io", () => {
       });
     });
 
-    it("should not crash with raw binary", done => {
+    it("should not crash with raw binary", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv, { reconnection: false });
-        sio.on("connection", s => {
-          s.once("error", err => {
+        sio.on("connection", (s) => {
+          s.once("error", (err) => {
             expect(err.message).to.match(/Illegal attachments/);
             done();
           });
@@ -1693,13 +1682,13 @@ describe("socket.io", () => {
       });
     });
 
-    it("should handle empty binary packet", done => {
+    it("should handle empty binary packet", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       srv.listen(() => {
         const socket = client(srv, { reconnection: false });
-        sio.on("connection", s => {
-          s.once("error", err => {
+        sio.on("connection", (s) => {
+          s.once("error", (err) => {
             expect(err.message).to.match(/Illegal attachments/);
             done();
           });
@@ -1710,7 +1699,7 @@ describe("socket.io", () => {
       });
     });
 
-    it("should not crash when messing with Object prototype (and other globals)", done => {
+    it("should not crash when messing with Object prototype (and other globals)", (done) => {
       // @ts-ignore
       Object.prototype.foo = "bar";
       // @ts-ignore
@@ -1722,7 +1711,7 @@ describe("socket.io", () => {
       srv.listen(() => {
         const socket = client(srv);
 
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           s.disconnect(true);
           sio.close();
           setTimeout(() => {
@@ -1732,13 +1721,13 @@ describe("socket.io", () => {
       });
     });
 
-    it("should throw on reserved event", done => {
+    it("should throw on reserved event", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
 
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           expect(() => s.emit("connect_error")).to.throwException(
             /"connect_error" is a reserved event name/
           );
@@ -1749,7 +1738,7 @@ describe("socket.io", () => {
     });
 
     describe("onAny", () => {
-      it("should call listener", done => {
+      it("should call listener", (done) => {
         const srv = createServer();
         const sio = new Server(srv);
 
@@ -1768,7 +1757,7 @@ describe("socket.io", () => {
         });
       });
 
-      it("should prepend listener", done => {
+      it("should prepend listener", (done) => {
         const srv = createServer();
         const sio = new Server(srv);
 
@@ -1796,7 +1785,7 @@ describe("socket.io", () => {
         });
       });
 
-      it("should remove listener", done => {
+      it("should remove listener", (done) => {
         const srv = createServer();
         const sio = new Server(srv);
 
@@ -1822,7 +1811,7 @@ describe("socket.io", () => {
   });
 
   describe("messaging many", () => {
-    it("emits to a namespace", done => {
+    it("emits to a namespace", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       let total = 2;
@@ -1831,11 +1820,11 @@ describe("socket.io", () => {
         const socket1 = client(srv, { multiplex: false });
         const socket2 = client(srv, { multiplex: false });
         const socket3 = client(srv, "/test");
-        socket1.on("a", a => {
+        socket1.on("a", (a) => {
           expect(a).to.be("b");
           --total || done();
         });
-        socket2.on("a", a => {
+        socket2.on("a", (a) => {
           expect(a).to.be("b");
           --total || done();
         });
@@ -1844,10 +1833,10 @@ describe("socket.io", () => {
         });
 
         let sockets = 3;
-        sio.on("connection", socket => {
+        sio.on("connection", (socket) => {
           --sockets || emit();
         });
-        sio.of("/test", socket => {
+        sio.of("/test", (socket) => {
           --sockets || emit();
         });
 
@@ -1857,7 +1846,7 @@ describe("socket.io", () => {
       });
     });
 
-    it("emits binary data to a namespace", done => {
+    it("emits binary data to a namespace", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       let total = 2;
@@ -1866,11 +1855,11 @@ describe("socket.io", () => {
         const socket1 = client(srv, { multiplex: false });
         const socket2 = client(srv, { multiplex: false });
         const socket3 = client(srv, "/test");
-        socket1.on("bin", a => {
+        socket1.on("bin", (a) => {
           expect(Buffer.isBuffer(a)).to.be(true);
           --total || done();
         });
-        socket2.on("bin", a => {
+        socket2.on("bin", (a) => {
           expect(Buffer.isBuffer(a)).to.be(true);
           --total || done();
         });
@@ -1879,10 +1868,10 @@ describe("socket.io", () => {
         });
 
         let sockets = 3;
-        sio.on("connection", socket => {
+        sio.on("connection", (socket) => {
           --sockets || emit();
         });
-        sio.of("/test", socket => {
+        sio.of("/test", (socket) => {
           --sockets || emit();
         });
 
@@ -1892,7 +1881,7 @@ describe("socket.io", () => {
       });
     });
 
-    it("emits to the rest", done => {
+    it("emits to the rest", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       const total = 2;
@@ -1901,7 +1890,7 @@ describe("socket.io", () => {
         const socket1 = client(srv, { multiplex: false });
         const socket2 = client(srv, { multiplex: false });
         const socket3 = client(srv, "/test");
-        socket1.on("a", a => {
+        socket1.on("a", (a) => {
           expect(a).to.be("b");
           socket1.emit("finish");
         });
@@ -1914,7 +1903,7 @@ describe("socket.io", () => {
         });
 
         const sockets = 2;
-        sio.on("connection", socket => {
+        sio.on("connection", (socket) => {
           socket.on("broadcast", () => {
             socket.broadcast.emit("a", "b");
           });
@@ -1925,7 +1914,7 @@ describe("socket.io", () => {
       });
     });
 
-    it("emits to rooms", done => {
+    it("emits to rooms", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       const total = 2;
@@ -1943,20 +1932,20 @@ describe("socket.io", () => {
         socket1.emit("join", "woot");
         socket1.emit("emit", "woot");
 
-        sio.on("connection", socket => {
+        sio.on("connection", (socket) => {
           socket.on("join", (room, fn) => {
             socket.join(room);
             fn && fn();
           });
 
-          socket.on("emit", room => {
+          socket.on("emit", (room) => {
             sio.in(room).emit("a");
           });
         });
       });
     });
 
-    it("emits to rooms avoiding dupes", done => {
+    it("emits to rooms avoiding dupes", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       let total = 2;
@@ -1981,24 +1970,21 @@ describe("socket.io", () => {
           socket2.emit("emit");
         });
 
-        sio.on("connection", socket => {
+        sio.on("connection", (socket) => {
           socket.on("join", (room, fn) => {
             socket.join(room);
             fn && fn();
           });
 
-          socket.on("emit", room => {
-            sio
-              .in("woot")
-              .in("test")
-              .emit("a");
+          socket.on("emit", (room) => {
+            sio.in("woot").in("test").emit("a");
             sio.in("third").emit("b");
           });
         });
       });
     });
 
-    it("broadcasts to rooms", done => {
+    it("broadcasts to rooms", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       let total = 2;
@@ -2027,7 +2013,7 @@ describe("socket.io", () => {
           --total || done();
         });
 
-        sio.on("connection", socket => {
+        sio.on("connection", (socket) => {
           socket.on("join", (room, fn) => {
             socket.join(room);
             fn && fn();
@@ -2041,7 +2027,7 @@ describe("socket.io", () => {
       });
     });
 
-    it("broadcasts binary data to rooms", done => {
+    it("broadcasts binary data to rooms", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       let total = 2;
@@ -2057,25 +2043,25 @@ describe("socket.io", () => {
           socket3.emit("broadcast");
         });
 
-        socket1.on("bin", data => {
+        socket1.on("bin", (data) => {
           throw new Error("got bin in socket1");
         });
-        socket2.on("bin", data => {
+        socket2.on("bin", (data) => {
           expect(Buffer.isBuffer(data)).to.be(true);
           --total || done();
         });
-        socket2.on("bin2", data => {
+        socket2.on("bin2", (data) => {
           throw new Error("socket2 got bin2");
         });
-        socket3.on("bin", data => {
+        socket3.on("bin", (data) => {
           throw new Error("socket3 got bin");
         });
-        socket3.on("bin2", data => {
+        socket3.on("bin2", (data) => {
           expect(Buffer.isBuffer(data)).to.be(true);
           --total || done();
         });
 
-        sio.on("connection", socket => {
+        sio.on("connection", (socket) => {
           socket.on("join", (room, fn) => {
             socket.join(room);
             fn && fn();
@@ -2088,13 +2074,13 @@ describe("socket.io", () => {
       });
     });
 
-    it("keeps track of rooms", done => {
+    it("keeps track of rooms", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
 
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           s.join("a");
           expect(s.rooms).to.contain(s.id, "a");
           s.join("b");
@@ -2110,13 +2096,13 @@ describe("socket.io", () => {
       });
     });
 
-    it("deletes empty rooms", done => {
+    it("deletes empty rooms", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
 
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           s.join("a");
           expect(s.nsp.adapter.rooms).to.contain("a");
           s.leave("a");
@@ -2126,13 +2112,13 @@ describe("socket.io", () => {
       });
     });
 
-    it("should properly cleanup left rooms", done => {
+    it("should properly cleanup left rooms", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
 
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           s.join("a");
           expect(s.rooms).to.contain(s.id, "a");
           s.join("b");
@@ -2146,13 +2132,13 @@ describe("socket.io", () => {
       });
     });
 
-    it("allows to join several rooms at once", done => {
+    it("allows to join several rooms at once", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
 
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", s => {
+        sio.on("connection", (s) => {
           s.join(["a", "b", "c"]);
           expect(s.rooms).to.contain(s.id, "a", "b", "c");
           done();
@@ -2164,7 +2150,7 @@ describe("socket.io", () => {
   describe("middleware", () => {
     const { Socket } = require("../dist/socket");
 
-    it("should call functions", done => {
+    it("should call functions", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       let run = 0;
@@ -2187,7 +2173,7 @@ describe("socket.io", () => {
       });
     });
 
-    it("should pass errors", done => {
+    it("should pass errors", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       const run = 0;
@@ -2202,14 +2188,14 @@ describe("socket.io", () => {
         socket.on("connect", () => {
           done(new Error("nope"));
         });
-        socket.on("connect_error", err => {
+        socket.on("connect_error", (err) => {
           expect(err.message).to.be("Authentication error");
           done();
         });
       });
     });
 
-    it("should pass an object", done => {
+    it("should pass an object", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       sio.use((socket, next) => {
@@ -2223,7 +2209,7 @@ describe("socket.io", () => {
         socket.on("connect", () => {
           done(new Error("nope"));
         });
-        socket.on("connect_error", err => {
+        socket.on("connect_error", (err) => {
           expect(err).to.be.an(Error);
           expect(err.message).to.eql("Authentication error");
           expect(err.data).to.eql({ a: "b", c: 3 });
@@ -2232,7 +2218,7 @@ describe("socket.io", () => {
       });
     });
 
-    it("should only call connection after fns", done => {
+    it("should only call connection after fns", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       sio.use((socket: any, next) => {
@@ -2241,14 +2227,14 @@ describe("socket.io", () => {
       });
       srv.listen(() => {
         const socket = client(srv);
-        sio.on("connection", socket => {
+        sio.on("connection", (socket) => {
           expect(socket.name).to.be("guillermo");
           done();
         });
       });
     });
 
-    it("should only call connection after (lengthy) fns", done => {
+    it("should only call connection after (lengthy) fns", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       let authenticated = false;
@@ -2268,7 +2254,7 @@ describe("socket.io", () => {
       });
     });
 
-    it("should be ignored if socket gets closed", done => {
+    it("should be ignored if socket gets closed", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
       let socket;
@@ -2283,16 +2269,16 @@ describe("socket.io", () => {
       });
       srv.listen(() => {
         socket = client(srv);
-        sio.on("connection", socket => {
+        sio.on("connection", (socket) => {
           done(new Error("should not fire"));
         });
       });
     });
 
-    it("should call functions in expected order", done => {
+    it("should call functions in expected order", (done) => {
       const srv = createServer();
       const sio = new Server(srv);
-      const result = [];
+      const result: number[] = [];
 
       sio.use(() => {
         done(new Error("should not fire"));
@@ -2319,7 +2305,7 @@ describe("socket.io", () => {
       });
     });
 
-    it("should disable the merge of handshake packets", done => {
+    it("should disable the merge of handshake packets", (done) => {
       const srv = createServer();
       const sio = new Server();
       sio.use((socket, next) => {
@@ -2332,7 +2318,7 @@ describe("socket.io", () => {
       });
     });
 
-    it("should work with a custom namespace", done => {
+    it("should work with a custom namespace", (done) => {
       const srv = createServer();
       const sio = new Server();
       sio.listen(srv);

--- a/test/support/util.ts
+++ b/test/support/util.ts
@@ -3,15 +3,15 @@ const i = expect.stringify;
 
 // add support for Set/Map
 const contain = expect.Assertion.prototype.contain;
-expect.Assertion.prototype.contain = function(...args) {
+expect.Assertion.prototype.contain = function (...args) {
   if (typeof this.obj === "object") {
-    args.forEach(obj => {
+    args.forEach((obj) => {
       this.assert(
         this.obj.has(obj),
-        function() {
+        function () {
           return "expected " + i(this.obj) + " to contain " + i(obj);
         },
-        function() {
+        function () {
           return "expected " + i(this.obj) + " to not contain " + i(obj);
         }
       );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,17 @@
     "target": "es2017",
     "module": "commonjs",
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+
+    "incremental": true,
+    "skipLibCheck": true,
+
+    "strict": true,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictPropertyInitialization": false,
+    "noImplicitReturns": true,
+    "importsNotUsedAsValues": "error",
   },
   "include": [
     "./lib/**/*"


### PR DESCRIPTION
- upgrade prettier to 2.2.0 to gain support for TypeScript's
  new type-only-imports feature.

tests are passing on my local machine (I was a bit confused by the two expected errors at first). You may want to regenerate package-lock.json yourself if you have (what I think is) a healthy level of distrust. I didn't add a malicious package to it, but there's nothing to immediately stop me from doing so.


### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other


