### PR TITLE
fix: Fixed default export not being typed

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -822,6 +822,14 @@ export class Server<
   }
 }
 
+export default function io<
+  ListenEvents extends EventsMap = DefaultEventsMap,
+  EmitEvents extends EventsMap = ListenEvents,
+  ServerSideEvents extends EventsMap = DefaultEventsMap
+>(srv?: http.Server | number, opts?: Partial<ServerOptions>) {
+  return new Server<ListenEvents, EmitEvents, ServerSideEvents>(srv, opts);
+}
+
 /**
  * Expose main namespace (/).
  */
@@ -838,7 +846,7 @@ emitterMethods.forEach(function (fn) {
   };
 });
 
-module.exports = (srv?, opts?) => new Server(srv, opts);
+module.exports = io;
 module.exports.Server = Server;
 module.exports.Namespace = Namespace;
 module.exports.Socket = Socket;


### PR DESCRIPTION
Fixed the default export (exported using 'module.exports') not having type definitions


### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
The default export exported using `module.exports` is not exported using `export default`. As a consequence, the default export is not typed and when using typescript as
```typescript
import io from 'socket.io'
io(3000) // This expression is not callable.
```

### New behavior
```typescript
import io from 'socket.io'
io(3000) // Works normally
```