### PR TITLE
Fix: Custom server instance not attached

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -156,9 +156,7 @@ export class Server<
     this.adapter(opts.adapter || Adapter);
     this.sockets = this.of("/");
     this.opts = opts;
-    if (srv instanceof http.Server || typeof srv === "number") {
-      this.attach(srv);
-    }
+    if (srv) this.attach(srv as http.Server | number);
   }
 
   /**


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

custom server instances not running attach function in constructor. this breaks feathers/socketio package which relies on socket.io.

### New behavior

custom server instance now runs attach function in constructor

### Other information (e.g. related issues)

fixes #4124
