### PR TITLE
Mouse movement path and drawing path are different upon scroll/resize.

### DIFF
--- a/examples/whiteboard/public/main.js
+++ b/examples/whiteboard/public/main.js
@@ -59,19 +59,29 @@
     drawing = true;
     current.x = e.clientX||e.touches[0].clientX;
     current.y = e.clientY||e.touches[0].clientY;
+    current.x -= current.fixX;
+    current.y -= current.fixY;
   }
 
   function onMouseUp(e){
     if (!drawing) { return; }
+    let newX = e.clientX || e.touches[0].clientX;
+    let newY = e.clientY || e.touches[0].clientY;
+    newX -= current.fixX;
+    newY -= current.fixY;
     drawing = false;
-    drawLine(current.x, current.y, e.clientX||e.touches[0].clientX, e.clientY||e.touches[0].clientY, current.color, true);
+    drawLine(current.x, current.y, newX, newY, current.color, true);
   }
 
   function onMouseMove(e){
     if (!drawing) { return; }
+    let newX = e.clientX || e.touches[0].clientX;
+    let newY = e.clientY || e.touches[0].clientY;
+    newX -= current.fixX;
+    newY -= current.fixY;
     drawLine(current.x, current.y, e.clientX||e.touches[0].clientX, e.clientY||e.touches[0].clientY, current.color, true);
-    current.x = e.clientX||e.touches[0].clientX;
-    current.y = e.clientY||e.touches[0].clientY;
+    current.x = newX;
+    current.y = newY;
   }
 
   function onColorUpdate(e){
@@ -101,6 +111,13 @@
   function onResize() {
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
+    fixOffset()
   }
 
+  // Fix offset when scrolled
+  window.addEventListener('scroll', fixOffset, false);
+  function fixOffset() {
+    current.fixX = canvas.getBoundingClientRect().left;
+    current.fixY = canvas.getBoundingClientRect().top;
+  }
 })();


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
While drawing, the lines are drawn with respect to the browser window (using clientX. clientY). When the canvas is more or less than the browser window line drawn are not accurate and are far away from mouse movement. 

Lets make canvas move down by 200px by adding css, canvas{margin-top:200px}
now the line drawn and the mouse movement will be 200px apart.

### New behavior
To fix this we have to decrease the top offset from current.x and left offset from current.y. So that, even after scrolling the offsets are fixed and drawn line is exactly below the cursor.

### Other information (e.g. related issues)
NA


