### PR TITLE
Include cookie-related CORS config in passport-example

### DIFF
--- a/examples/passport-example/index.html
+++ b/examples/passport-example/index.html
@@ -15,7 +15,10 @@
         </form>
         <script src="/socket.io/socket.io.js"></script>
         <script>
-          const socket = io();
+          const socket = io("ws://localhost:3000", {
+            // set this option to send cookies for session-management to work
+            withCredentials: true
+          });
           const socketIdSpan = document.getElementById("socketId");
           const usernameSpan = document.getElementById("username");
 

--- a/examples/passport-example/index.js
+++ b/examples/passport-example/index.js
@@ -70,7 +70,19 @@ passport.deserializeUser((id, cb) => {
   cb(null, DUMMY_USER);
 });
 
-const io = require('socket.io')(server);
+const io = require('socket.io').Server(server, {
+  /**
+   * We don't strictly need CORS configuration for this example because the socket.io server and the client are 
+   * on the same host:port, but this is a sample configuration when you do need it.
+   * See "Handling CORS" in documentation for full documentation of options.
+   **/
+  cors: {
+    origin: [`http://localhost:${port}`],
+    methods: ['GET', 'POST'],
+    // include this to accept cookies, used by express-session for the session-identifying cookie
+    credentials: true
+  },
+});
 
 // convert a connect middleware to a Socket.IO middleware
 const wrap = middleware => (socket, next) => middleware(socket.request, {}, next);


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other: update an example

### Current behavior

Example works without problems, but implicitly relies on same-origin cookie sending behaviour which isn't always the case in real implementations. 

### New behavior

Makes the reliance on same-origin cookie behaviour explicit and add sample CORS configuration that while not strictly needed in the example, are useful when adapting the example to real world scenario. Makes the example a tad bit more "complete".

### Other Info

Adding this is perhaps important because the configuration affects a library (`express-session`) that users may not directly work with, so may not have knowledge of correct configuration. Moreover, the library itself is centric to `express` so it doesn't offer `socket.io` configuration information, so this might be the best place to put this. 
