### PR TITLE
feat: ignore the query string when serving client JavaScript

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -334,7 +334,7 @@ export class Server<
     this.clientPathRegex = new RegExp(
       "^" +
         escapedPath +
-        "/socket\\.io(\\.min|\\.msgpack\\.min)?\\.js(\\.map)?$"
+        "/socket\\.io(\\.min|\\.msgpack\\.min)?\\.js(\\.map)?(?:\\?|$)"
     );
     return this;
   }
@@ -487,7 +487,7 @@ export class Server<
    * @private
    */
   private serve(req: http.IncomingMessage, res: http.ServerResponse): void {
-    const filename = req.url!.replace(this._path, "");
+    const filename = req.url!.replace(this._path, "").replace(/\?.*$/, "");
     const isMap = dotMapRegex.test(filename);
     const type = isMap ? "map" : "source";
 

--- a/test/socket.io.ts
+++ b/test/socket.io.ts
@@ -83,6 +83,10 @@ describe("socket.io", () => {
       };
 
       it("should serve client", testSource("socket.io.js"));
+      it(
+        "should serve client with query string",
+        testSource("socket.io.js?buster=" + Date.now())
+      );
       it("should serve source map", testSourceMap("socket.io.js.map"));
       it("should serve client (min)", testSource("socket.io.min.js"));
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

Client JavaScript will not be served if the request URL contains a query string.

### New behavior

Client JavaScript will be served, even if the request URL contains a query string.

### Other information (e.g. related issues)

Resolves socketio/socket.io#4023
