### PR TITLE
Fixes #5034 - change private property io.httpServer to a public property

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -169,6 +169,7 @@ export class Server<
    *
    */
   public engine: BaseServer;
+  public httpServer: TServerInstance;
 
   /** @private */
   readonly _parser: typeof parser;
@@ -209,7 +210,6 @@ export class Server<
    * @private
    */
   _connectTimeout: number;
-  private httpServer: TServerInstance;
   private _corsMiddleware: (
     req: http.IncomingMessage,
     res: http.ServerResponse,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -169,6 +169,11 @@ export class Server<
    *
    */
   public engine: BaseServer;
+  /**
+   * The underlying Node.js HTTP server.
+   *
+   * @see https://nodejs.org/api/http.html
+   */
   public httpServer: TServerInstance;
 
   /** @private */

--- a/test/support/util.ts
+++ b/test/support/util.ts
@@ -7,6 +7,7 @@ import {
   SocketOptions,
 } from "socket.io-client";
 import request from "supertest";
+import type { AddressInfo } from "node:net";
 import type { DefaultEventsMap, EventsMap } from "../../lib/typed-events";
 
 const expect = require("expect.js");
@@ -40,8 +41,7 @@ export function createClient<
   nsp: string = "/",
   opts?: Partial<ManagerOptions & SocketOptions>
 ): ClientSocket<STC, CTS> {
-  const address = io.httpServer.address();
-  const port = (typeof address !== "string" && address?.port) || 0;
+  const port = (io.httpServer.address() as AddressInfo).port;
   return ioc(`http://localhost:${port}${nsp}`, opts);
 }
 
@@ -74,8 +74,7 @@ export function assert(condition: any): asserts condition {
 }
 
 export function getPort(io: Server): number {
-  const address = io.httpServer.address();
-  return (typeof address !== "string" && address?.port) || 0;
+  return (io.httpServer.address() as AddressInfo).port;
 }
 
 export function createPartialDone(count: number, done: (err?: Error) => void) {

--- a/test/support/util.ts
+++ b/test/support/util.ts
@@ -40,8 +40,8 @@ export function createClient<
   nsp: string = "/",
   opts?: Partial<ManagerOptions & SocketOptions>
 ): ClientSocket<STC, CTS> {
-  // @ts-ignore
-  const port = io.httpServer.address().port;
+  const address = io.httpServer.address();
+  const port = (typeof address !== "string" && address?.port) || 0;
   return ioc(`http://localhost:${port}${nsp}`, opts);
 }
 
@@ -74,8 +74,8 @@ export function assert(condition: any): asserts condition {
 }
 
 export function getPort(io: Server): number {
-  // @ts-ignore
-  return io.httpServer.address().port;
+  const address = io.httpServer.address();
+  return (typeof address !== "string" && address?.port) || 0;
 }
 
 export function createPartialDone(count: number, done: (err?: Error) => void) {


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
```ts
import { Server } from "socket.io";

const io = new Server(3000, { /* options */ });

io.httpServer // Property 'httpServer' is private and only accessible within class 'Server<ListenEvents, EmitEvents, ServerSideEvents, SocketData>'.ts(2341)
```
### New behavior

```ts
import { Server } from "socket.io";

const io = new Server(3000, { /* options */ });

io.httpServer // now is accessible as the documentations says (https://socket.io/docs/v4/server-initialization/#standalone)
```
### Other information (e.g. related issues)
https://github.com/socketio/socket.io/issues/5034

