### PR TITLE
Exclude specific sockets when emitting

### DIFF
--- a/lib/namespace.ts
+++ b/lib/namespace.ts
@@ -30,6 +30,9 @@ export class Namespace extends EventEmitter {
   _rooms: Set<Room> = new Set();
 
   /** @private */
+  _except: Set<Room> = new Set();
+
+  /** @private */
   _flags: any = {};
 
   /** @private */
@@ -124,6 +127,18 @@ export class Namespace extends EventEmitter {
   }
 
   /**
+   * Excludes a room when emitting.
+   *
+   * @param name
+   * @return self
+   * @public
+   */
+  public except(name: Room): Namespace {
+    this._except.add(name);
+    return this;
+  }
+
+  /**
    * Adds a new client.
    *
    * @return {Socket}
@@ -203,14 +218,17 @@ export class Namespace extends EventEmitter {
 
     const rooms = new Set(this._rooms);
     const flags = Object.assign({}, this._flags);
+    const except = new Set(this._except);
 
     // reset flags
     this._rooms.clear();
     this._flags = {};
+    this._except.clear();
 
     this.adapter.broadcast(packet, {
       rooms: rooms,
       flags: flags,
+      except: except,
     });
 
     return true;

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -91,6 +91,7 @@ export class Socket extends EventEmitter {
   > = [];
   private flags: BroadcastFlags = {};
   private _rooms: Set<Room> = new Set();
+  private _except: Set<Room> = new Set();
   private _anyListeners?: Array<(...args: any[]) => void>;
 
   /**
@@ -165,14 +166,16 @@ export class Socket extends EventEmitter {
 
     const rooms = new Set(this._rooms);
     const flags = Object.assign({}, this.flags);
+    const except = new Set(this._except);
 
     // reset flags
     this._rooms.clear();
     this.flags = {};
+    this._except.clear();
 
     if (rooms.size || flags.broadcast) {
       this.adapter.broadcast(packet, {
-        except: new Set([this.id]),
+        except: new Set([this.id, ...except]),
         rooms: rooms,
         flags: flags,
       });
@@ -204,6 +207,18 @@ export class Socket extends EventEmitter {
    */
   public in(name: Room): Socket {
     this._rooms.add(name);
+    return this;
+  }
+
+  /**
+   * Excludes a room when broadcasting.
+   *
+   * @param name
+   * @return self
+   * @public
+   */
+  public except(name: Room): Socket {
+    this._except.add(name);
     return this;
   }
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### New behavior

This PR adds the possibility to exclude specific socket ids when emitting messages:
```js
io.except(id).emit("foo", "bar");
socket.broadcast.except(id).emit("foo", "bar");
socket.to("room").except(id).emit("foo", "bar");
```
In combination with https://github.com/socketio/socket.io-adapter/pull/66 this will allow excluding all sockets in a specific room as well.

### Other information (e.g. related issues)

See also https://github.com/socketio/socket.io-adapter/pull/66 and https://github.com/socketio/socket.io-emitter/pull/92.
