### PR TITLE
Fix reconnection handling in the chat demo app

### DIFF
--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -6,7 +6,7 @@ A simple chat demo for Socket.IO
 ## How to use
 
 ```
-$ npm ci
+$ npm i
 $ npm start
 ```
 

--- a/examples/chat/public/main.js
+++ b/examples/chat/public/main.js
@@ -264,14 +264,14 @@ $(function() {
     log('you have been disconnected');
   });
 
-  socket.on('reconnect', () => {
+  socket.io.on('reconnect', () => {
     log('you have been reconnected');
     if (username) {
       socket.emit('add user', username);
     }
   });
 
-  socket.on('reconnect_error', () => {
+  socket.io.on('reconnect_error', () => {
     log('attempt to reconnect has failed');
   });
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behavior
The source code of the example app `examples/chat`  implies that reconnetion status (failure or success) is shown to the user.
In fact, it's not, because the reconnection events are listened to incorrectly: you're supposed to listen to the Manager's events like `socket.io.on(...)`, not just `socket.on(...)`.

I only wanted to take a look at how to handle disconnections and do reconnections, but here is what it came down to :)

### New behavior
The example works as it's supposed to, you can now see messages like "attempt to reconnect has failed" in the UI.

### Other information (e.g. related issues)
Also updated README in the example: it says you need to run `npm ci` to install packages, but since lockfiles are gitignored in the `example` folder, you actually need to run `npm i`

