### PR TITLE
fix: ParentNamespace adapter broadcast bug

### DIFF
--- a/lib/parent-namespace.ts
+++ b/lib/parent-namespace.ts
@@ -113,12 +113,8 @@ export class ParentNamespace<
  * @private file
  */
 class ParentBroadcastAdapter extends Adapter {
-  constructor(private readonly parentNsp: any) {
-    super(parentNsp);
-  }
-
   broadcast(packet: any, opts: BroadcastOptions) {
-    this.parentNsp.children.forEach((nsp) => {
+    this.nsp.children.forEach((nsp) => {
       nsp.adapter.broadcast(packet, opts);
     });
   }

--- a/lib/parent-namespace.ts
+++ b/lib/parent-namespace.ts
@@ -48,7 +48,7 @@ export class ParentNamespace<
    * @private
    */
   _initAdapter(): void {
-    this.adapter = new ParentBroadcastAdapter(this, this.children);
+    this.adapter = new ParentBroadcastAdapter(this);
   }
 
   public emit<Ev extends EventNamesWithoutAck<EmitEvents>>(
@@ -113,12 +113,12 @@ export class ParentNamespace<
  * @private file
  */
 class ParentBroadcastAdapter extends Adapter {
-  constructor(parentNsp: any, private readonly children: Set<Namespace>) {
+  constructor(private readonly parentNsp: any) {
     super(parentNsp);
   }
 
   broadcast(packet: any, opts: BroadcastOptions) {
-    this.children.forEach((nsp) => {
+    this.parentNsp.children.forEach((nsp) => {
       nsp.adapter.broadcast(packet, opts);
     });
   }

--- a/test/namespaces.ts
+++ b/test/namespaces.ts
@@ -505,6 +505,7 @@ describe("namespaces", () => {
         .on("connect", (socket) => {
           expect(socket.nsp.name).to.be("/dynamic-101");
           dynamicNsp.emit("hello", 1, "2", { 3: "4" });
+          dynamicNsp.to(socket.id).emit("there", 1, "2", { 3: "4" });
           partialDone();
         })
         .use((socket, next) => {


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
When a dynamic namespace emits to an individual socket, it will be met with an error:

```
node_modules/socket.io/dist/parent-namespace.js:88
        this.children.forEach((nsp) => {
                      ^

TypeError: Cannot read properties of undefined (reading 'forEach')
    at ParentBroadcastAdapter.broadcast (node_modules/socket.io/dist/parent-namespace.js:88:23)
    at BroadcastOperator.emit (node_modules/socket.io/dist/broadcast-operator.js:169:26)
    at Socket.<anonymous> (server.js:60:33)
    at Socket.emit (node:events:520:28)
    at Socket.emitReserved (node_modules/socket.io/dist/typed-events.js:56:22)
    at Socket._onclose (node_modules/socket.io/dist/socket.js:547:14)
    at Client.onclose (node_modules/socket.io/dist/client.js:247:20)
    at Socket.emit (node:events:532:35)
    at Socket.onClose (node_modules/engine.io/build/socket.js:304:18)
    at Object.onceWrapper (node:events:639:28)
```

### New behavior
This fixes that error and adds a test that would guard this scenario.

### Other information (e.g. related issues)
resolves #4985 

