### PR TITLE
TypeError: cb is not a function

### DIFF
--- a/examples/typescript/server.ts
+++ b/examples/typescript/server.ts
@@ -7,7 +7,7 @@ io.on("connect", (socket: Socket) => {
 
     socket.on("ping", (cb) => {
         console.log("ping");
-        cb();
+//         cb();
     });
 
     socket.on("disconnect", () => {


### PR DESCRIPTION
C:\Users\user\devel\ts-socket\server.ts:10
    cb();
    ^
TypeError: cb is not a function
    at Socket.<anonymous> (C:\Users\user\devel\ts-socket\server.ts:10:5)
    at Socket.emit (events.js:315:20)
    at Socket.EventEmitter.emit (domain.js:486:12)
    at C:\Users\user\devel\ts-socket\node_modules\socket.io\dist\socket.js:435:32 
    at processTicksAndRejections (internal/process/task_queues.js:75:11)


### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior


### New behavior


### Other information (e.g. related issues)


