### PR TITLE
fix: init options at addChatMessage

### DIFF
--- a/examples/chat/public/main.js
+++ b/examples/chat/public/main.js
@@ -72,7 +72,7 @@ $(function() {
   }
 
   // Adds the visual chat message to the message list
-  const addChatMessage = (data, options) => {
+  const addChatMessage = (data, options = {}) => {
     // Don't fade the message in if there is an 'X was typing'
     const $typingMessages = getTypingMessages(data);
     if ($typingMessages.length !== 0) {


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
Clients do not render participants messages due addChatMessage is trying to access to un initiated options to set fade to false

### New behavior
Now renders

### Other information (e.g. related issues)


