### PR TITLE
Update .NET client library link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ Some implementations in other languages are also available:
 - [Swift](https://github.com/socketio/socket.io-client-swift)
 - [Dart](https://github.com/rikulo/socket.io-client-dart)
 - [Python](https://github.com/miguelgrinberg/python-socketio)
-- [.Net](https://github.com/Quobject/SocketIoClientDotNet)
+- [.NET](https://github.com/doghappy/socket.io-client-csharp)
 
 Its main features are:
 


### PR DESCRIPTION

### The kind of change this PR does introduce

* [] a bug fix
* [ ] a new feature
* [x ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
Old library is deprecated: https://github.com/Quobject/SocketIoClientDotNet

### New behavior
Official site docs are pointing to this actively maintained library: https://github.com/doghappy/socket.io-client-csharp

### Other information (e.g. related issues)
Site docs link: https://socket.io/docs/v4/

