### PR TITLE
Add type information to `Socket.data`

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -21,21 +21,27 @@ interface WriteOptions {
 export class Client<
   ListenEvents extends EventsMap,
   EmitEvents extends EventsMap,
-  ServerSideEvents extends EventsMap
+  ServerSideEvents extends EventsMap,
+  SocketData = any
 > {
   public readonly conn: RawSocket;
 
   private readonly id: string;
-  private readonly server: Server<ListenEvents, EmitEvents, ServerSideEvents>;
+  private readonly server: Server<
+    ListenEvents,
+    EmitEvents,
+    ServerSideEvents,
+    SocketData
+  >;
   private readonly encoder: Encoder;
   private readonly decoder: Decoder;
   private sockets: Map<
     SocketId,
-    Socket<ListenEvents, EmitEvents, ServerSideEvents>
+    Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>
   > = new Map();
   private nsps: Map<
     string,
-    Socket<ListenEvents, EmitEvents, ServerSideEvents>
+    Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>
   > = new Map();
   private connectTimeout?: NodeJS.Timeout;
 
@@ -112,7 +118,7 @@ export class Client<
       auth,
       (
         dynamicNspName:
-          | Namespace<ListenEvents, EmitEvents, ServerSideEvents>
+          | Namespace<ListenEvents, EmitEvents, ServerSideEvents, SocketData>
           | false
       ) => {
         if (dynamicNspName) {
@@ -171,7 +177,9 @@ export class Client<
    *
    * @private
    */
-  _remove(socket: Socket<ListenEvents, EmitEvents, ServerSideEvents>): void {
+  _remove(
+    socket: Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>
+  ): void {
     if (this.sockets.has(socket.id)) {
       const nsp = this.sockets.get(socket.id)!.nsp.name;
       this.sockets.delete(socket.id);

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -53,7 +53,7 @@ export class Client<
    * @package
    */
   constructor(
-    server: Server<ListenEvents, EmitEvents, ServerSideEvents>,
+    server: Server<ListenEvents, EmitEvents, ServerSideEvents, SocketData>,
     conn: any
   ) {
     this.server = server;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -72,7 +72,8 @@ interface ServerOptions extends EngineOptions, AttachOptions {
 export class Server<
   ListenEvents extends EventsMap = DefaultEventsMap,
   EmitEvents extends EventsMap = ListenEvents,
-  ServerSideEvents extends EventsMap = DefaultEventsMap
+  ServerSideEvents extends EventsMap = DefaultEventsMap,
+  SocketData = any
 > extends StrictEventEmitter<
   ServerSideEvents,
   EmitEvents,
@@ -81,7 +82,8 @@ export class Server<
   public readonly sockets: Namespace<
     ListenEvents,
     EmitEvents,
-    ServerSideEvents
+    ServerSideEvents,
+    SocketData
   >;
   /**
    * A reference to the underlying Engine.IO server.
@@ -504,7 +506,7 @@ export class Server<
    */
   public of(
     name: string | RegExp | ParentNspNameMatchFn,
-    fn?: (socket: Socket<ListenEvents, EmitEvents, ServerSideEvents>) => void
+    fn?: (socket: Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>) => void
   ): Namespace<ListenEvents, EmitEvents, ServerSideEvents> {
     if (typeof name === "function" || name instanceof RegExp) {
       const parentNsp = new ParentNamespace(this);
@@ -568,7 +570,7 @@ export class Server<
    */
   public use(
     fn: (
-      socket: Socket<ListenEvents, EmitEvents, ServerSideEvents>,
+      socket: Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>,
       next: (err?: ExtendedError) => void
     ) => void
   ): this {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -77,7 +77,12 @@ export class Server<
 > extends StrictEventEmitter<
   ServerSideEvents,
   EmitEvents,
-  ServerReservedEventsMap<ListenEvents, EmitEvents, ServerSideEvents>
+  ServerReservedEventsMap<
+    ListenEvents,
+    EmitEvents,
+    ServerSideEvents,
+    SocketData
+  >
 > {
   public readonly sockets: Namespace<
     ListenEvents,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -506,7 +506,9 @@ export class Server<
    */
   public of(
     name: string | RegExp | ParentNspNameMatchFn,
-    fn?: (socket: Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>) => void
+    fn?: (
+      socket: Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>
+    ) => void
   ): Namespace<ListenEvents, EmitEvents, ServerSideEvents> {
     if (typeof name === "function" || name instanceof RegExp) {
       const parentNsp = new ParentNamespace(this);

--- a/lib/namespace.ts
+++ b/lib/namespace.ts
@@ -50,7 +50,8 @@ export const RESERVED_EVENTS: ReadonlySet<string | Symbol> = new Set<
 export class Namespace<
   ListenEvents extends EventsMap = DefaultEventsMap,
   EmitEvents extends EventsMap = ListenEvents,
-  ServerSideEvents extends EventsMap = DefaultEventsMap
+  ServerSideEvents extends EventsMap = DefaultEventsMap,
+  SocketData = any
 > extends StrictEventEmitter<
   ServerSideEvents,
   EmitEvents,
@@ -59,18 +60,18 @@ export class Namespace<
   public readonly name: string;
   public readonly sockets: Map<
     SocketId,
-    Socket<ListenEvents, EmitEvents, ServerSideEvents>
+    Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>
   > = new Map();
 
   public adapter: Adapter;
 
   /** @private */
-  readonly server: Server<ListenEvents, EmitEvents, ServerSideEvents>;
+  readonly server: Server<ListenEvents, EmitEvents, ServerSideEvents, SocketData>;
 
   /** @private */
   _fns: Array<
     (
-      socket: Socket<ListenEvents, EmitEvents, ServerSideEvents>,
+      socket: Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>,
       next: (err?: ExtendedError) => void
     ) => void
   > = [];
@@ -85,7 +86,7 @@ export class Namespace<
    * @param name
    */
   constructor(
-    server: Server<ListenEvents, EmitEvents, ServerSideEvents>,
+    server: Server<ListenEvents, EmitEvents, ServerSideEvents, SocketData>,
     name: string
   ) {
     super();
@@ -114,7 +115,7 @@ export class Namespace<
    */
   public use(
     fn: (
-      socket: Socket<ListenEvents, EmitEvents, ServerSideEvents>,
+      socket: Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>,
       next: (err?: ExtendedError) => void
     ) => void
   ): this {
@@ -130,7 +131,7 @@ export class Namespace<
    * @private
    */
   private run(
-    socket: Socket<ListenEvents, EmitEvents, ServerSideEvents>,
+    socket: Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>,
     fn: (err: ExtendedError | null) => void
   ) {
     const fns = this._fns.slice(0);
@@ -195,7 +196,7 @@ export class Namespace<
     client: Client<ListenEvents, EmitEvents, ServerSideEvents>,
     query,
     fn?: () => void
-  ): Socket<ListenEvents, EmitEvents, ServerSideEvents> {
+  ): Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData> {
     debug("adding socket to nsp %s", this.name);
     const socket = new Socket(this, client, query);
     this.run(socket, (err) => {
@@ -238,7 +239,7 @@ export class Namespace<
    *
    * @private
    */
-  _remove(socket: Socket<ListenEvents, EmitEvents, ServerSideEvents>): void {
+  _remove(socket: Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>): void {
     if (this.sockets.has(socket.id)) {
       this.sockets.delete(socket.id);
     } else {

--- a/lib/namespace.ts
+++ b/lib/namespace.ts
@@ -66,7 +66,12 @@ export class Namespace<
   public adapter: Adapter;
 
   /** @private */
-  readonly server: Server<ListenEvents, EmitEvents, ServerSideEvents, SocketData>;
+  readonly server: Server<
+    ListenEvents,
+    EmitEvents,
+    ServerSideEvents,
+    SocketData
+  >;
 
   /** @private */
   _fns: Array<
@@ -239,7 +244,9 @@ export class Namespace<
    *
    * @private
    */
-  _remove(socket: Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>): void {
+  _remove(
+    socket: Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>
+  ): void {
     if (this.sockets.has(socket.id)) {
       this.sockets.delete(socket.id);
     } else {

--- a/lib/namespace.ts
+++ b/lib/namespace.ts
@@ -21,30 +21,35 @@ export interface ExtendedError extends Error {
 export interface NamespaceReservedEventsMap<
   ListenEvents extends EventsMap,
   EmitEvents extends EventsMap,
-  ServerSideEvents extends EventsMap
+  ServerSideEvents extends EventsMap,
+  SocketData
 > {
-  connect: (socket: Socket<ListenEvents, EmitEvents, ServerSideEvents>) => void;
+  connect: (
+    socket: Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>
+  ) => void;
   connection: (
-    socket: Socket<ListenEvents, EmitEvents, ServerSideEvents>
+    socket: Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>
   ) => void;
 }
 
 export interface ServerReservedEventsMap<
   ListenEvents,
   EmitEvents,
-  ServerSideEvents
+  ServerSideEvents,
+  SocketData
 > extends NamespaceReservedEventsMap<
     ListenEvents,
     EmitEvents,
-    ServerSideEvents
+    ServerSideEvents,
+    SocketData
   > {
   new_namespace: (
-    namespace: Namespace<ListenEvents, EmitEvents, ServerSideEvents>
+    namespace: Namespace<ListenEvents, EmitEvents, ServerSideEvents, SocketData>
   ) => void;
 }
 
 export const RESERVED_EVENTS: ReadonlySet<string | Symbol> = new Set<
-  keyof ServerReservedEventsMap<never, never, never>
+  keyof ServerReservedEventsMap<never, never, never, never>
 >(<const>["connect", "connection", "new_namespace"]);
 
 export class Namespace<
@@ -55,7 +60,12 @@ export class Namespace<
 > extends StrictEventEmitter<
   ServerSideEvents,
   EmitEvents,
-  NamespaceReservedEventsMap<ListenEvents, EmitEvents, ServerSideEvents>
+  NamespaceReservedEventsMap<
+    ListenEvents,
+    EmitEvents,
+    ServerSideEvents,
+    SocketData
+  >
 > {
   public readonly name: string;
   public readonly sockets: Map<

--- a/lib/parent-namespace.ts
+++ b/lib/parent-namespace.ts
@@ -11,13 +11,17 @@ import type { BroadcastOptions } from "socket.io-adapter";
 export class ParentNamespace<
   ListenEvents extends EventsMap = DefaultEventsMap,
   EmitEvents extends EventsMap = ListenEvents,
-  ServerSideEvents extends EventsMap = DefaultEventsMap
-> extends Namespace<ListenEvents, EmitEvents, ServerSideEvents> {
+  ServerSideEvents extends EventsMap = DefaultEventsMap,
+  SocketData = any
+> extends Namespace<ListenEvents, EmitEvents, ServerSideEvents, SocketData> {
   private static count: number = 0;
-  private children: Set<Namespace<ListenEvents, EmitEvents, ServerSideEvents>> =
-    new Set();
+  private children: Set<
+    Namespace<ListenEvents, EmitEvents, ServerSideEvents, SocketData>
+  > = new Set();
 
-  constructor(server: Server<ListenEvents, EmitEvents, ServerSideEvents>) {
+  constructor(
+    server: Server<ListenEvents, EmitEvents, ServerSideEvents, SocketData>
+  ) {
     super(server, "/_" + ParentNamespace.count++);
   }
 
@@ -47,7 +51,7 @@ export class ParentNamespace<
 
   createChild(
     name: string
-  ): Namespace<ListenEvents, EmitEvents, ServerSideEvents> {
+  ): Namespace<ListenEvents, EmitEvents, ServerSideEvents, SocketData> {
     const namespace = new Namespace(this.server, name);
     namespace._fns = this._fns.slice(0);
     this.listeners("connect").forEach((listener) =>

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -113,7 +113,8 @@ type Event = [eventName: string, ...args: any[]];
 export class Socket<
   ListenEvents extends EventsMap = DefaultEventsMap,
   EmitEvents extends EventsMap = ListenEvents,
-  ServerSideEvents extends EventsMap = DefaultEventsMap
+  ServerSideEvents extends EventsMap = DefaultEventsMap,
+  SocketData = any
 > extends StrictEventEmitter<
   ListenEvents,
   EmitEvents,
@@ -124,7 +125,7 @@ export class Socket<
   /**
    * Additional information that can be attached to the Socket instance and which will be used in the fetchSockets method
    */
-  public data: any = {};
+  public data: Partial<SocketData> = {};
 
   public connected: boolean;
   public disconnected: boolean;

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -46,7 +46,7 @@ export interface EventEmitterReservedEventsMap {
 
 export const RESERVED_EVENTS: ReadonlySet<string | Symbol> = new Set<
   | ClientReservedEvents
-  | keyof NamespaceReservedEventsMap<never, never, never>
+  | keyof NamespaceReservedEventsMap<never, never, never, never>
   | keyof SocketReservedEventsMap
   | keyof EventEmitterReservedEventsMap
 >(<const>[
@@ -130,7 +130,12 @@ export class Socket<
   public connected: boolean;
   public disconnected: boolean;
 
-  private readonly server: Server<ListenEvents, EmitEvents, ServerSideEvents>;
+  private readonly server: Server<
+    ListenEvents,
+    EmitEvents,
+    ServerSideEvents,
+    SocketData
+  >;
   private readonly adapter: Adapter;
   private acks: Map<number, () => void> = new Map();
   private fns: Array<(event: Event, next: (err?: Error) => void) => void> = [];


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behavior

`Socket.data` is `any`

### New behavior

`Socket.data` is `any` by default but `Partial<ProvidedType>` if a type is provided in the `Server` and/or `Socket` constructors

### Other information (e.g. related issues)

I had to wrap the provided type in `Partial` because we are initializing the `Socket.data` with `{}`. I did not want to alter this behavior but instead I just wanted to provide a simple way to type the `Socket.data` field. This fixes #4155.
