### PR TITLE
fix(typings): ensure compatibility with TypeScript 3.x

### DIFF
--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -107,7 +107,10 @@ export interface Handshake {
   auth: { [key: string]: any };
 }
 
-export type Event = [eventName: string, ...args: any[]];
+/**
+ * `[eventName, ...args]`
+ */
+export type Event = [string, ...any[]];
 
 export class Socket<
   ListenEvents extends EventsMap = DefaultEventsMap,


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix

### Current behavior

#4138 added an `Event` type using Typescript’s labelled tuple syntax:

```ts
type Event = [eventName: string, ...args: any[]];
```

This fails to compile if a consumer is using a TypeScript version less than 4.x

Reference: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-0.html#labeled-tuple-elements

### New behavior

This PR removes the labelling in the `Event` type to continue to support TypeScript 3.x as did 0cb6ac9.


