### PR TITLE
docs: fix missing types in basic CRUD example

### DIFF
--- a/examples/basic-crud-application/angular-client/tsconfig.app.json
+++ b/examples/basic-crud-application/angular-client/tsconfig.app.json
@@ -3,7 +3,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/app",
-    "types": []
+    "types": [
+      "node"
+    ]
   },
   "files": [
     "src/main.ts",

--- a/examples/basic-crud-application/server/package.json
+++ b/examples/basic-crud-application/server/package.json
@@ -26,7 +26,6 @@
   "devDependencies": {
     "@types/chai": "^4.2.16",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^18.16.3",
     "@types/uuid": "^8.3.0",
     "chai": "^4.3.4",
     "mocha": "^10.0.0",

--- a/examples/basic-crud-application/server/package.json
+++ b/examples/basic-crud-application/server/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@types/chai": "^4.2.16",
     "@types/mocha": "^10.0.0",
+    "@types/node": "^18.16.3",
     "@types/uuid": "^8.3.0",
     "chai": "^4.3.4",
     "mocha": "^10.0.0",


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
I tried pulling the latest version of the [Basic CRUD application with Socket.IO](https://github.com/socketio/socket.io/tree/main/examples/basic-crud-application) and after installing the dependencies and starting both the client and the server apps, I got this error on the client side:
```
error TS2591: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i @types/node` and then add `node` to the types field in your tsconfig.
```
<img height=300 width=650 src="https://user-images.githubusercontent.com/56412800/235356442-8388aef6-5917-4c0a-a573-52c1ee3ad58d.png" />


### New behavior
- ~installed `@types/node` as devDependency in the `server` directory.~
- updated `angular-client/tsconfig.app.json` with 
```js
"types": [ "node"]
``` 
PS: the code worked on me without installing `@types/node` dep, however I thought it would be recommended to install it anyway. 
### Other information (e.g. related issues)
none
