### PR TITLE
fix: move `types` condition to the front

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "type": "commonjs",
   "main": "./dist/index.js",
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./wrapper.mjs",
-    "require": "./dist/index.js",
-    "types": "./dist/index.d.ts"
+    "require": "./dist/index.js"
   },
   "types": "./dist/index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

I moved `types` condition to the front. `package.json#exports` are **order-sensitive** - they are always matched from the top to the bottom. When a match is found then it should be used and no further matching should occur. 

Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.