### PR TITLE
Update docker-compose.yml

### DIFF
--- a/examples/cluster-nginx/docker-compose.yml
+++ b/examples/cluster-nginx/docker-compose.yml
@@ -1,58 +1,43 @@
+services:
+  nginx:
+    image: nginx:alpine
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    ports:
+    - "3000:80"
 
-nginx:
-  image: nginx:alpine
-  volumes:
-    - ./nginx.conf:/etc/nginx/nginx.conf:ro
-  links:
-    - server-john
-    - server-paul
-    - server-george
-    - server-ringo
-  ports:
-   - "3000:80"
-
-server-john:
-  build: ./server
-  links:
-    - redis
-  expose:
+  server-john:
+    build: ./server
+    expose:
     - "3000"
-  environment:
-    - NAME=John
+    environment:
+      - NAME=John
 
-server-paul:
-  build: ./server
-  links:
-    - redis
-  expose:
-    - "3000"
-  environment:
-    - NAME=Paul
+  server-paul:
+    build: ./server
+    expose:
+      - "3000"
+    environment:
+      - NAME=Paul
 
-server-george:
-  build: ./server
-  links:
-    - redis
-  expose:
-    - "3000"
-  environment:
-    - NAME=George
+  server-george:
+    build: ./server
+    expose:
+      - "3000"
+    environment:
+      - NAME=George
 
-server-ringo:
-  build: ./server
-  links:
-    - redis
-  expose:
-    - "3000"
-  environment:
-    - NAME=Ringo
+  server-ringo:
+    build: ./server
+    expose:
+      - "3000"
+    environment:
+      - NAME=Ringo
 
-client:
-  build: ./client
-  links:
-    - nginx
+  client:
+    build: ./client
 
-redis:
-  image: redis:alpine
-  expose:
-    - "6379"
+  redis:
+    image: redis:alpine
+    expose:
+      - "6379"


### PR DESCRIPTION
Updated docker compose to be in line with current practices. Added `services` and indented all services under it. Also removed `links` as that is intrinsic.

The previous docker compose file did not work with newer versions of docker compose, giving `(root) Additional property server-john is not allowed` since `services` should be the only root property. Marking it as a bug fix.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior


### New behavior


### Other information (e.g. related issues)


