### PR TITLE
Propagate constraints from `NamespaceReservedEventsMap` to `ServerReservedEventsMap`

### DIFF
--- a/lib/namespace.ts
+++ b/lib/namespace.ts
@@ -33,9 +33,9 @@ export interface NamespaceReservedEventsMap<
 }
 
 export interface ServerReservedEventsMap<
-  ListenEvents,
-  EmitEvents,
-  ServerSideEvents,
+  ListenEvents extends EventsMap,
+  EmitEvents extends EventsMap,
+  ServerSideEvents extends EventsMap,
   SocketData
 > extends NamespaceReservedEventsMap<
     ListenEvents,


### PR DESCRIPTION
Hi there! 👋

TypeScript recently added some stricter checking around unconstrained generics being incompatible with emptyish object types. The changes are only in nightly versions of TypeScript right now, but we've been exploring how open-source projects have been impacted. These are the changes necessary for socket.io to build cleanly in TypeScript 4.8.