### PR TITLE
fix(types) : added typing for callbacks to socket.emit and socket.on

### DIFF
--- a/lib/broadcast-operator.ts
+++ b/lib/broadcast-operator.ts
@@ -3,7 +3,7 @@ import { Handshake, RESERVED_EVENTS, Socket } from "./socket";
 import { PacketType } from "socket.io-parser";
 import type { Adapter } from "socket.io-adapter";
 import type {
-  EventParams,
+  EventEmitArgs,
   EventNames,
   EventsMap,
   TypedEventBroadcaster,
@@ -160,7 +160,7 @@ export class BroadcastOperator<EmitEvents extends EventsMap, SocketData>
    */
   public emit<Ev extends EventNames<EmitEvents>>(
     ev: Ev,
-    ...args: EventParams<EmitEvents, Ev>
+    ...args: EventEmitArgs<EmitEvents, Ev>
   ): boolean {
     if (RESERVED_EVENTS.has(ev)) {
       throw new Error(`"${ev}" is a reserved event name`);
@@ -360,7 +360,7 @@ export class RemoteSocket<EmitEvents extends EventsMap, SocketData>
 
   public emit<Ev extends EventNames<EmitEvents>>(
     ev: Ev,
-    ...args: EventParams<EmitEvents, Ev>
+    ...args: EventEmitArgs<EmitEvents, Ev>
   ): boolean {
     return this.operator.emit(ev, ...args);
   }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -24,7 +24,7 @@ import type { BroadcastOperator, RemoteSocket } from "./broadcast-operator";
 import {
   EventsMap,
   DefaultEventsMap,
-  EventParams,
+  EventEmitArgs,
   StrictEventEmitter,
   EventNames,
 } from "./typed-events";
@@ -698,7 +698,7 @@ export class Server<
    * @return self
    * @public
    */
-  public send(...args: EventParams<EmitEvents, "message">): this {
+  public send(...args: EventEmitArgs<EmitEvents, "message">): this {
     this.sockets.emit("message", ...args);
     return this;
   }
@@ -709,7 +709,7 @@ export class Server<
    * @return self
    * @public
    */
-  public write(...args: EventParams<EmitEvents, "message">): this {
+  public write(...args: EventEmitArgs<EmitEvents, "message">): this {
     this.sockets.emit("message", ...args);
     return this;
   }
@@ -723,7 +723,7 @@ export class Server<
    */
   public serverSideEmit<Ev extends EventNames<ServerSideEvents>>(
     ev: Ev,
-    ...args: EventParams<ServerSideEvents, Ev>
+    ...args: EventEmitArgs<ServerSideEvents, Ev>
   ): boolean {
     return this.sockets.serverSideEmit(ev, ...args);
   }

--- a/lib/namespace.ts
+++ b/lib/namespace.ts
@@ -1,7 +1,7 @@
 import { Socket } from "./socket";
 import type { Server } from "./index";
 import {
-  EventParams,
+  EventEmitArgs,
   EventNames,
   EventsMap,
   StrictEventEmitter,
@@ -274,7 +274,7 @@ export class Namespace<
    */
   public emit<Ev extends EventNames<EmitEvents>>(
     ev: Ev,
-    ...args: EventParams<EmitEvents, Ev>
+    ...args: EventEmitArgs<EmitEvents, Ev>
   ): boolean {
     return new BroadcastOperator<EmitEvents, SocketData>(this.adapter).emit(
       ev,
@@ -288,7 +288,7 @@ export class Namespace<
    * @return self
    * @public
    */
-  public send(...args: EventParams<EmitEvents, "message">): this {
+  public send(...args: EventEmitArgs<EmitEvents, "message">): this {
     this.emit("message", ...args);
     return this;
   }
@@ -299,7 +299,7 @@ export class Namespace<
    * @return self
    * @public
    */
-  public write(...args: EventParams<EmitEvents, "message">): this {
+  public write(...args: EventEmitArgs<EmitEvents, "message">): this {
     this.emit("message", ...args);
     return this;
   }
@@ -313,7 +313,7 @@ export class Namespace<
    */
   public serverSideEmit<Ev extends EventNames<ServerSideEvents>>(
     ev: Ev,
-    ...args: EventParams<ServerSideEvents, Ev>
+    ...args: EventEmitArgs<ServerSideEvents, Ev>
   ): boolean {
     if (RESERVED_EVENTS.has(ev)) {
       throw new Error(`"${ev}" is a reserved event name`);

--- a/lib/parent-namespace.ts
+++ b/lib/parent-namespace.ts
@@ -1,7 +1,7 @@
 import { Namespace } from "./namespace";
 import type { Server, RemoteSocket } from "./index";
 import type {
-  EventParams,
+  EventEmitArgs,
   EventNames,
   EventsMap,
   DefaultEventsMap,
@@ -40,7 +40,7 @@ export class ParentNamespace<
 
   public emit<Ev extends EventNames<EmitEvents>>(
     ev: Ev,
-    ...args: EventParams<EmitEvents, Ev>
+    ...args: EventEmitArgs<EmitEvents, Ev>
   ): boolean {
     this.children.forEach((nsp) => {
       nsp.emit(ev, ...args);

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -2,7 +2,7 @@ import { Packet, PacketType } from "socket.io-parser";
 import debugModule from "debug";
 import type { Server } from "./index";
 import {
-  EventParams,
+  EventEmitArgs,
   EventNames,
   EventsMap,
   StrictEventEmitter,
@@ -198,7 +198,7 @@ export class Socket<
    */
   public emit<Ev extends EventNames<EmitEvents>>(
     ev: Ev,
-    ...args: EventParams<EmitEvents, Ev>
+    ...args: EventEmitArgs<EmitEvents, Ev>
   ): boolean {
     if (RESERVED_EVENTS.has(ev)) {
       throw new Error(`"${ev}" is a reserved event name`);
@@ -290,7 +290,7 @@ export class Socket<
    * @return self
    * @public
    */
-  public send(...args: EventParams<EmitEvents, "message">): this {
+  public send(...args: EventEmitArgs<EmitEvents, "message">): this {
     this.emit("message", ...args);
     return this;
   }
@@ -301,7 +301,7 @@ export class Socket<
    * @return self
    * @public
    */
-  public write(...args: EventParams<EmitEvents, "message">): this {
+  public write(...args: EventEmitArgs<EmitEvents, "message">): this {
     this.emit("message", ...args);
     return this;
   }


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Example data
```
export class EmitEvents implements EventsMap {
    'join': (data: string) => string;
}
export class ListenEvents implements EventsMap {
    'message': (data: string) => number;
}
```
### Current behavior : Emit (and derivates)
```
const sock: Socket<EmitEvents, ListenEvents>;
//typing for sock.emit is:
//sock.emit(ev : "join", data : string);
sock.emit('join', "hello", (res)=>{console.log(res)}); // Leads to error since the callback is not defined in typing
```
### New behavior
```
const sock: Socket<EmitEvents, ListenEvents >;
//typing for sock.emit is:
//sock.emit(ev : "join", data : string, cb?:(response : string)=>void); // Uses the return type of the EmitEvent to type the response in the callback
sock.emit('join', "hello", (res)=>{console.log(res)}); // Compiles
```

### Current behavior : On (and derivates)
```
const sock: Socket<EmitEvents, ListenEvents>;
//typing for sock.on is:
//sock.on(ev : "message", listener : (data: string)=>void);
sock.emit('join', "hello", (data, cb)=>{cb("Welcome")}); // Leads to error since the callback is not defined in typing
```

### New behavior
```
const sock: Socket<EmitEvents, ListenEvents>;
//typing for sock.on is:
//sock.on(ev : "message", listener : (data: string, cb:(response:number)=>void)=>void); // Uses return type of the ListenEvent as Cb type
sock.emit('join', "hello", (data, cb)=>{cb(1)}); // Compiles
```


### Other information (e.g. related issues)

Could possibly break older type script versions from building the Project.
The fix is using following features which I haven't seen be used in other parts of the code:
    1. named tuples        (Released in TS4.0)
    2. ReturnType  utility (Released in TS2.8)
