### PR TITLE
Add name field to server cookie option type

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -107,7 +107,7 @@ interface EngineOptions {
    * might be used for sticky-session. Defaults to not sending any cookie.
    * @default false
    */
-  cookie: CookieSerializeOptions | boolean;
+  cookie: CookieSerializeOptions & { name: string } | boolean;
   /**
    * the options that will be forwarded to the cors module
    */


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

Using the `name` field in the `cookie` server option produces a type error since the field isn't in `CookieSerializeOptions` but is added by socket.io (engine.io specifically).

### New behavior

The type error doesn't happen anymore.

### Other information (e.g. related issues)

See [the code](https://github.com/socketio/engine.io/blob/master/lib/server.js#L355) that references `name` in engine.io.

