### PR TITLE
[3.x/bugfix] Custom "generateId()" works only on the handshake

### DIFF
--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -109,11 +109,21 @@ export class Socket extends EventEmitter {
       // @ts-ignore
       this.id = nsp.name !== "/" ? nsp.name + "#" + client.id : client.id;
     } else {
-      this.id = base64id.generateId(); // don't reuse the Engine.IO id because it's sensitive information
+      this.id = this.generateId(); // don't reuse the Engine.IO id because it's sensitive information
     }
     this.connected = true;
     this.disconnected = false;
     this.handshake = this.buildHandshake(auth);
+  }
+
+  /**
+   * Generate an ID for the client.
+   *
+   * @return {any}
+   * @private
+   */
+  private generateId(): any {
+    return base64id.generateId();
   }
 
   /**

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -120,9 +120,8 @@ export class Socket extends EventEmitter {
    * Generate an ID for the client.
    *
    * @return {any}
-   * @private
    */
-  private generateId(): any {
+  generateId(): any {
     return base64id.generateId();
   }
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
Currently, the Session IDs cannot be sent to the client after they were generated by the server using custom generation method. It seems like the initial handshake results with a good ID, but the one generated after `on('connect', ...)` are not custom generated. Here is the connections in the WS tab:

| Data | Length |
| - | - |
| 0{"sid":"5533569206.4606719705","upgrades":[],"pingInterval":25000,"pingTimeout":5000} | 86 |
| 40/echo-app,{"headers":{"X-CSRF-TOKEN":"9Os3T9FdJMaJBLbG15dOG9IWX3XLSGu5uYilVrnI"}} | 83 |
| 40/echo-app,{"sid":"o4IkedYULu37hAzfAAAD"} | 42 |
| 42/echo-app,["subscribe",{"channel":"presence-room","auth":{"headers":{"X-CSRF-TOKEN":"9Os3T9FdJMaJBLbG15dOG9IWX3XLSGu5uYilVrnI"}}}] | 132 |

As you can see, the first `sid` is correct (as it is generated in a custom manner), but the subsequent `sid` is not generated using the custom function.

### New behavior
Not sure if this is a good implementation the way I did it, but I expect this function to be replaceable like the Engine.IO has the `generateId()` function [as explained in the documentation](https://socket.io/docs/v3/server-api/#server-engine-generateId).

