### PR TITLE
Adding support for middlewares intercepting outgoing events

### DIFF
--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -966,8 +966,21 @@ export class Socket<
   /**
    * Sets up a socketmiddleware for outgoing requests.
    *
-   *
-   *
+   * Can be used to hook right before acknowlegement callbacks get ran.
+   * @example
+   * io.on("connection", (socket) => {
+   *   socket.useOutgoing((event, next) => {
+   *     if (event.length && typeof event[event.length - 1] === 'function') {
+   *       const callback = event[event.length - 1];
+   *       event[event.length - 1] = (...args) => {
+   *         // able to hook right before the acknowledgement callback is executed.
+   *         callback(...args);
+   *       }
+   *     }
+   *     // do not forget to call next
+   *     next();
+   *   });
+   * });
    * @param {Function} fn - middleware function (event, next)
    * @returns {Socket} self
    */
@@ -1005,6 +1018,13 @@ export class Socket<
     run(0);
   }
 
+  /**
+   * Executes the middleware for an outgoing event.
+   *
+   * @param {Array} event - event that will get emitted to client
+   * @param {Function} fn - last fn call in the middleware
+   * @private
+   */
   private runOutgoing(event, fn: (err: Error | null) => void): void {
     const outFns = this.outFns.slice(0);
     if (!outFns.length) return fn(null);

--- a/test/index.ts
+++ b/test/index.ts
@@ -16,6 +16,7 @@ describe("socket.io", () => {
   require("./messaging-many");
   require("./middleware");
   require("./socket-middleware");
+  require("./socket-outgoing-middleware");
   require("./v2-compatibility");
   require("./socket-timeout");
   require("./uws");

--- a/test/socket-outgoing-middleware.ts
+++ b/test/socket-outgoing-middleware.ts
@@ -1,0 +1,58 @@
+import { Server } from "..";
+import expect from "expect.js";
+import { success, createClient } from "./support/util";
+
+describe("socket outgoing middleware", () => {
+  it("should call functions before sending event", (done) => {
+    const io = new Server(0);
+    let run = 0;
+    const clientSocket = createClient(io, "/", { multiplex: false });
+    io.on("connection", (socket) => {
+      socket.useOutgoing((event, next) => {
+        expect(event).to.eql(["join", "woot"]);
+        event.unshift("wrap");
+        run++;
+        next();
+      });
+      socket.useOutgoing((event, next) => {
+        expect(event).to.eql(["wrap", "join", "woot"]);
+        run++;
+        next();
+      });
+      socket.onAnyOutgoing((arg1, arg2, arg3) => {
+        expect(arg1).to.be("wrap");
+        expect(arg2).to.be("join");
+        expect(arg3).to.be("woot");
+        expect(run).to.be(2);
+
+        success(done, io, clientSocket);
+      });
+
+      socket.emit("join", "woot");
+    });
+  });
+
+  it("should pass errors", (done) => {
+    const io = new Server(0);
+    const clientSocket = createClient(io, "/", { multiplex: false });
+
+    io.on("connection", (socket) => {
+      socket.useOutgoing((event, next) => {
+        next(new Error("Filtering error"));
+      });
+      socket.useOutgoing((event, next) => {
+        done(new Error("should not happen"));
+      });
+      socket.on("join", () => {
+        done(new Error("should not happen"));
+      });
+      socket.on("error", (err) => {
+        expect(err).to.be.an(Error);
+        expect(err.message).to.eql("Filtering error");
+
+        success(done, io, clientSocket);
+      });
+      socket.emit("join", "woot");
+    });
+  });
+});


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

Currently middlewares are limited to hook before the server aknowledges a clients message, but it can't hook on the client acknowledging from the client.
Currently data validation logic needs to be rewritten in the logic of every emited with acknowledgements, that may result in a lot of boiler plate code.

### New behavior

Introduced the useOutgoing((event: [string, ...any[]], next: (err?: Error) => void) => void) method.
It is behaving much like regular use() does, but before the messages are being sent from the server to the client.
(They do run before the catch all listeners and before the acknowledgement callback gets popped to the ack manager in order to be able to edit the event, or abort it).

Example: 
```ts
io.on("connection", (socket) => {
    socket.useOutgoing((event, next) => {
      if (event.length && typeof event[event.length - 1] === 'function') {
        const callback = event[event.length - 1];
        event[event.length - 1] = (...args) => {
          // able to hook right before the acknowledgement callback is executed.
          callback(...args);
        }
      }
      // do not forget to call next
      next();
    });
});
```


### Other information (e.g. related issues)

I disscussed other option briefly in this issue https://github.com/socketio/socket.io/issues/4882.
For short, the tricky part about this, is that one might want access to the context of the event that originated the ack repsonse whilst consuming what the client acknowledged. Else it would be of no use hooking there, except for logging purposes I guess.
This would be a solution that doesn't disrupt current usage of Socket.IO, and we have access to the context of the event.