### PR TITLE
parent-namespace: change inline Adapter-like to file-private class

### DIFF
--- a/lib/parent-namespace.ts
+++ b/lib/parent-namespace.ts
@@ -6,6 +6,7 @@ import type {
   DefaultEventsMap,
   EventNamesWithoutAck,
 } from "./typed-events";
+import {Adapter} from "socket.io-adapter";
 import type { BroadcastOptions } from "socket.io-adapter";
 import debugModule from "debug";
 
@@ -33,7 +34,7 @@ export class ParentNamespace<
   SocketData = any
 > extends Namespace<ListenEvents, EmitEvents, ServerSideEvents, SocketData> {
   private static count: number = 0;
-  private children: Set<
+  private readonly children: Set<
     Namespace<ListenEvents, EmitEvents, ServerSideEvents, SocketData>
   > = new Set();
 
@@ -47,13 +48,7 @@ export class ParentNamespace<
    * @private
    */
   _initAdapter(): void {
-    const broadcast = (packet: any, opts: BroadcastOptions) => {
-      this.children.forEach((nsp) => {
-        nsp.adapter.broadcast(packet, opts);
-      });
-    };
-    // @ts-ignore FIXME is there a way to declare an inner class in TypeScript?
-    this.adapter = { broadcast };
+    this.adapter = new ParentBroadcastAdapter(this, this.children);
   }
 
   public emit<Ev extends EventNamesWithoutAck<EmitEvents>>(
@@ -111,4 +106,20 @@ export class ParentNamespace<
     // may exist on one node but not exist on another (since it is created upon client connection)
     throw new Error("fetchSockets() is not supported on parent namespaces");
   }
+}
+
+/**
+ * A dummy adapter that only supports broadcasting to child (concrete) namespaces.
+ * @private file
+ */
+class ParentBroadcastAdapter extends Adapter {
+  constructor(parentNsp: any, private readonly children: Set<Namespace>) {
+    super(parentNsp);
+  }
+
+  broadcast(packet: any, opts: BroadcastOptions) {
+    this.children.forEach((nsp) => {
+      nsp.adapter.broadcast(packet, opts);
+    });
+  };
 }

--- a/lib/parent-namespace.ts
+++ b/lib/parent-namespace.ts
@@ -6,7 +6,7 @@ import type {
   DefaultEventsMap,
   EventNamesWithoutAck,
 } from "./typed-events";
-import {Adapter} from "socket.io-adapter";
+import { Adapter } from "socket.io-adapter";
 import type { BroadcastOptions } from "socket.io-adapter";
 import debugModule from "debug";
 
@@ -121,5 +121,5 @@ class ParentBroadcastAdapter extends Adapter {
     this.children.forEach((nsp) => {
       nsp.adapter.broadcast(packet, opts);
     });
-  };
+  }
 }


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other: remove 1 FIXME in code

### Current behavior

`parentNamespace.adapter` be a dummy adapter-like object, and only supports `broadcast` operation.

### New behavior

The same behavior, but with a class that will pass type check.

### Other information (e.g. related issues)

When reading the code I saw the FIXME, so I thought the type check can be satisfied this way.

IMO except the type check the inline `{broadcast}` adapter was not bad. It is arguably better in that unsupported operations will fail loudly instead of silently. So I'm not very confident of this PR. Opinions welcome 🙏🏽 .

To pass type check while preserving the old fail-fast behavior, one could also `this.adapter = {broadcast} as Adapter;`