### PR TITLE
update wrapper.mjs so it provides the same `default` as for CommonJS users

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test:unit": "nyc mocha --require ts-node/register --reporter spec --slow 200 --bail --timeout 10000 test/socket.io.ts",
     "format:check": "prettier --check \"lib/**/*.ts\" \"test/**/*.ts\"",
     "format:fix": "prettier --write \"lib/**/*.ts\" \"test/**/*.ts\"",
-    "prepack": "npm run compile"
+    "prepare": "npm run compile"
   },
   "dependencies": {
     "@types/cookie": "^0.4.1",

--- a/wrapper.mjs
+++ b/wrapper.mjs
@@ -1,3 +1,4 @@
 import io from "./dist/index.js";
 
+export default io;
 export const {Server, Namespace, Socket} = io;


### PR DESCRIPTION


### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

When migrating from CommonJS to ESM, the end user no longer had the default option available unless they `import io from 'socket.io/dist/index.js'`.

You can see at the bottom of this file: https://unpkg.com/socket.io@4.2.0/dist/index.js

There is this line:

```js
module.exports = (srv, opts) => new Server(srv, opts);
```

which is a convenience for CommonJS users, but ESM users don't have this option (unless they import `dist/index.js`)

### New behavior

Now they can `import io from 'socket.io'` which is similar to `const io = require('socket.io')` as they had when using CommonJS.

### Other information (e.g. related issues)

n/a