### PR TITLE
fix https server instance not being attached in constructor

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,5 @@
 import http = require("http");
+import https = require("https");
 import { createReadStream } from "fs";
 import { createDeflate, createGzip, createBrotliCompress } from "zlib";
 import accepts = require("accepts");
@@ -156,7 +157,11 @@ export class Server<
     this.adapter(opts.adapter || Adapter);
     this.sockets = this.of("/");
     this.opts = opts;
-    if (srv instanceof http.Server || typeof srv === "number") {
+    if (
+      srv instanceof http.Server ||
+      srv instanceof https.Server ||
+      typeof srv === "number"
+    ) {
       this.attach(srv);
     }
   }


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

https server instances not running attach function in constructor

### New behavior

https server instance now runs attach function in constructor

### Other information (e.g. related issues)

fixes https://github.com/socketio/socket.io/issues/4124

