### PR TITLE
Add timeout method to remote socket

### DIFF
--- a/lib/broadcast-operator.ts
+++ b/lib/broadcast-operator.ts
@@ -435,7 +435,7 @@ export class RemoteSocket<EmitEvents extends EventsMap, SocketData>
   public readonly rooms: Set<Room>;
   public readonly data: SocketData;
 
-  private readonly operator: BroadcastOperator<EmitEvents, SocketData>;
+  private operator: BroadcastOperator<EmitEvents, SocketData>;
 
   constructor(adapter: Adapter, details: SocketDetails<SocketData>) {
     this.id = details.id;
@@ -446,6 +446,25 @@ export class RemoteSocket<EmitEvents extends EventsMap, SocketData>
       adapter,
       new Set([this.id])
     );
+  }
+
+  /**
+   * Adds a timeout in milliseconds for the next operation.
+   *
+   * @example
+   * socket.timeout(1000).emit("some-event", (err, responses) => {
+   *   if (err) {
+   *     // some clients did not acknowledge the event in the given delay
+   *   } else {
+   *     console.log(responses); // one response per client
+   *   }
+   * });
+   *
+   * @param timeout
+   */
+  public timeout(timeout: number) {
+    this.operator = this.operator.timeout(timeout);
+    return this;
   }
 
   public emit<Ev extends EventNames<EmitEvents>>(


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
The RemoteSocket does currently not expose a timeout method. With that I encountered problems when emitting events by using a remote socket that I fetched from another instance by using the redis adapter. 

When I emit a message like this: 

```typescript
remoteSocketFromServer2.emit('send', { key: 'value' }, (err, res) => {
    if (err) {
        ...
    } else {
        ...
    }
});
```

then the client receives the emitted message but the callback of the sender is invoked immediately with a timeout error. Reason for that is that the flags.timeout of the BroadcastOperator is not set when emitting the message. 

<img width="681" alt="image" src="https://user-images.githubusercontent.com/5354675/207900044-eec50d72-67fe-4dc1-a6a7-18b254e30a41.png">


### New behavior
Exposes a timeout method that can be called on the RemoteSocket to set a timeout. 

### Other information (e.g. related issues)

I encountered this problem by using the following dependencies:

```json
{
    "socket.io": "^4.5.4",
    "socket.io-client": "^4.5.4",
    "@socket.io/redis-adapter": "^8.0.0",
}
```

The following piece of code can be used to reproduce the issue: 

```typescript
import Redis from 'ioredis';
import { createAdapter } from '@socket.io/redis-adapter';

import { Server } from 'socket.io';

import { io as ioClient } from 'socket.io-client';

describe('Redis socket io store System Test', () => {
    let io1: Server;
    let io2: Server;

    beforeAll(async () => {
        io1 = new Server();
        io1.listen(5001);
        setupRedisAdapterForServer(io1);

        io2 = new Server();
        io2.listen(5002);
        setupRedisAdapterForServer(io2);
    });

    function setupRedisAdapterForServer(io: Server) {
        const pubClient = new Redis({
            port: 6379, // Redis port
            host: '127.0.0.1', // Redis host
            username: 'default', // Not used
            password: 'my-top-secret', // Not Used
            db: 0 // Defaults to 0
        });

        const subClient = pubClient.duplicate();
        io.adapter(createAdapter(pubClient, subClient, { requestsTimeout: 5000 }));
    }

    it('scenario', async () => {
        const socket2 = await connectSocket(5002);

        socket2.on('send', (msg, ack) => {
            ack('OK');
        });

        const socketsFromServer2 = await io1.in(socket2.id).fetchSockets();
        const socketFromServer2 = socketsFromServer2[0];

        let result;
        socketFromServer2.emit('send', { key: 'value' }, (err, res) => {
            if (err) {
                result = err;
            } else {
                result = res[0];
            }
        });

        while (!result) {
            await delay(250);
        }

        expect(result).toBe('OK');
    });
});

const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));

async function connectSocket(port) {
    const socket = ioClient('http://localhost:' + port, {
        transports: ['websocket']
    });

    const promise = new Promise((resolve, reject) => {
        socket.on('connect', () => {
            resolve('success');
        });
        socket.on('connect_error', (err) => {
            reject(err);
        });
    });

    await promise;

    return socket;
}

```

