### PR TITLE
Allow explicit creation of namespaces within a dynamic namespace

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -257,8 +257,11 @@ export class Server extends EventEmitter {
         if (err || !allow) {
           run();
         } else {
-          let nsp = this.parentNsps.get(nextFn.value)!.createChild(name);
-          process.nextTick(() => fn(nsp));
+          let nsp = this._nsps.get(name);
+          if (!nsp) {
+            nsp = this.parentNsps.get(nextFn.value)!.createChild(name);
+          }
+          process.nextTick(() => fn(nsp as Namespace));
         }
       });
     };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -257,7 +257,8 @@ export class Server extends EventEmitter {
         if (err || !allow) {
           run();
         } else {
-          fn(this.parentNsps.get(nextFn.value)!.createChild(name));
+          let nsp = this.parentNsps.get(nextFn.value)!.createChild(name);
+          process.nextTick(() => fn(nsp));
         }
       });
     };

--- a/test/socket.io.ts
+++ b/test/socket.io.ts
@@ -900,6 +900,27 @@ describe("socket.io", () => {
           });
         });
       });
+
+      it("should run middleware on the first connection when the namespace has been created", (done) => {
+        const srv = createServer();
+        const sio = new Server(srv);
+        const nsp = "/dynamic";
+        let called = false;
+        srv.listen(() => {
+          const socket = client(srv, nsp);
+          sio.of((name, query, next) => {
+            sio.of(nsp).use((socket, next) => {
+              called = true;
+              next();
+            });
+            next(null, true);
+          });
+          socket.on("connect", () => {
+            expect(called).to.equal(true);
+            done();
+          });
+        });
+      });
     });
   });
 

--- a/test/socket.io.ts
+++ b/test/socket.io.ts
@@ -879,6 +879,27 @@ describe("socket.io", () => {
           });
         });
       });
+
+      it("should run middleware on the first connection", (done) => {
+        const srv = createServer();
+        const sio = new Server(srv);
+        const nsp = "/dynamic";
+        let called = false;
+        srv.listen(() => {
+          const socket = client(srv, nsp);
+          sio.of((name, query, next) => {
+            next(null, true);
+            sio.of(nsp).use((socket, next) => {
+              called = true;
+              next();
+            });
+          });
+          socket.on("connect", () => {
+            expect(called).to.equal(true);
+            done();
+          });
+        });
+      });
     });
   });
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

I have a use case where I dynamically create namespaces, but when the namespace is created I also set up some middleware. Those middleware functions are not run for the socket that triggered the dynamic namespace to be created though:

```js
sio.of((name, query, next) => {
  if (isValidNamespace(name) {
    next(null, true);
    sio.of(name).use((socket, next) => {

      // This middleware function is not run for the socket that caused the
      // namespace to be created, only for subsequent connections.
      socket.user = authenticate(socket);
      next(null);

    });
  } else {
    return next(null, false};
  }
});
```

### New behavior

The middleware function should be run for the first connection as well.

### Other information (e.g. related issues)

I am aware that you can register middleware directly on the dynamic namespace like
```js
sio.of((name, query, next) => next(null, true)).use((socket, next) => {
  // Do something
});
```
but in my use case I have to do some setup work when a namespace is created, which requires me to pass the *true* namespace.

I have solved this by manually patching the socket.io server object
```js
const { _checkNamespace } = Server.prototype;
Server.prototype._checkNamespace = function(name, auth, fn) {
  return _checkNamespace.call(this, name, auth, function(nsp) {
    if (nsp) {
      process.nextTick(() => fn.call(this, nsp));
    } else {
      fn(nsp);
    }
  });
};
```
which delays the connection of the socket to the namespace to the next tick, allowing to do some *synchronous* setup work first. It's exactly that solution that I've used in this PR as well. I've added a test case and all existing tests still pass.

A similar solution can be used to backport this to the v2 branch as well as the issue exists here too.