### PR TITLE
Add missing constraints

### DIFF
--- a/lib/namespace.ts
+++ b/lib/namespace.ts
@@ -33,9 +33,9 @@ export interface NamespaceReservedEventsMap<
 }
 
 export interface ServerReservedEventsMap<
-  ListenEvents,
-  EmitEvents,
-  ServerSideEvents,
+  ListenEvents extends EventsMap,
+  EmitEvents extends EventsMap,
+  ServerSideEvents extends EventsMap,
   SocketData
 > extends NamespaceReservedEventsMap<
     ListenEvents,


### PR DESCRIPTION
Fixes a build break in 4.8 caused by a bug fixed on the TS side; see https://github.com/microsoft/TypeScript/issues/49489