### PR TITLE
Add cleanupEmptyChildNamespaces server option

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -96,6 +96,11 @@ interface ServerOptions extends EngineOptions, AttachOptions {
      */
     skipMiddlewares?: boolean;
   };
+  /**
+   * whether or not to remove child namespaces that have no sockets connected to them
+   * @default false
+   */
+  cleanupEmptyChildNamespaces: boolean;
 }
 
 /**
@@ -153,6 +158,7 @@ export class Server<
    *
    */
   public engine: BaseServer;
+  public readonly cleanupEmptyChildNamespaces: boolean;
 
   /** @private */
   readonly _parser: typeof parser;
@@ -226,6 +232,7 @@ export class Server<
     this.path(opts.path || "/socket.io");
     this.connectTimeout(opts.connectTimeout || 45000);
     this.serveClient(false !== opts.serveClient);
+    this.cleanupEmptyChildNamespaces = !!opts.cleanupEmptyChildNamespaces;
     this._parser = opts.parser || parser;
     this.encoder = new this._parser.Encoder();
     this.opts = opts;

--- a/lib/parent-namespace.ts
+++ b/lib/parent-namespace.ts
@@ -52,7 +52,11 @@ export class ParentNamespace<
   createChild(
     name: string
   ): Namespace<ListenEvents, EmitEvents, ServerSideEvents, SocketData> {
-    const namespace = new Namespace(this.server, name);
+    const namespace = new Namespace(this.server, name, (nsp: Namespace) => {
+      nsp.adapter.close();
+      this.server._nsps.delete(nsp.name);
+      this.children.delete(nsp);
+    });
     namespace._fns = this._fns.slice(0);
     this.listeners("connect").forEach((listener) =>
       namespace.on("connect", listener)

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -713,6 +713,7 @@ export class Socket<
     this.client._remove(this);
     this.connected = false;
     this.emitReserved("disconnect", reason);
+    this.nsp.cleanupEmptyNamespace();
     return;
   }
 


### PR DESCRIPTION
- When a socket disconnects from a child namespace (those created by a ParentNamespace), if this option is enabled and there are no other sockets connected, it will call nsp.adapter.close() and remove the namespace.
- The namespace can be connected to later (it will be recreated)
- Added some tests to cover the new code changes


### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [x] a code change that improves performance
* [ ] other

### Current behavior
Currently, child namespaces (those created by a `ParentNamespace`, maybe dynamic namespace is the correct term?) exist forever while the server is running. This can cause issues with certain adapters (like redis) where it continues to subscribe and never unsubscribes, as pointed out in [this  issue](https://github.com/socketio/socket.io-redis-adapter/issues/480).

### New behavior
This PR adds a new server option, `cleanupEmptyChildNamespaces`. With this option enabled, when a client socket disconnects, if there are no other sockets connected  to the namespace, the following with occur:

- Call `nsp.adapter.close()`
- Remove the namespace from the servers internal namespace list (`_nsps`)
- Remove the namespace from it's parent list (`ParentNamespace.children`)

Calling `adapter.close()` will allow the adapters to clean up any subscriptions. 

Removing the namespace from `_nsps` is necessary, otherwise the adapters won't re-subscribe when the namespace is connected to again. 

Removing the namespace from the `ParentNamespace.children` is to prevent memory leaks, since the old namespace is no longer used.

### Other information (e.g. related issues)
One thing I'm unsure of is how this will affect the other adapters. I only use the redis adapter, which doesn't implement close yet (I will be creating a new PR to implement it). I don't know if calling close on the other adapters would have some bad side effects.