### PR TITLE
Use own interface for Socket request to allow extending the request interface independently of Express.

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1136,4 +1136,4 @@ export {
   BroadcastOperator,
   RemoteSocket,
 };
-export { Event } from "./socket";
+export { Event, SocketRequest } from "./socket";

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -87,6 +87,8 @@ export const RESERVED_EVENTS: ReadonlySet<string | Symbol> = new Set<
   "removeListener",
 ]);
 
+export interface SocketRequest extends IncomingMessage {}
+
 /**
  * The handshake details
  */
@@ -990,7 +992,7 @@ export class Socket<
   /**
    * A reference to the request that originated the underlying Engine.IO Socket.
    */
-  public get request(): IncomingMessage {
+  public get request(): SocketRequest {
     return this.client.request;
   }
 


### PR DESCRIPTION
Use own interface for Socket request to allow extending the request interface with custom properties without polluting the IncomingMessage type which is also used by Express/Passport.

Using socket.io with passport middlewares causes issues when using the same 'userProperty' key is used for both - for example by extending `IncomingMessage { user: Express.User }` we break passport's `isAuthenticated()` function, because now typescript thinks that the request is always of the type `AuthenticatedRequest` as `IncomingMessage` always has a user property on itself. To fix this, I believe we should be able to extend only the request type inside socket.io -> SocketRequest.


### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other - Type change


