### PR TITLE
Fix #3833: Add fallback to untyped event listener

### DIFF
--- a/lib/typed-events.ts
+++ b/lib/typed-events.ts
@@ -43,11 +43,23 @@ export type ReservedOrUserListener<
   ReservedEvents extends EventsMap,
   UserEvents extends EventsMap,
   Ev extends ReservedOrUserEventNames<ReservedEvents, UserEvents>
-> = Ev extends EventNames<ReservedEvents>
-  ? ReservedEvents[Ev]
-  : Ev extends EventNames<UserEvents>
-  ? UserEvents[Ev]
-  : never;
+> = FallbackToUntypedListener<
+  Ev extends EventNames<ReservedEvents>
+    ? ReservedEvents[Ev]
+    : Ev extends EventNames<UserEvents>
+    ? UserEvents[Ev]
+    : never
+>;
+
+/**
+ * Returns an untyped listener type if `T` is `never`; otherwise, returns `T`.
+ *
+ * This is a hack to mitigate https://github.com/socketio/socket.io/issues/3833.
+ * Needed because of https://github.com/microsoft/TypeScript/issues/41778
+ */
+type FallbackToUntypedListener<T> = [T] extends [never]
+  ? (...args: any[]) => void
+  : T;
 
 /**
  * Interface for classes that aren't `EventEmitter`s, but still expose a

--- a/test/socket.io.test-d.ts
+++ b/test/socket.io.test-d.ts
@@ -44,6 +44,38 @@ describe("server", () => {
           });
         });
       });
+
+      it("infers 'any' for listener parameters of other events using enums", () => {
+        const srv = createServer();
+        const sio = new Server(srv);
+        srv.listen(() => {
+          sio.on("connection", (socket) => {
+            expectType<Socket<DefaultEventsMap, DefaultEventsMap>>(socket);
+          });
+
+          enum Events {
+            CONNECTION = "connection",
+            TEST = "test",
+          }
+
+          sio.on(Events.CONNECTION, (socket) => {
+            // TODO(#3833): Make this expect `Socket<DefaultEventsMap, DefaultEventsMap>`
+            expectType<any>(socket);
+
+            socket.on("test", (a, b, c) => {
+              expectType<any>(a);
+              expectType<any>(b);
+              expectType<any>(c);
+            });
+
+            socket.on(Events.TEST, (a, b, c) => {
+              expectType<any>(a);
+              expectType<any>(b);
+              expectType<any>(c);
+            });
+          });
+        });
+      });
     });
 
     describe("emit", () => {


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

Due to a compiler bug, we had the following issue (see #3833):

```ts
import { Server } from "socket.io";

const io = new Server(3000, {});

// this works fine
io.on("connection", (socket) => {});

enum Event {
    CONNECTION = "connection",
}
// Fails to compile!
// Argument of type '(socket:Socket) => void' is not assignable to parameter of type 'never'.
// ts(2345)
io.on(Event.CONNECTION, (socket) => {});
```

### New behavior

The above code now compiles. However, in the line `io.on(Event.CONNECTION, (socket) => {});`, the lambda parameter `socket` is inferred to be of type `any` instead of `Socket` if an enum member is used. 

Note that this only affects the situation where an enum member is used: If a string literal is used, the correct type (`Socket`) is still inferred.

Also note that inferring `any` in this situation is what was already happening in 3.x. So we are essentially reverting to that, at least until the compiler bug is fixed.

### Other information (e.g. related issues)

Fixes #3833 

