### PR TITLE
fix(client): auth init error

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -115,6 +115,8 @@ export class Client<
    * @private
    */
   private connect(name: string, auth: Record<string, unknown> = {}): void {
+    auth === null && (auth = {});
+    
     if (this.server._nsps.has(name)) {
       debug("connecting to namespace %s", name);
       return this.doConnect(name, auth);


### PR DESCRIPTION
Parser maybe parse `undefined` value to `null`, like [msgpackr](https://github.com/kriszyp/msgpackr#readme)'s `encodeUndefinedAsNil` option.


### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
Throw error.

### New behavior
Work fine.

### Other information (e.g. related issues)


