### PR TITLE
Add https.Server to accepted types

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,5 @@
 import http = require("http");
+import https = require("https");
 import { createReadStream } from "fs";
 import { createDeflate, createGzip, createBrotliCompress } from "zlib";
 import accepts = require("accepts");
@@ -131,7 +132,7 @@ export class Server<
    * @private
    */
   _connectTimeout: number;
-  private httpServer: http.Server;
+  private httpServer: http.Server | https.Server;
 
   /**
    * Server constructor.
@@ -141,13 +142,13 @@ export class Server<
    * @public
    */
   constructor(opts?: Partial<ServerOptions>);
-  constructor(srv?: http.Server | number, opts?: Partial<ServerOptions>);
+  constructor(srv?: http.Server | https.Server | number, opts?: Partial<ServerOptions>);
   constructor(
-    srv: undefined | Partial<ServerOptions> | http.Server | number,
+    srv: undefined | Partial<ServerOptions> | http.Server | https.Server | number,
     opts?: Partial<ServerOptions>
   );
   constructor(
-    srv: undefined | Partial<ServerOptions> | http.Server | number,
+    srv: undefined | Partial<ServerOptions> | http.Server | https.Server | number,
     opts: Partial<ServerOptions> = {}
   ) {
     super();
@@ -167,7 +168,7 @@ export class Server<
     this.adapter(opts.adapter || Adapter);
     this.sockets = this.of("/");
     this.opts = opts;
-    if (srv || typeof srv == "number") this.attach(srv as http.Server | number);
+    if (srv || typeof srv == "number") this.attach(srv as http.Server | https.Server | number);
   }
 
   /**
@@ -300,7 +301,7 @@ export class Server<
    * @public
    */
   public listen(
-    srv: http.Server | number,
+    srv: http.Server | https.Server | number,
     opts: Partial<ServerOptions> = {}
   ): this {
     return this.attach(srv, opts);
@@ -315,7 +316,7 @@ export class Server<
    * @public
    */
   public attach(
-    srv: http.Server | number,
+    srv: http.Server | https.Server | number,
     opts: Partial<ServerOptions> = {}
   ): this {
     if ("function" == typeof srv) {
@@ -421,7 +422,7 @@ export class Server<
    * @private
    */
   private initEngine(
-    srv: http.Server,
+    srv: http.Server | https.Server,
     opts: EngineOptions & AttachOptions
   ): void {
     // initialize engine
@@ -444,7 +445,7 @@ export class Server<
    * @param srv http server
    * @private
    */
-  private attachServe(srv: http.Server): void {
+  private attachServe(srv: http.Server | https.Server): void {
     debug("attaching client serving req handler");
 
     const evs = srv.listeners("request").slice(0);


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
Currently you can't attach a https server to the socket.io instance. You would first need to cast it to any and then to http.Server if you want to use it

### New behavior
Socket.io should now also accept https.Server

### Other information (e.g. related issues)