### PR TITLE
Change 'import express = require("express");' to correct TS syntax

### DIFF
--- a/examples/express-session-example/ts/index.ts
+++ b/examples/express-session-example/ts/index.ts
@@ -1,8 +1,7 @@
-import express = require("express");
+import express, { type Request } from "express";
 import { createServer } from "http";
 import { Server } from "socket.io";
 import session from "express-session";
-import { type Request } from "express";
 
 declare module "express-session" {
   interface SessionData {


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

import express = require("express")
### New behavior

import express, { type Request } from "express";
### Other information (e.g. related issues)


