### PR TITLE
[4.x] Allow RemoteSocket to emit to current rooms

### DIFF
--- a/lib/broadcast-operator.ts
+++ b/lib/broadcast-operator.ts
@@ -273,7 +273,7 @@ export class RemoteSocket<EmitEvents extends EventsMap>
     this.handshake = details.handshake;
     this.rooms = new Set(details.rooms);
     this.data = details.data;
-    this.operator = new BroadcastOperator(adapter, new Set(details.rooms));
+    this.operator = new BroadcastOperator(adapter, new Set([this.id]));
   }
 
   public emit<Ev extends EventNames<EmitEvents>>(

--- a/lib/broadcast-operator.ts
+++ b/lib/broadcast-operator.ts
@@ -290,7 +290,7 @@ export class RemoteSocket<EmitEvents extends EventsMap>
    * @return self
    * @public
    */
-   public to(room: Room | Room[]): BroadcastOperator<EmitEvents> {
+  public to(room: Room | Room[]): BroadcastOperator<EmitEvents> {
     return this.newBroadcastOperator().to(room);
   }
 
@@ -345,7 +345,7 @@ export class RemoteSocket<EmitEvents extends EventsMap>
    * @return {Socket} self
    * @public
    */
-   public compress(compress: boolean): this {
+  public compress(compress: boolean): this {
     this.flags.compress = compress;
     return this;
   }
@@ -358,7 +358,7 @@ export class RemoteSocket<EmitEvents extends EventsMap>
    * @return {Socket} self
    * @public
    */
-   public get volatile(): this {
+  public get volatile(): this {
     this.flags.volatile = true;
     return this;
   }

--- a/lib/broadcast-operator.ts
+++ b/lib/broadcast-operator.ts
@@ -257,7 +257,7 @@ interface SocketDetails {
  * Expose of subset of the attributes and methods of the Socket class
  */
 export class RemoteSocket<EmitEvents extends EventsMap>
-implements TypedEventBroadcaster<EmitEvents> {
+  implements TypedEventBroadcaster<EmitEvents> {
   public readonly adapter: Adapter;
   public readonly id: SocketId;
   public readonly handshake: Handshake;


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

`RemoteSocket` objects cannot emit to other members in some rooms. This simple fix is letting users specify to which rooms the `Socket` (retrieved as `RemoteSocket`) is into, and broadcast to them, excepting the original sender.

```js
io.of('/some-namespace').fetchSockets().then(sockets => {
    sockets.forEach(socket => {
        // Issue: What if you want to emit to everyone but a RemoteSocket?
        if (typeof socket.to !== 'undefined') {
            socket.to('some-room').emit('event', { foo: 'bar' });
        }
    });
});
```

### New behavior

You can now call `.to()` and `.in()` on `RemoteSocket` objects. This way, you can use for example the Redis adapter and use the `RemoteSocket` as a normal `Socket` object when broadcasting to everyone except the sender:

```js
io.of('/some-namespace').fetchSockets().then(sockets => {
    sockets.forEach(socket => {
        socket.to('some-room').emit('event', { foo: 'bar' });
    });
});
```

### Other information (e.g. related issues)

Closes #3857

In #3857 is described in simple terms the desired behavior.

This also fixes a use case I confront with (and perhaps many will confront).

Consider having a multi-node or a multi-process deployment of Socket.IO, each one exposing a REST API to accept broadcasting messages (same as Pusher API) and their WS server, used by the clients. Both use Redis adapter and are set up properly for high scalability.

If Alice is on Node 1, and Bob is on Node 2, and Alice makes an HTTP request to Node 2 to emit to everyone but to Alice (by using the Client Socket ID), the `fetchSockets()` call will retrieve Bob as `Socket` and Alice as `RemoteSocket`, but calling `.emit()` from `RemoteSocket` will not allow Alice to emit to anyone else.

