### PR TITLE
Fix: Calling io.emit("event") with events that have no arguments results in TypeScript errors

### DIFF
--- a/lib/typed-events.ts
+++ b/lib/typed-events.ts
@@ -52,9 +52,11 @@ export type EventNamesWithoutAck<
 > = IfAny<
   Last<Parameters<Map[K]>> | Map[K],
   K,
-  K extends (
-    Last<Parameters<Map[K]>> extends (...args: any[]) => any ? never : K
-  )
+  K extends (Parameters<Map[K]> extends never[] ? K : never)
+    ? K
+    : K extends (
+        Last<Parameters<Map[K]>> extends (...args: any[]) => any ? never : K
+      )
     ? K
     : never
 >;

--- a/test/connection-state-recovery.ts
+++ b/test/connection-state-recovery.ts
@@ -222,11 +222,11 @@ describe("connection state recovery", () => {
 
     class DummyAdapter extends Adapter {
       override persistSession(session) {
-        expect.fail();
+        expect().fail();
       }
 
       override restoreSession(pid, offset) {
-        expect.fail();
+        expect().fail();
         return Promise.reject("should not happen");
       }
     }

--- a/test/messaging-many.ts
+++ b/test/messaging-many.ts
@@ -526,7 +526,7 @@ describe("messaging many", () => {
     ]).then(async () => {
       try {
         await io.timeout(200).emitWithAck("some event");
-        expect.fail();
+        expect().fail();
       } catch (err) {
         expect(err).to.be.an(Error);
         // @ts-ignore

--- a/test/namespaces.ts
+++ b/test/namespaces.ts
@@ -6,6 +6,7 @@ import {
   createClient,
   successFn,
   createPartialDone,
+  assert,
 } from "./support/util";
 
 describe("namespaces", () => {
@@ -417,6 +418,7 @@ describe("namespaces", () => {
     socket1.on("a", successFn(done, io, socket1, socket2));
 
     socket2.on("connect", () => {
+      assert(socket2.id);
       io.except(socket2.id).emit("a");
     });
   });
@@ -435,6 +437,7 @@ describe("namespaces", () => {
     socket1.on("a", successFn(done, io, socket1, socket2));
 
     socket2.on("connect", () => {
+      assert(socket2.id);
       nsp.except(socket2.id).emit("a");
     });
   });

--- a/test/socket-timeout.ts
+++ b/test/socket-timeout.ts
@@ -62,7 +62,7 @@ describe("timeout", () => {
     io.on("connection", async (socket) => {
       try {
         await socket.timeout(50).emitWithAck("unknown");
-        expect.fail();
+        expect().fail();
       } catch (err) {
         expect(err).to.be.an(Error);
         success(done, io, client);

--- a/test/socket.io.test-d.ts
+++ b/test/socket.io.test-d.ts
@@ -285,7 +285,7 @@ describe("server", () => {
         sio.send(1, "2", [3]);
         // @ts-expect-error - ServerToClientEvents doesn't have a message event
         nio.send(1, "2", [3]);
-        // This should likely be an error, but I don't know how to make it one
+        // This correctly becomes an error in TS 5.3.2, so when updating typescript, this should expect-error
         sio.send();
         nio.send();
       });

--- a/test/socket.io.test-d.ts
+++ b/test/socket.io.test-d.ts
@@ -442,6 +442,9 @@ describe("server", () => {
         expectType<ToEmit<ServerToClientEventsNoAck, "noArgs">>(
           sio.emit<"noArgs">
         );
+        expectType<ToEmit<ServerToClientEventsNoAck, "noArgs">>(
+          nio.emit<"noArgs">
+        );
         expectType<ToEmit<ServerToClientEventsNoAck, "helloFromServer">>(
           // These errors will dissapear once the TS version is updated from 4.7.4
           // the TSD instance is using a newer version of TS than the workspace version

--- a/test/support/expectjs.d.ts
+++ b/test/support/expectjs.d.ts
@@ -1,0 +1,221 @@
+declare function expect(target?: any): Expect.Root;
+
+declare namespace Expect {
+  interface Assertion {
+    /**
+     * Check if the value is truthy
+     */
+    ok(): void;
+
+    /**
+     * Creates an anonymous function which calls fn with arguments.
+     */
+    withArgs(...args: any[]): Root;
+
+    /**
+     * Assert that the function throws.
+     *
+     * @param fn callback to match error string against
+     */
+    throwError(fn?: (exception: any) => void): void;
+
+    /**
+     * Assert that the function throws.
+     *
+     * @param fn callback to match error string against
+     */
+    throwException(fn?: (exception: any) => void): void;
+
+    /**
+     * Assert that the function throws.
+     *
+     * @param regexp regexp to match error string against
+     */
+    throwError(regexp: RegExp): void;
+
+    /**
+     * Assert that the function throws.
+     *
+     * @param fn callback to match error string against
+     */
+    throwException(regexp: RegExp): void;
+
+    /**
+     * Checks if the array is empty.
+     */
+    empty(): Assertion;
+
+    /**
+     * Checks if the obj exactly equals another.
+     */
+    equal(obj: any): Assertion;
+
+    /**
+     * Checks if the obj sortof equals another.
+     */
+    eql(obj: any): Assertion;
+
+    /**
+     * Assert within start to finish (inclusive).
+     *
+     * @param start
+     * @param finish
+     */
+    within(start: number, finish: number): Assertion;
+
+    /**
+     * Assert typeof.
+     */
+    a(type: string): Assertion;
+
+    /**
+     * Assert instanceof.
+     */
+    a(type: Function): Assertion;
+
+    /**
+     * Assert typeof / instanceof.
+     */
+    an: An;
+
+    /**
+     * Assert numeric value above n.
+     */
+    greaterThan(n: number): Assertion;
+
+    /**
+     * Assert numeric value above n.
+     */
+    above(n: number): Assertion;
+
+    /**
+     * Assert numeric value below n.
+     */
+    lessThan(n: number): Assertion;
+
+    /**
+     * Assert numeric value below n.
+     */
+    below(n: number): Assertion;
+
+    /**
+     * Assert string value matches regexp.
+     *
+     * @param regexp
+     */
+    match(regexp: RegExp): Assertion;
+
+    /**
+     * Assert property "length" exists and has value of n.
+     *
+     * @param n
+     */
+    length(n: number): Assertion;
+
+    /**
+     * Assert property name exists, with optional val.
+     *
+     * @param name
+     * @param val
+     */
+    property(name: string, val?: any): Assertion;
+
+    /**
+     * Assert that string contains str.
+     */
+    contain(...strings: string[]): Assertion;
+    string(str: string): Assertion;
+
+    /**
+     * Assert that the array contains obj.
+     */
+    contain(...objs: any[]): Assertion;
+    string(obj: any): Assertion;
+
+    /**
+     * Assert exact keys or inclusion of keys by using the `.own` modifier.
+     */
+    key(keys: string[]): Assertion;
+    /**
+     * Assert exact keys or inclusion of keys by using the `.own` modifier.
+     */
+    key(...keys: string[]): Assertion;
+    /**
+     * Assert exact keys or inclusion of keys by using the `.own` modifier.
+     */
+    keys(keys: string[]): Assertion;
+    /**
+     * Assert exact keys or inclusion of keys by using the `.own` modifier.
+     */
+    keys(...keys: string[]): Assertion;
+
+    /**
+     * Assert a failure.
+     */
+    fail(message?: string): Assertion;
+  }
+
+  interface Root extends Assertion {
+    not: Not;
+    to: To;
+    only: Only;
+    have: Have;
+    be: Be;
+  }
+
+  interface Be extends Assertion {
+    /**
+     * Checks if the obj exactly equals another.
+     */
+    (obj: any): Assertion;
+
+    an: An;
+  }
+
+  interface An extends Assertion {
+    /**
+     * Assert typeof.
+     */
+    (type: string): Assertion;
+
+    /**
+     * Assert instanceof.
+     */
+    (type: Function): Assertion;
+  }
+
+  interface Not extends Expect.NotBase {
+    to: Expect.ToBase;
+  }
+
+  interface NotBase extends Assertion {
+    be: Be;
+    have: Have;
+    include: Assertion;
+    only: Only;
+  }
+
+  interface To extends Expect.ToBase {
+    not: Expect.NotBase;
+  }
+
+  interface ToBase extends Assertion {
+    be: Be;
+    have: Have;
+    include: Assertion;
+    only: Only;
+  }
+
+  interface Only extends Assertion {
+    have: Have;
+  }
+
+  interface Have extends Assertion {
+    own: Assertion;
+  }
+}
+
+declare module "expect.js" {
+  //@ts-ignore
+  export = expect;
+}

--- a/test/support/util.ts
+++ b/test/support/util.ts
@@ -1,3 +1,4 @@
+/// <reference types="./expectjs" />
 import type { Server } from "../..";
 import {
   io as ioc,

--- a/test/support/util.ts
+++ b/test/support/util.ts
@@ -63,6 +63,16 @@ export function successFn(
   return () => success(done, sio, ...clientSockets);
 }
 
+/**
+ * Asserts a condition so that typescript will recognize the assertion!
+ *
+ * Uses expect's `ok` check on condition
+ * @param condition
+ */
+export function assert(condition: any): asserts condition {
+  expect(condition).to.be.ok();
+}
+
 export function getPort(io: Server): number {
   // @ts-ignore
   return io.httpServer.address().port;

--- a/test/uws.ts
+++ b/test/uws.ts
@@ -7,6 +7,7 @@ import { Server } from "..";
 import { io as ioc, Socket as ClientSocket } from "socket.io-client";
 import request from "supertest";
 import expect from "expect.js";
+import { assert } from "./support/util";
 
 const createPartialDone = (done: (err?: Error) => void, count: number) => {
   let i = 0;
@@ -134,6 +135,8 @@ describe("socket.io with uWebSocket.js-based engine", () => {
     clientWSOnly.on("hello", partialDone);
     clientPollingOnly.on("hello", partialDone);
     clientCustomNamespace.on("hello", shouldNotHappen(done));
+    assert(clientWSOnly.id);
+    assert(clientPollingOnly.id);
 
     io.of("/").sockets.get(clientWSOnly.id)!.join("room1");
     io.of("/").sockets.get(clientPollingOnly.id)!.join("room1");
@@ -148,6 +151,8 @@ describe("socket.io with uWebSocket.js-based engine", () => {
     clientWSOnly.on("hello", partialDone);
     clientPollingOnly.on("hello", partialDone);
     clientCustomNamespace.on("hello", shouldNotHappen(done));
+    assert(clientWSOnly.id);
+    assert(clientPollingOnly.id);
 
     io.of("/").sockets.get(clientWSOnly.id)!.join("room1");
     io.of("/").sockets.get(clientPollingOnly.id)!.join("room2");
@@ -163,6 +168,8 @@ describe("socket.io with uWebSocket.js-based engine", () => {
     clientPollingOnly.on("hello", shouldNotHappen(done));
     clientCustomNamespace.on("hello", shouldNotHappen(done));
 
+    assert(clientWSOnly.id);
+    assert(clientPollingOnly.id);
     io.of("/").sockets.get(clientWSOnly.id)!.join("room1");
     io.of("/").sockets.get(clientPollingOnly.id)!.join("room2");
 
@@ -177,6 +184,9 @@ describe("socket.io with uWebSocket.js-based engine", () => {
     clientPollingOnly.on("hello", partialDone);
     clientCustomNamespace.on("hello", shouldNotHappen(done));
 
+    assert(client.id);
+    assert(clientWSOnly.id);
+    assert(clientPollingOnly.id);
     io.of("/").sockets.get(client.id)!.join("room1");
     io.of("/").sockets.get(clientPollingOnly.id)!.join("room1");
 
@@ -189,6 +199,7 @@ describe("socket.io with uWebSocket.js-based engine", () => {
   it("should not crash when socket is disconnected before the upgrade", (done) => {
     client.on("disconnect", () => done());
 
+    assert(client.id);
     io.of("/").sockets.get(client.id)!.disconnect();
   });
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

Typescript type fixe relating to #4817, also type failures in the tests due to the client#id type becoming `string|undefined` ([f9c16f2](https://github.com/socketio/socket.io-client/commit/f9c16f226512fc8a8df461e3a07e392720462165))

### Current behavior
```ts
import { Server } from "socket.io";

interface ServerToClientEvents {
  noArg: () => void;
}

const io = new Server<{}, ServerToClientEvents>();

io.emit("noArg"); // <- Error
```

### New behavior
```ts
import { Server } from "socket.io";

interface ServerToClientEvents {
  noArg: () => void;
}

const io = new Server<{}, ServerToClientEvents>();

io.emit("noArg"); // ✔️ - no error!
```

### Other information (e.g. related issues)
#4914 

