### PR TITLE
improve emit types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "typescript.tsdk": "node_modules/typescript/lib"
-}

--- a/lib/broadcast-operator.ts
+++ b/lib/broadcast-operator.ts
@@ -516,11 +516,10 @@ export class RemoteSocket<EmitEvents extends EventsMap, SocketData>
    *
    * @param timeout
    */
-  public timeout(timeout: number) {
-    return this.operator.timeout(timeout) as BroadcastOperator<
-      DecorateAcknowledgements<EmitEvents>,
-      SocketData
-    >;
+  public timeout(
+    timeout: number
+  ): BroadcastOperator<DecorateAcknowledgements<EmitEvents>, SocketData> {
+    return this.operator.timeout(timeout);
   }
 
   public emit<Ev extends EventNames<EmitEvents>>(

--- a/lib/broadcast-operator.ts
+++ b/lib/broadcast-operator.ts
@@ -8,10 +8,9 @@ import type {
   EventsMap,
   TypedEventBroadcaster,
   DecorateAcknowledgements,
-  DecorateAcknowledgementsWithTimeoutAndMultipleResponses,
   AllButLast,
   Last,
-  SecondArg,
+  FirstNonErrorArg,
 } from "./typed-events";
 
 export class BroadcastOperator<EmitEvents extends EventsMap, SocketData>
@@ -177,7 +176,7 @@ export class BroadcastOperator<EmitEvents extends EventsMap, SocketData>
   public timeout(timeout: number) {
     const flags = Object.assign({}, this.flags, { timeout });
     return new BroadcastOperator<
-      DecorateAcknowledgementsWithTimeoutAndMultipleResponses<EmitEvents>,
+      DecorateAcknowledgements<EmitEvents>,
       SocketData
     >(this.adapter, this.rooms, this.exceptRooms, flags);
   }
@@ -303,7 +302,7 @@ export class BroadcastOperator<EmitEvents extends EventsMap, SocketData>
   public emitWithAck<Ev extends EventNames<EmitEvents>>(
     ev: Ev,
     ...args: AllButLast<EventParams<EmitEvents, Ev>>
-  ): Promise<SecondArg<Last<EventParams<EmitEvents, Ev>>>> {
+  ): Promise<FirstNonErrorArg<Last<EventParams<EmitEvents, Ev>>>> {
     return new Promise((resolve, reject) => {
       args.push((err, responses) => {
         if (err) {

--- a/lib/broadcast-operator.ts
+++ b/lib/broadcast-operator.ts
@@ -11,6 +11,7 @@ import type {
   AllButLast,
   Last,
   FirstNonErrorArg,
+  EventNamesWithError,
 } from "./typed-events";
 
 export class BroadcastOperator<EmitEvents extends EventsMap, SocketData>
@@ -299,7 +300,7 @@ export class BroadcastOperator<EmitEvents extends EventsMap, SocketData>
    *
    * @return a Promise that will be fulfilled when all clients have acknowledged the event
    */
-  public emitWithAck<Ev extends EventNames<EmitEvents>>(
+  public emitWithAck<Ev extends EventNamesWithError<EmitEvents>>(
     ev: Ev,
     ...args: AllButLast<EventParams<EmitEvents, Ev>>
   ): Promise<FirstNonErrorArg<Last<EventParams<EmitEvents, Ev>>>> {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -39,7 +39,6 @@ import {
   RemoveAcknowledgements,
   EventNamesWithAck,
   FirstNonErrorArg,
-  DecorateAcknowledgementsWithMultipleResponses,
 } from "./typed-events";
 import { patchAdapter, restoreAdapter, serveFile } from "./uws";
 import corsMiddleware from "cors";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -37,9 +37,6 @@ import {
   AllButLast,
   Last,
   FirstArg,
-  FirstNonErrorArg,
-  DecorateAcknowledgementsWithMultipleResponses,
-  DecorateAcknowledgements,
   RemoveAcknowledgements,
 } from "./typed-events";
 import { patchAdapter, restoreAdapter, serveFile } from "./uws";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -37,7 +37,9 @@ import {
   AllButLast,
   Last,
   FirstArg,
-  SecondArg,
+  FirstNonErrorArg,
+  DecorateAcknowledgementsWithMultipleResponses,
+  DecorateAcknowledgements,
 } from "./typed-events";
 import { patchAdapter, restoreAdapter, serveFile } from "./uws";
 import corsMiddleware from "cors";
@@ -140,7 +142,7 @@ export class Server<
   SocketData = any
 > extends StrictEventEmitter<
   ServerSideEvents,
-  EmitEvents,
+  DecorateAcknowledgementsWithMultipleResponses<EmitEvents>,
   ServerReservedEventsMap<
     ListenEvents,
     EmitEvents,
@@ -862,7 +864,7 @@ export class Server<
   public emitWithAck<Ev extends EventNames<EmitEvents>>(
     ev: Ev,
     ...args: AllButLast<EventParams<EmitEvents, Ev>>
-  ): Promise<SecondArg<Last<EventParams<EmitEvents, Ev>>>> {
+  ): Promise<FirstNonErrorArg<Last<EventParams<EmitEvents, Ev>>>[]> {
     return this.sockets.emitWithAck(ev, ...args);
   }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -40,6 +40,7 @@ import {
   FirstNonErrorArg,
   DecorateAcknowledgementsWithMultipleResponses,
   DecorateAcknowledgements,
+  RemoveAcknowledgements,
 } from "./typed-events";
 import { patchAdapter, restoreAdapter, serveFile } from "./uws";
 import corsMiddleware from "cors";
@@ -142,7 +143,7 @@ export class Server<
   SocketData = any
 > extends StrictEventEmitter<
   ServerSideEvents,
-  DecorateAcknowledgementsWithMultipleResponses<EmitEvents>,
+  RemoveAcknowledgements<EmitEvents>,
   ServerReservedEventsMap<
     ListenEvents,
     EmitEvents,
@@ -846,26 +847,6 @@ export class Server<
    */
   public except(room: Room | Room[]) {
     return this.sockets.except(room);
-  }
-
-  /**
-   * Emits an event and waits for an acknowledgement from all clients.
-   *
-   * @example
-   * try {
-   *   const responses = await io.timeout(1000).emitWithAck("some-event");
-   *   console.log(responses); // one response per client
-   * } catch (e) {
-   *   // some clients did not acknowledge the event in the given delay
-   * }
-   *
-   * @return a Promise that will be fulfilled when all clients have acknowledged the event
-   */
-  public emitWithAck<Ev extends EventNames<EmitEvents>>(
-    ev: Ev,
-    ...args: AllButLast<EventParams<EmitEvents, Ev>>
-  ): Promise<FirstNonErrorArg<Last<EventParams<EmitEvents, Ev>>>[]> {
-    return this.sockets.emitWithAck(ev, ...args);
   }
 
   /**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -36,8 +36,10 @@ import {
   DecorateAcknowledgementsWithTimeoutAndMultipleResponses,
   AllButLast,
   Last,
-  FirstArg,
   RemoveAcknowledgements,
+  EventNamesWithAck,
+  FirstNonErrorArg,
+  DecorateAcknowledgementsWithMultipleResponses,
 } from "./typed-events";
 import { patchAdapter, restoreAdapter, serveFile } from "./uws";
 import corsMiddleware from "cors";
@@ -928,10 +930,10 @@ export class Server<
    *
    * @return a Promise that will be fulfilled when all servers have acknowledged the event
    */
-  public serverSideEmitWithAck<Ev extends EventNames<ServerSideEvents>>(
+  public serverSideEmitWithAck<Ev extends EventNamesWithAck<ServerSideEvents>>(
     ev: Ev,
     ...args: AllButLast<EventParams<ServerSideEvents, Ev>>
-  ): Promise<FirstArg<Last<EventParams<ServerSideEvents, Ev>>>[]> {
+  ): Promise<FirstNonErrorArg<Last<EventParams<ServerSideEvents, Ev>>>[]> {
     return this.sockets.serverSideEmitWithAck(ev, ...args);
   }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -863,7 +863,9 @@ export class Server<
    * @return self
    */
   public send(...args: EventParams<EmitEvents, "message">): this {
-    this.sockets.emit("message", ...args);
+    // This type-cast is needed because EmitEvents likely doesn't have `message` as a key.
+    // if you specify the EmitEvents, the type of args will be never.
+    this.sockets.emit("message" as any, ...args);
     return this;
   }
 
@@ -873,7 +875,9 @@ export class Server<
    * @return self
    */
   public write(...args: EventParams<EmitEvents, "message">): this {
-    this.sockets.emit("message", ...args);
+    // This type-cast is needed because EmitEvents likely doesn't have `message` as a key.
+    // if you specify the EmitEvents, the type of args will be never.
+    this.sockets.emit("message" as any, ...args);
     return this;
   }
 

--- a/lib/namespace.ts
+++ b/lib/namespace.ts
@@ -13,6 +13,7 @@ import {
   DecorateAcknowledgementsWithMultipleResponses,
   FirstNonErrorArg,
   DecorateAcknowledgements,
+  RemoveAcknowledgements,
 } from "./typed-events";
 import type { Client } from "./client";
 import debugModule from "debug";
@@ -119,7 +120,7 @@ export class Namespace<
   SocketData = any
 > extends StrictEventEmitter<
   ServerSideEvents,
-  EmitEvents,
+  RemoveAcknowledgements<EmitEvents>,
   NamespaceReservedEventsMap<
     ListenEvents,
     EmitEvents,
@@ -441,37 +442,12 @@ export class Namespace<
    */
   public emit<Ev extends EventNames<EmitEvents>>(
     ev: Ev,
-    ...args: EventParams<EmitEvents, Ev>
+    ...args: EventParams<RemoveAcknowledgements<EmitEvents>, Ev>
   ): boolean {
     return new BroadcastOperator<EmitEvents, SocketData>(this.adapter).emit(
       ev,
       ...args
     );
-  }
-
-  /**
-   * Emits an event and waits for an acknowledgement from all clients.
-   *
-   * @example
-   * const myNamespace = io.of("/my-namespace");
-   *
-   * try {
-   *   const responses = await myNamespace.timeout(1000).emitWithAck("some-event");
-   *   console.log(responses); // one response per client
-   * } catch (e) {
-   *   // some clients did not acknowledge the event in the given delay
-   * }
-   *
-   * @return a Promise that will be fulfilled when all clients have acknowledged the event
-   */
-  public emitWithAck<Ev extends EventNames<EmitEvents>>(
-    ev: Ev,
-    ...args: AllButLast<EventParams<EmitEvents, Ev>>
-  ): Promise<FirstNonErrorArg<Last<EventParams<EmitEvents, Ev>>>[]> {
-    return new BroadcastOperator<
-      DecorateAcknowledgementsWithMultipleResponses<EmitEvents>,
-      SocketData
-    >(this.adapter).emitWithAck(ev, ...args);
   }
 
   /**

--- a/lib/namespace.ts
+++ b/lib/namespace.ts
@@ -11,7 +11,6 @@ import {
   Last,
   FirstArg,
   DecorateAcknowledgementsWithMultipleResponses,
-  FirstNonErrorArg,
   DecorateAcknowledgements,
   RemoveAcknowledgements,
 } from "./typed-events";

--- a/lib/namespace.ts
+++ b/lib/namespace.ts
@@ -10,7 +10,9 @@ import {
   AllButLast,
   Last,
   FirstArg,
-  SecondArg,
+  DecorateAcknowledgementsWithMultipleResponses,
+  FirstNonErrorArg,
+  DecorateAcknowledgements,
 } from "./typed-events";
 import type { Client } from "./client";
 import debugModule from "debug";
@@ -252,7 +254,10 @@ export class Namespace<
    * @return a new {@link BroadcastOperator} instance for chaining
    */
   public to(room: Room | Room[]) {
-    return new BroadcastOperator<EmitEvents, SocketData>(this.adapter).to(room);
+    return new BroadcastOperator<
+      DecorateAcknowledgementsWithMultipleResponses<EmitEvents>,
+      SocketData
+    >(this.adapter).to(room);
   }
 
   /**
@@ -268,7 +273,10 @@ export class Namespace<
    * @return a new {@link BroadcastOperator} instance for chaining
    */
   public in(room: Room | Room[]) {
-    return new BroadcastOperator<EmitEvents, SocketData>(this.adapter).in(room);
+    return new BroadcastOperator<
+      DecorateAcknowledgementsWithMultipleResponses<EmitEvents>,
+      SocketData
+    >(this.adapter).in(room);
   }
 
   /**
@@ -290,9 +298,10 @@ export class Namespace<
    * @return a new {@link BroadcastOperator} instance for chaining
    */
   public except(room: Room | Room[]) {
-    return new BroadcastOperator<EmitEvents, SocketData>(this.adapter).except(
-      room
-    );
+    return new BroadcastOperator<
+      DecorateAcknowledgementsWithMultipleResponses<EmitEvents>,
+      SocketData
+    >(this.adapter).except(room);
   }
 
   /**
@@ -458,10 +467,11 @@ export class Namespace<
   public emitWithAck<Ev extends EventNames<EmitEvents>>(
     ev: Ev,
     ...args: AllButLast<EventParams<EmitEvents, Ev>>
-  ): Promise<SecondArg<Last<EventParams<EmitEvents, Ev>>>> {
-    return new BroadcastOperator<EmitEvents, SocketData>(
-      this.adapter
-    ).emitWithAck(ev, ...args);
+  ): Promise<FirstNonErrorArg<Last<EventParams<EmitEvents, Ev>>>[]> {
+    return new BroadcastOperator<
+      DecorateAcknowledgementsWithMultipleResponses<EmitEvents>,
+      SocketData
+    >(this.adapter).emitWithAck(ev, ...args);
   }
 
   /**
@@ -612,9 +622,10 @@ export class Namespace<
    * @return self
    */
   public compress(compress: boolean) {
-    return new BroadcastOperator<EmitEvents, SocketData>(this.adapter).compress(
-      compress
-    );
+    return new BroadcastOperator<
+      DecorateAcknowledgementsWithMultipleResponses<EmitEvents>,
+      SocketData
+    >(this.adapter).compress(compress);
   }
 
   /**
@@ -630,7 +641,10 @@ export class Namespace<
    * @return self
    */
   public get volatile() {
-    return new BroadcastOperator<EmitEvents, SocketData>(this.adapter).volatile;
+    return new BroadcastOperator<
+      DecorateAcknowledgementsWithMultipleResponses<EmitEvents>,
+      SocketData
+    >(this.adapter).volatile;
   }
 
   /**
@@ -645,7 +659,10 @@ export class Namespace<
    * @return a new {@link BroadcastOperator} instance for chaining
    */
   public get local() {
-    return new BroadcastOperator<EmitEvents, SocketData>(this.adapter).local;
+    return new BroadcastOperator<
+      DecorateAcknowledgementsWithMultipleResponses<EmitEvents>,
+      SocketData
+    >(this.adapter).local;
   }
 
   /**
@@ -664,10 +681,18 @@ export class Namespace<
    *
    * @param timeout
    */
-  public timeout(timeout: number) {
-    return new BroadcastOperator<EmitEvents, SocketData>(this.adapter).timeout(
-      timeout
-    );
+  public timeout(
+    timeout: number
+  ): BroadcastOperator<
+    DecorateAcknowledgements<
+      DecorateAcknowledgementsWithMultipleResponses<EmitEvents>
+    >,
+    SocketData
+  > {
+    return new BroadcastOperator<
+      DecorateAcknowledgementsWithMultipleResponses<EmitEvents>,
+      SocketData
+    >(this.adapter).timeout(timeout);
   }
 
   /**

--- a/lib/namespace.ts
+++ b/lib/namespace.ts
@@ -14,6 +14,7 @@ import {
   RemoveAcknowledgements,
   EventNamesWithAck,
   FirstNonErrorArg,
+  EventNamesWithoutAck,
 } from "./typed-events";
 import type { Client } from "./client";
 import debugModule from "debug";
@@ -440,9 +441,9 @@ export class Namespace<
    *
    * @return Always true
    */
-  public emit<Ev extends EventNames<EmitEvents>>(
+  public emit<Ev extends EventNamesWithoutAck<EmitEvents>>(
     ev: Ev,
-    ...args: EventParams<RemoveAcknowledgements<EmitEvents>, Ev>
+    ...args: EventParams<EmitEvents, Ev>
   ): boolean {
     return new BroadcastOperator<EmitEvents, SocketData>(this.adapter).emit(
       ev,
@@ -468,7 +469,9 @@ export class Namespace<
    * @return self
    */
   public send(...args: EventParams<EmitEvents, "message">): this {
-    this.emit("message", ...args);
+    // This type-cast is needed because EmitEvents likely doesn't have `message` as a key.
+    // if you specify the EmitEvents, the type of args will be never.
+    this.emit("message" as any, ...args);
     return this;
   }
 
@@ -478,7 +481,9 @@ export class Namespace<
    * @return self
    */
   public write(...args: EventParams<EmitEvents, "message">): this {
-    this.emit("message", ...args);
+    // This type-cast is needed because EmitEvents likely doesn't have `message` as a key.
+    // if you specify the EmitEvents, the type of args will be never.
+    this.emit("message" as any, ...args);
     return this;
   }
 

--- a/lib/namespace.ts
+++ b/lib/namespace.ts
@@ -9,10 +9,11 @@ import {
   DecorateAcknowledgementsWithTimeoutAndMultipleResponses,
   AllButLast,
   Last,
-  FirstArg,
   DecorateAcknowledgementsWithMultipleResponses,
   DecorateAcknowledgements,
   RemoveAcknowledgements,
+  EventNamesWithAck,
+  FirstNonErrorArg,
 } from "./typed-events";
 import type { Client } from "./client";
 import debugModule from "debug";
@@ -542,10 +543,10 @@ export class Namespace<
    *
    * @return a Promise that will be fulfilled when all servers have acknowledged the event
    */
-  public serverSideEmitWithAck<Ev extends EventNames<ServerSideEvents>>(
+  public serverSideEmitWithAck<Ev extends EventNamesWithAck<ServerSideEvents>>(
     ev: Ev,
     ...args: AllButLast<EventParams<ServerSideEvents, Ev>>
-  ): Promise<FirstArg<Last<EventParams<ServerSideEvents, Ev>>>[]> {
+  ): Promise<FirstNonErrorArg<Last<EventParams<ServerSideEvents, Ev>>>[]> {
     return new Promise((resolve, reject) => {
       args.push((err, responses) => {
         if (err) {

--- a/lib/parent-namespace.ts
+++ b/lib/parent-namespace.ts
@@ -2,9 +2,9 @@ import { Namespace } from "./namespace";
 import type { Server, RemoteSocket } from "./index";
 import type {
   EventParams,
-  EventNames,
   EventsMap,
   DefaultEventsMap,
+  EventNamesWithoutAck,
 } from "./typed-events";
 import type { BroadcastOptions } from "socket.io-adapter";
 import debugModule from "debug";
@@ -56,7 +56,7 @@ export class ParentNamespace<
     this.adapter = { broadcast };
   }
 
-  public emit<Ev extends EventNames<EmitEvents>>(
+  public emit<Ev extends EventNamesWithoutAck<EmitEvents>>(
     ev: Ev,
     ...args: EventParams<EmitEvents, Ev>
   ): boolean {

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -9,7 +9,7 @@ import {
   EventNames,
   EventParams,
   EventsMap,
-  FirstArg,
+  FirstNonErrorArg,
   Last,
   StrictEventEmitter,
 } from "./typed-events";
@@ -386,7 +386,7 @@ export class Socket<
   public emitWithAck<Ev extends EventNames<EmitEvents>>(
     ev: Ev,
     ...args: AllButLast<EventParams<EmitEvents, Ev>>
-  ): Promise<FirstArg<Last<EventParams<EmitEvents, Ev>>>> {
+  ): Promise<FirstNonErrorArg<Last<EventParams<EmitEvents, Ev>>>> {
     // the timeout flag is optional
     const withErr = this.flags.timeout !== undefined;
     return new Promise((resolve, reject) => {

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -7,6 +7,7 @@ import {
   DecorateAcknowledgementsWithMultipleResponses,
   DefaultEventsMap,
   EventNames,
+  EventNamesWithAck,
   EventParams,
   EventsMap,
   FirstNonErrorArg,
@@ -383,7 +384,7 @@ export class Socket<
    *
    * @return a Promise that will be fulfilled when the client acknowledges the event
    */
-  public emitWithAck<Ev extends EventNames<EmitEvents>>(
+  public emitWithAck<Ev extends EventNamesWithAck<EmitEvents>>(
     ev: Ev,
     ...args: AllButLast<EventParams<EmitEvents, Ev>>
   ): Promise<FirstNonErrorArg<Last<EventParams<EmitEvents, Ev>>>> {

--- a/lib/typed-events.ts
+++ b/lib/typed-events.ts
@@ -178,9 +178,6 @@ export abstract class StrictEventEmitter<
     >[];
   }
 }
-export type MultiplyArray<T extends unknown[]> = {
-  [K in keyof T]: T[K][];
-};
 export type FirstNonErrorTuple<T extends unknown[]> = T[0] extends Error
   ? T[1]
   : T[0];
@@ -214,9 +211,9 @@ type ExpectMultipleResponses<T extends any[]> = {
     err: Error,
     ...args: infer Params
   ) => infer Result
-    ? (err: Error, ...arg: MultiplyArray<Params>) => Result
+    ? (err: Error, ...arg: [Params[0][]]) => Result
     : T[K] extends (...args: infer Params) => infer Result
-    ? (...args: MultiplyArray<Params>) => Result
+    ? (...args: [Params[0][]]) => Result
     : T[K];
 };
 /**

--- a/lib/typed-events.ts
+++ b/lib/typed-events.ts
@@ -41,6 +41,27 @@ export type EventNamesWithAck<
     ? K
     : never
 >;
+/**
+ * Returns a union type containing all the keys of an event map that have an acknowledgement callback.
+ *
+ * That also have *some* data coming in.
+ */
+export type EventNamesWithoutAck<
+  Map extends EventsMap,
+  K extends EventNames<Map> = EventNames<Map>
+> = IfAny<
+  Last<Parameters<Map[K]>> | Map[K],
+  K,
+  K extends (
+    Last<Parameters<Map[K]>> extends (...args: any[]) => any ? never : K
+  )
+    ? K
+    : never
+>;
+
+export type RemoveAcknowledgements<E extends EventsMap> = {
+  [K in EventNamesWithoutAck<E>]: E[K];
+};
 
 export type EventNamesWithError<
   Map extends EventsMap,
@@ -336,13 +357,5 @@ export type DecorateAcknowledgementsWithTimeoutAndMultipleResponses<E> = {
 export type DecorateAcknowledgementsWithMultipleResponses<E> = {
   [K in keyof E]: E[K] extends (...args: infer Params) => infer Result
     ? (...args: ExpectMultipleResponses<Params>) => Result
-    : E[K];
-};
-
-export type RemoveAcknowledgements<E> = {
-  [K in keyof E]: E[K] extends (...args: infer Params) => infer Result
-    ? Last<Params> extends (...args: any[]) => any
-      ? (...args: AllButLast<Params>) => Result
-      : E[K]
     : E[K];
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,7 @@
         "debug": "~4.3.2",
         "engine.io": "~6.5.2",
         "socket.io-adapter": "~2.5.2",
-        "socket.io-parser": "~4.2.4",
-        "type-fest": "^3.13.1"
+        "socket.io-parser": "~4.2.4"
       },
       "devDependencies": {
         "@types/mocha": "^9.0.0",
@@ -4048,17 +4047,6 @@
         "node": ">=14.16"
       }
     },
-    "node_modules/type-fest": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -7389,11 +7377,6 @@
         "path-exists": "^4.0.0",
         "read-pkg-up": "^7.0.0"
       }
-    },
-    "type-fest": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g=="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "socket.io",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "socket.io",
-      "version": "4.7.1",
+      "version": "4.7.2",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.4",
@@ -29,7 +29,7 @@
         "superagent": "^8.0.0",
         "supertest": "^6.1.6",
         "ts-node": "^10.2.1",
-        "tsd": "^0.21.0",
+        "tsd": "^0.27.0",
         "typescript": "^4.4.2",
         "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.30.0"
       },
@@ -646,14 +646,10 @@
       "dev": true
     },
     "node_modules/@tsd/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-jbtC+RgKZ9Kk65zuRZbKLTACf+tvFW4Rfq0JEMXrlmV3P3yme+Hm+pnb5fJRyt61SjIitcrC810wj7+1tgsEmg==",
-      "dev": true,
-      "bin": {
-        "tsc": "typescript/bin/tsc",
-        "tsserver": "typescript/bin/tsserver"
-      }
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-+UgxOvJUl5rQdPFSSOOwhmSmpThm8DJ3HwHxAOq5XYe7CcmG1LcM2QeqWwILzUIT5tbeMqY8qABiCsRtIjk/2g==",
+      "dev": true
     },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
@@ -4014,12 +4010,12 @@
       }
     },
     "node_modules/tsd": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.21.0.tgz",
-      "integrity": "sha512-6DugCw1Q4H8HYwDT3itzgALjeDxN4RO3iqu7gRdC/YNVSCRSGXRGQRRasftL1uKDuKxlFffYKHv5j5G7YnKGxQ==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.27.0.tgz",
+      "integrity": "sha512-G/2Sejk9N21TcuWlHwrvVWwIyIl2mpECFPbnJvFMsFN1xQCIbi2QnvG4fkw3VitFhNF6dy38cXxKJ8Paq8kOGQ==",
       "dev": true,
       "dependencies": {
-        "@tsd/typescript": "~4.7.3",
+        "@tsd/typescript": "~4.9.5",
         "eslint-formatter-pretty": "^4.1.0",
         "globby": "^11.0.1",
         "meow": "^9.0.0",
@@ -4030,7 +4026,7 @@
         "tsd": "dist/cli.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.16"
       }
     },
     "node_modules/type-fest": {
@@ -4825,9 +4821,9 @@
       "dev": true
     },
     "@tsd/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-jbtC+RgKZ9Kk65zuRZbKLTACf+tvFW4Rfq0JEMXrlmV3P3yme+Hm+pnb5fJRyt61SjIitcrC810wj7+1tgsEmg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-+UgxOvJUl5rQdPFSSOOwhmSmpThm8DJ3HwHxAOq5XYe7CcmG1LcM2QeqWwILzUIT5tbeMqY8qABiCsRtIjk/2g==",
       "dev": true
     },
     "@types/cookie": {
@@ -7346,12 +7342,12 @@
       }
     },
     "tsd": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.21.0.tgz",
-      "integrity": "sha512-6DugCw1Q4H8HYwDT3itzgALjeDxN4RO3iqu7gRdC/YNVSCRSGXRGQRRasftL1uKDuKxlFffYKHv5j5G7YnKGxQ==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.27.0.tgz",
+      "integrity": "sha512-G/2Sejk9N21TcuWlHwrvVWwIyIl2mpECFPbnJvFMsFN1xQCIbi2QnvG4fkw3VitFhNF6dy38cXxKJ8Paq8kOGQ==",
       "dev": true,
       "requires": {
-        "@tsd/typescript": "~4.7.3",
+        "@tsd/typescript": "~4.9.5",
         "eslint-formatter-pretty": "^4.1.0",
         "globby": "^11.0.1",
         "meow": "^9.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "debug": "~4.3.2",
         "engine.io": "~6.5.2",
         "socket.io-adapter": "~2.5.2",
-        "socket.io-parser": "~4.2.4"
+        "socket.io-parser": "~4.2.4",
+        "type-fest": "^3.13.1"
       },
       "devDependencies": {
         "@types/mocha": "^9.0.0",
@@ -1873,6 +1874,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/hasha/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -3195,6 +3205,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/read-pkg/node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -4030,12 +4049,14 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true,
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typedarray-to-buffer": {
@@ -5750,6 +5771,14 @@
       "requires": {
         "is-stream": "^2.0.0",
         "type-fest": "^0.8.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
       }
     },
     "he": {
@@ -6750,6 +6779,12 @@
           "requires": {
             "p-limit": "^2.2.0"
           }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
         }
       }
     },
@@ -7356,10 +7391,9 @@
       }
     },
     "type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g=="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "debug": "~4.3.2",
     "engine.io": "~6.5.2",
     "socket.io-adapter": "~2.5.2",
-    "socket.io-parser": "~4.2.4"
+    "socket.io-parser": "~4.2.4",
+    "type-fest": "^3.13.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "superagent": "^8.0.0",
     "supertest": "^6.1.6",
     "ts-node": "^10.2.1",
-    "tsd": "^0.21.0",
+    "tsd": "^0.27.0",
     "typescript": "^4.4.2",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.30.0"
   },

--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
     "debug": "~4.3.2",
     "engine.io": "~6.5.2",
     "socket.io-adapter": "~2.5.2",
-    "socket.io-parser": "~4.2.4",
-    "type-fest": "^3.13.1"
+    "socket.io-parser": "~4.2.4"
   },
   "devDependencies": {
     "@types/mocha": "^9.0.0",

--- a/test/socket.io.test-d.ts
+++ b/test/socket.io.test-d.ts
@@ -2,7 +2,7 @@
 import { createServer } from "http";
 import { Adapter } from "socket.io-adapter";
 import { expectType } from "tsd";
-import { BroadcastOperator, Server, Socket } from "..";
+import { BroadcastOperator, Server, Socket } from "../lib/index";
 import type { DisconnectReason } from "../lib/socket";
 import type { DefaultEventsMap, EventsMap } from "../lib/typed-events";
 

--- a/test/socket.io.test-d.ts
+++ b/test/socket.io.test-d.ts
@@ -150,42 +150,19 @@ describe("server", () => {
         const sio = new Server<BidirectionalEvents, BidirectionalEvents, {}>(
           srv
         );
-        expectError(sio.on("random", (a, b, c) => {}));
+        // @ts-expect-error - shouldn't accept arguments of the wrong types
+        sio.on("random", (a, b, c) => {});
         srv.listen(() => {
-          expectError(sio.on("wrong name", (s) => {}));
+          // @ts-expect-error - shouldn't accept arguments of the wrong types
+          sio.on("wrong name", (s) => {});
           sio.on("connection", (s) => {
             s.on("random", (a, b, c) => {});
-            expectError(s.on("random"));
-            expectError(s.on("random", (a, b, c, d) => {}));
-            expectError(s.on(2, 3));
-          });
-        });
-      });
-    });
-
-    describe("emit", () => {
-      it("accepts arguments of the correct types", () => {
-        const srv = createServer();
-        const sio = new Server<BidirectionalEvents>(srv);
-        srv.listen(() => {
-          sio.on("connection", (s) => {
-            s.emit("random", 1, "2", [3]);
-          });
-        });
-      });
-
-      it("does not accept arguments of the wrong types", () => {
-        const srv = createServer();
-        const sio = new Server<BidirectionalEvents>(srv);
-        srv.listen(() => {
-          sio.on("connection", (s) => {
-            expectError(s.emit("noParameter", 2));
-            expectError(s.emit("oneParameter"));
-            expectError(s.emit("random"));
-            expectError(s.emit("oneParameter", 2, 3));
-            expectError(s.emit("random", (a, b, c) => {}));
-            expectError(s.emit("wrong name", () => {}));
-            expectError(s.emit("complicated name with spaces", 2));
+            // @ts-expect-error - shouldn't accept arguments of the wrong types
+            s.on("random");
+            // @ts-expect-error - shouldn't accept arguments of the wrong types
+            s.on("random", (a, b, c, d) => {});
+            // @ts-expect-error - shouldn't accept arguments of the wrong types
+            s.on(2, 3);
           });
         });
       });
@@ -456,10 +433,6 @@ describe("server", () => {
       });
     });
     describe("emitWithAck", () => {
-      it("works untyped", () => {
-        const untyped = new Server();
-        expectType<Promise<any>>(untyped.to("1").emitWithAck("random", "test"));
-      });
       it("Infers correct types", () => {
         const sio = new Server<ClientToServerEvents, ServerToClientEvents>();
         sio.on("connection", (s) => {
@@ -517,11 +490,10 @@ describe("server", () => {
         const sio = new Server<ClientToServerEvents, ServerToClientEvents>(srv);
         srv.listen(() => {
           sio.on("connection", (s) => {
-            expectError(
-              s.on("helloFromServer", (message, number) => {
-                done();
-              })
-            );
+            // @ts-expect-error - shouldn't accept emit events
+            s.on("helloFromServer", (message, number) => {
+              done();
+            });
           });
         });
       });
@@ -610,7 +582,8 @@ describe("server", () => {
 
     it("does not accept arguments of wrong types", () => {
       const io = new Server();
-      expectError(io.adapter((nsp) => "nope"));
+      // @ts-expect-error - shouldn't accept arguments of the wrong types
+      io.adapter((nsp) => "nope");
     });
   });
 });

--- a/test/socket.io.test-d.ts
+++ b/test/socket.io.test-d.ts
@@ -533,6 +533,9 @@ describe("server", () => {
             expectType<number>(x);
           });
 
+          //@ts-expect-error - "helloFromServerToServer" does not have a callback
+          sio.serverSideEmitWithAck("helloFromServerToServer", "hello");
+
           sio.on("ackFromServerToServer", (...args) => {
             expectType<[string, (bar: number) => void]>(args);
           });

--- a/test/socket.io.test-d.ts
+++ b/test/socket.io.test-d.ts
@@ -1,15 +1,10 @@
 "use strict";
-import { BroadcastOperator, Namespace, Server, Socket } from "..";
-import type {
-  DefaultEventsMap,
-  EventNames,
-  EventsMap,
-} from "../lib/typed-events";
 import { createServer } from "http";
-import { expectError, expectNever, expectNotAssignable, expectType } from "tsd";
 import { Adapter } from "socket.io-adapter";
+import { expectType } from "tsd";
+import { BroadcastOperator, Server, Socket } from "..";
 import type { DisconnectReason } from "../lib/socket";
-import type { Simplify } from "type-fest";
+import type { DefaultEventsMap, EventsMap } from "../lib/typed-events";
 
 // This file is run by tsd, not mocha.
 
@@ -362,12 +357,14 @@ describe("server", () => {
       it("has the correct types for `emitWithAck`", () => {
         const sio = new Server<ClientToServerEvents, ServerToClientEvents>();
         const sansTimeout = sio.in("1");
-        // Without timeout, emitWithAck shouldn't accept any events
+        // Without timeout, `emitWithAck` shouldn't accept any events
         expectType<never>(
           undefined as Parameters<typeof sansTimeout["emitWithAck"]>[0]
         );
         // @ts-expect-error - "helloFromServer" doesn't have a callback and is thus excluded
         sio.timeout(0).emitWithAck("helloFromServer");
+        // @ts-expect-error - "onlyCallback" doesn't have a callback and is thus excluded
+        sio.timeout(0).emitWithAck("onlyCallback");
         expectType<
           ToEmitWithAck<
             ServerToClientEventsWithMultipleWithAck,
@@ -380,9 +377,6 @@ describe("server", () => {
             "ackFromServer"
           >
         >(sio.timeout(0).emitWithAck<"ackFromServer">);
-        expectType<
-          ToEmitWithAck<ServerToClientEventsWithMultipleWithAck, "onlyCallback">
-        >(sio.timeout(0).emitWithAck<"onlyCallback">);
       });
     });
     describe("emit", () => {
@@ -438,15 +432,16 @@ describe("server", () => {
         sio.on("connection", (s) => {
           // @ts-expect-error - "helloFromServer" doesn't have a callback and is thus excluded
           s.emitWithAck("helloFromServer");
+          // @ts-expect-error - "onlyCallback" doesn't have a callback and is thus excluded
+          s.emitWithAck("onlyCallback");
+          // @ts-expect-error - "onlyCallback" doesn't have a callback and is thus excluded
+          s.timeout(0).emitWithAck("onlyCallback");
           expectType<
             ToEmitWithAck<ServerToClientEventsWithAck, "ackFromServerSingleArg">
           >(s.emitWithAck<"ackFromServerSingleArg">);
           expectType<
             ToEmitWithAck<ServerToClientEventsWithAck, "ackFromServer">
           >(s.emitWithAck<"ackFromServer">);
-          expectType<
-            ToEmitWithAck<ServerToClientEventsWithAck, "onlyCallback">
-          >(s.emitWithAck<"onlyCallback">);
 
           expectType<
             ToEmitWithAck<ServerToClientEventsWithAck, "ackFromServerSingleArg">
@@ -454,9 +449,6 @@ describe("server", () => {
           expectType<
             ToEmitWithAck<ServerToClientEventsWithAck, "ackFromServer">
           >(s.timeout(0).emitWithAck<"ackFromServer">);
-          expectType<
-            ToEmitWithAck<ServerToClientEventsWithAck, "onlyCallback">
-          >(s.timeout(0).emitWithAck<"onlyCallback">);
         });
       });
     });

--- a/test/socket.io.test-d.ts
+++ b/test/socket.io.test-d.ts
@@ -305,22 +305,22 @@ describe("server", () => {
 
           // Two args
           sio.emit("ackFromServer", true, "123", (...args) => {
-            expectType<[boolean[], string[]]>(args);
+            expectType<[boolean[]]>(args);
           });
           // Two args + timeout
           sio.timeout(1).emit("ackFromServer", true, "123", (...args) => {
-            expectType<[Error, boolean[], string[]]>(args);
+            expectType<[Error, boolean[]]>(args);
           });
           // Two args + room
           sio.to("1").emit("ackFromServer", true, "123", (...args) => {
-            expectType<[boolean[], string[]]>(args);
+            expectType<[boolean[]]>(args);
           });
           // Two args + timeout + room
           sio
             .timeout(1)
             .in("1")
             .emit("ackFromServer", true, "123", (...args) => {
-              expectType<[Error, boolean[], string[]]>(args);
+              expectType<[Error, boolean[]]>(args);
             });
           // Two args + timeout + room + timeout + room
           sio
@@ -329,7 +329,7 @@ describe("server", () => {
             .timeout(1)
             .to("1")
             .emit("ackFromServer", true, "123", (...args) => {
-              expectType<[Error, boolean[], string[]]>(args);
+              expectType<[Error, boolean[]]>(args);
             });
 
           sio.on("connection", (s) => {
@@ -378,13 +378,13 @@ describe("server", () => {
             });
             // Two args + room
             s.to("1").emit("ackFromServer", true, "1", (...args) => {
-              expectType<[boolean[], string[]]>(args);
+              expectType<[boolean[]]>(args);
             });
             // Two args + timeout + room
             s.timeout(1)
               .in("1")
               .emit("ackFromServer", true, "1", (...args) => {
-                expectType<[Error, boolean[], string[]]>(args);
+                expectType<[Error, boolean[]]>(args);
               });
             // Two args + timeout + room + timeout + room
             s.timeout(1)
@@ -392,7 +392,7 @@ describe("server", () => {
               .timeout(1)
               .to("1")
               .emit("ackFromServer", true, "1", (...args) => {
-                expectType<[Error, boolean[], string[]]>(args);
+                expectType<[Error, boolean[]]>(args);
               });
             done();
           });

--- a/test/socket.ts
+++ b/test/socket.ts
@@ -9,6 +9,7 @@ import {
 } from "./support/util";
 import { Server } from "..";
 import expect from "expect.js";
+import { EventNamesWithAck } from "../lib/typed-events";
 
 describe("socket", () => {
   it("should not fire events more than once after manually reconnecting", (done) => {
@@ -606,9 +607,11 @@ describe("socket", () => {
   });
 
   it("should emit an event and wait for the acknowledgement", (done) => {
-    const io = new Server(0);
-    const socket = createClient(io);
-
+    type Events = {
+      hi: (a: number, b: number, cb: (c: number) => void) => void;
+    };
+    const io = new Server<{}, Events>(0);
+    const socket = createClient<Events, Events>(io);
     io.on("connection", async (s) => {
       socket.on("hi", (a, b, fn) => {
         expect(a).to.be(1);

--- a/test/socket.ts
+++ b/test/socket.ts
@@ -9,7 +9,6 @@ import {
 } from "./support/util";
 import { Server } from "..";
 import expect from "expect.js";
-import { EventNamesWithAck } from "../lib/typed-events";
 
 describe("socket", () => {
   it("should not fire events more than once after manually reconnecting", (done) => {

--- a/test/support/util.ts
+++ b/test/support/util.ts
@@ -6,6 +6,7 @@ import {
   SocketOptions,
 } from "socket.io-client";
 import request from "supertest";
+import type { DefaultEventsMap, EventsMap } from "../../lib/typed-events";
 
 const expect = require("expect.js");
 const i = expect.stringify;
@@ -30,11 +31,14 @@ expect.Assertion.prototype.contain = function (...args) {
   return contain.apply(this, args);
 };
 
-export function createClient(
+export function createClient<
+  CTS extends EventsMap = DefaultEventsMap,
+  STC extends EventsMap = DefaultEventsMap
+>(
   io: Server,
   nsp: string = "/",
   opts?: Partial<ManagerOptions & SocketOptions>
-): ClientSocket {
+): ClientSocket<STC, CTS> {
   // @ts-ignore
   const port = io.httpServer.address().port;
   return ioc(`http://localhost:${port}${nsp}`, opts);


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
The types of the `emit`, `emitWithAck`, `serverSideEmit`, and `serverSideEmitWithAck` have issues with their types.

They revert to `any` very often or aren't arrays when they should be (server/namespace emit and server/namespace => broadcastOperator emit).

### New behavior
This fixes most of this behavior and adds tests for them.

### Other information (e.g. related issues)
Fixes #4813 

