### PR TITLE
added missing type declaration to .of

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -578,7 +578,7 @@ export class Server<
    * @param fn optional, nsp `connection` ev handler
    * @public
    */
-  public of(
+  public of<ListenEvents, EmitEvents, ServerSideEvents, SocketData>(
     name: string | RegExp | ParentNspNameMatchFn,
     fn?: (
       socket: Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix

### Current behavior
socketServer.of(...) method has not ability to pass templates like Socket constructor do 

### New behavior
Enables

### Other information (e.g. related issues)
I've created, but not accepted yet
