### PR TITLE
docs: add rust-socketio implementation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,6 +21,7 @@ Some implementations in other languages are also available:
 - [Dart](https://github.com/rikulo/socket.io-client-dart)
 - [Python](https://github.com/miguelgrinberg/python-socketio)
 - [.NET](https://github.com/doghappy/socket.io-client-csharp)
+- [Rust](https://github.com/1c3t3a/rust-socketio)
 
 Its main features are:
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

This adds the [rust-socketio](https://github.com/1c3t3a/rust-socketio) implementation to the list of socket.io implementations.

