### PR TITLE
feat: add details to the disconnecting and disconnect events

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -311,9 +311,10 @@ export class Client<
    * Called upon transport close.
    *
    * @param reason
+   * @param description
    * @private
    */
-  private onclose(reason: CloseReason | "forced server close"): void {
+  private onclose(reason: CloseReason | "forced server close", description?: any): void {
     debug("client close with reason %s", reason);
 
     // ignore a potential subsequent `close` event
@@ -321,7 +322,7 @@ export class Client<
 
     // `nsps` and `sockets` are cleaned up seamlessly
     for (const socket of this.sockets.values()) {
-      socket._onclose(reason);
+      socket._onclose(reason, description);
     }
     this.sockets.clear();
 

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -56,8 +56,8 @@ const RECOVERABLE_DISCONNECT_REASONS: ReadonlySet<DisconnectReason> = new Set([
 ]);
 
 export interface SocketReservedEventsMap {
-  disconnect: (reason: DisconnectReason) => void;
-  disconnecting: (reason: DisconnectReason) => void;
+  disconnect: (reason: DisconnectReason, description?: any) => void;
+  disconnecting: (reason: DisconnectReason, description?: any) => void;
   error: (err: Error) => void;
 }
 
@@ -732,14 +732,15 @@ export class Socket<
    * Called upon closing. Called by `Client`.
    *
    * @param {String} reason
+   * @param description
    * @throw {Error} optional error object
    *
    * @private
    */
-  _onclose(reason: DisconnectReason): this | undefined {
+  _onclose(reason: DisconnectReason, description?: any): this | undefined {
     if (!this.connected) return this;
     debug("closing socket - reason %s", reason);
-    this.emitReserved("disconnecting", reason);
+    this.emitReserved("disconnecting", reason, description);
 
     if (RECOVERABLE_DISCONNECT_REASONS.has(reason)) {
       debug("connection state recovery is enabled for sid %s", this.id);
@@ -755,7 +756,7 @@ export class Socket<
     this.nsp._remove(this);
     this.client._remove(this);
     this.connected = false;
-    this.emitReserved("disconnect", reason);
+    this.emitReserved("disconnect", reason, description);
     return;
   }
 


### PR DESCRIPTION
### The kind of change this PR does introduce
* [X] a new feature

### New behavior
The "disconnecting" and "disconnect" events will now include additional details to help debugging if anything has gone wrong.
The goal is to mirror this change made to the client : https://github.com/socketio/socket.io-client/commit/b862924b7f1720979e5db2f0154906b305d420e3
