### PR TITLE
fix NodeNext module resolution compatibility

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -41,7 +41,7 @@ import {
   SecondArg,
 } from "./typed-events";
 import { patchAdapter, restoreAdapter, serveFile } from "./uws";
-import type { BaseServer } from "engine.io/build/server";
+import type { BaseServer } from "engine.io";
 
 const debug = debugModule("socket.io:server");
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

Types are not found when typescript moduleResolution is set to NodeNext, issue #4621

### New behavior

Works normally with NodeNext

### Other information (e.g. related issues)

Must be merged together with the engine.io PR https://github.com/socketio/engine.io/pull/669
