### PR TITLE
update type returned from emit

### DIFF
--- a/lib/broadcast-operator.ts
+++ b/lib/broadcast-operator.ts
@@ -133,7 +133,7 @@ export class BroadcastOperator<EmitEvents extends EventsMap>
   public emit<Ev extends EventNames<EmitEvents>>(
     ev: Ev,
     ...args: EventParams<EmitEvents, Ev>
-  ): true {
+  ): boolean {
     if (RESERVED_EVENTS.has(ev)) {
       throw new Error(`"${ev}" is a reserved event name`);
     }


### PR DESCRIPTION
Using a `true` here breaks using union types to do emits.. ie this no longer works
`(channel ? io.to(channel) : io).emit("stuff", message);`


### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior


### New behavior


### Other information (e.g. related issues)


