### PR TITLE
Remove unnecessary type annotations in examples

### DIFF
--- a/examples/angular-todomvc/server.ts
+++ b/examples/angular-todomvc/server.ts
@@ -1,4 +1,4 @@
-import { Server, Socket } from "socket.io";
+import { Server } from "socket.io";
 
 const io = new Server(8080, {
   cors: {
@@ -15,7 +15,7 @@ interface Todo {
 
 let todos: Array<Todo> = [];
 
-io.on("connect", (socket: Socket) => {
+io.on("connect", (socket) => {
     socket.emit("todos", todos);
 
     // note: we could also create a CRUD (create/read/update/delete) service for the todo list

--- a/examples/typescript/server.ts
+++ b/examples/typescript/server.ts
@@ -1,8 +1,8 @@
-import { Server, Socket } from "socket.io";
+import { Server } from "socket.io";
 
 const io = new Server(8080);
 
-io.on("connect", (socket: Socket) => {
+io.on("connect", (socket) => {
     console.log(`connect ${socket.id}`);
 
     socket.on("ping", (cb) => {


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

`socket` is inferred as type `Socket` as of 4.0.0; it was previously inferred as `any`. The type annotation is no longer needed to cast the `any` to `Socket`.

### New behavior

The `Socket` type annotation can be safely removed. The behavior is unchanged, but it's less code.

### Other information (e.g. related issues)

Typed events in socket.io 4.0 remove the need for writing type annotations in callbacks of reserved events.

