### PR TITLE
Update socket.ts: Change the socket.data type from Partial<SocketData…

### DIFF
--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -202,7 +202,7 @@ export class Socket<
    * Additional information that can be attached to the Socket instance and which will be used in the
    * {@link Server.fetchSockets()} method.
    */
-  public data: SocketData = {};
+  public data: SocketData = {} as SocketData;
   /**
    * Whether the socket is currently connected or not.
    *

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -202,7 +202,7 @@ export class Socket<
    * Additional information that can be attached to the Socket instance and which will be used in the
    * {@link Server.fetchSockets()} method.
    */
-  public data: Partial<SocketData> = {};
+  public data: SocketData = {};
   /**
    * Whether the socket is currently connected or not.
    *
@@ -260,7 +260,7 @@ export class Socket<
       this.id = previousSession.sid;
       this.pid = previousSession.pid;
       previousSession.rooms.forEach((room) => this.join(room));
-      this.data = previousSession.data as Partial<SocketData>;
+      this.data = previousSession.data as SocketData;
       previousSession.missedPackets.forEach((packet) => {
         this.packet({
           type: PacketType.EVENT,


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behavior
The type of socket.data is Partial<SocketData>. If I am passing SocketData type as {id: number, name: string}, then as I read socket.data.name I would have to use non-null assertions even though my own type implies that id would always be defined.

### New behavior
Now, if someone wants to specify that a few or all of their properties might not be available at runtime, they can do so by specifying that in their own type.


### Other information (e.g. related issues)
See [issue 4537](https://github.com/socketio/socket.io/issues/4537)


