### PR TITLE
Npm audit changes to fix engine.io vulnerability CVE-2022-21676

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -442,9 +442,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
-      "integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw=="
+      "version": "17.0.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.12.tgz",
+      "integrity": "sha512-4YpbAsnJXWYK/fpTVFlMIcUIho2AYCi4wg5aNPrG1ng7fn/1/RZfCIpRCiBX+12RVa34RluilnvCqD+g3KiSiA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -863,9 +863,9 @@
       "dev": true
     },
     "engine.io": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.0.tgz",
-      "integrity": "sha512-ErhZOVu2xweCjEfYcTdkCnEYUiZgkAcBBAhW4jbIvNG8SLU3orAqoJCiytZjYF7eTpVmmCrLDjLIEaPlUAs1uw==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.2.tgz",
+      "integrity": "sha512-v/7eGHxPvO2AWsksyx2PUsQvBafuvqs0jJJQ0FdmJG1b9qIvgSbqDRGwNhfk2XHaTTbTXiC4quRE8Q9nRjsrQQ==",
       "requires": {
         "@types/cookie": "^0.4.1",
         "@types/cors": "^2.8.12",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "accepts": "~1.3.4",
     "base64id": "~2.0.0",
     "debug": "~4.3.2",
-    "engine.io": "~6.1.0",
+    "engine.io": "^6.1.2",
     "socket.io-adapter": "~2.3.3",
     "socket.io-parser": "~4.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "accepts": "~1.3.4",
     "base64id": "~2.0.0",
     "debug": "~4.3.2",
-    "engine.io": "^6.1.2",
+    "engine.io": "~6.1.2",
     "socket.io-adapter": "~2.3.3",
     "socket.io-parser": "~4.0.4"
   },


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behavior


### New behavior


### Other information (e.g. related issues)
Runned npm audit fix in order to update the engine.io dependency version. The new version fixes the vulnerability [CVE-2022-21676](https://github.com/socketio/engine.io/security/advisories/GHSA-273r-mgr4-v34f)

