### PR TITLE
Add emitWithAck method to RemoteSocket class

### DIFF
--- a/lib/broadcast-operator.ts
+++ b/lib/broadcast-operator.ts
@@ -529,6 +529,13 @@ export class RemoteSocket<EmitEvents extends EventsMap, SocketData>
     return this.operator.emit(ev, ...args);
   }
 
+  public emitWithAck<Ev extends EventNamesWithError<EmitEvents>>(
+    ev: Ev,
+    ...args: AllButLast<EventParams<EmitEvents, Ev>>
+  ): Promise<FirstNonErrorArg<Last<EventParams<EmitEvents, Ev>>>> {
+    return this.operator.emitWithAck(ev, ...args);
+  }
+
   /**
    * Joins a room.
    *


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
`fetchSockets()` returns `RemoteSocket` array.
But `RemoteSocket` does not have `emitWithAck` method.
So currently, we can not use handy way.

### New behavior
`RemoteSocket` instances can use `emitWithAck` method also.


### Other information (e.g. related issues)
I just added code like `emit` method.
It's calling `BroadcastOperator`'s `emit` method.