### PR TITLE
add missing module

### DIFF
--- a/examples/basic-crud-application/server/package.json
+++ b/examples/basic-crud-application/server/package.json
@@ -24,6 +24,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@types/mocha": "^8.2.3",
     "@types/chai": "^4.2.16",
     "@types/uuid": "^8.3.0",
     "chai": "^4.3.4",


### PR DESCRIPTION
test/todo-management/todo.tests.ts:275:3 - error TS2582: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha`.


### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior


### New behavior


### Other information (e.g. related issues)


