### PR TITLE
Adapter should not use `typeof`

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -168,7 +168,7 @@ export class Server extends EventEmitter {
    */
   _nsps: Map<string, Namespace> = new Map();
   private parentNsps: Map<ParentNspNameMatchFn, ParentNamespace> = new Map();
-  private _adapter?: typeof Adapter;
+  private _adapter?: Adapter;
   private _serveClient: boolean;
   private opts: Partial<EngineOptions>;
   private eio;
@@ -315,10 +315,10 @@ export class Server extends EventEmitter {
    * @return self when setting or value when getting
    * @public
    */
-  public adapter(): typeof Adapter | undefined;
-  public adapter(v: typeof Adapter): this;
-  public adapter(v?: typeof Adapter): typeof Adapter | undefined | this;
-  public adapter(v?: typeof Adapter): typeof Adapter | undefined | this {
+  public adapter(): Adapter | undefined;
+  public adapter(v: Adapter): this;
+  public adapter(v?: Adapter): Adapter | undefined | this;
+  public adapter(v?: Adapter): Adapter | undefined | this {
     if (!arguments.length) return this._adapter;
     this._adapter = v;
     for (const nsp of this._nsps.values()) {


### PR DESCRIPTION
Not sure why `typeof` was used but Adapter is a class and does not need a typeof. The problem is that it was not possible to have a function thats return type is an Adapter:

```
const createAdapter = (): Adapter => { ... };
server.adapter(createAdapter());
```

If there is a reason for use of `typeof` then the types should be `Adapter | typeof Adapter`

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior


### New behavior


### Other information (e.g. related issues)


