### PR TITLE
docs: fix conjunction with fastify example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -160,7 +160,9 @@ called `io`.
 ```js
 const app = require('fastify')();
 app.register(require('fastify-socket.io'));
-app.io.on('connection', () => { /* … */ });
+app.ready().then(() => {
+    app.io.on('connection', () => { /* … */ });
+})
 app.listen(3000);
 ```
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
Right now the readme example directly uses `app.io` in the conjunction with fastify example but `io` is undefined while the server (app) is not ready
```js
const app = require('fastify')();
app.register(require('fastify-socket.io'));
app.io.on('connection', () => { /* … */ }); // here io is undefined
app.listen(3000);
```

### New behavior
Now app.io is accessed after the server (app) is ready so it is defined
```js
const app = require('fastify')();
app.register(require('fastify-socket.io'));
app.ready().then(() => {
    app.io.on('connection', () => { /* … */ }); // here app.io is defined
});
app.listen(3000);
```

### Other information (e.g. related issues)
I was using it for the first time and got confused if I installed something wrong, then after diving into the [detailed docs](https://socket.io/docs/v4/server-initialization/#with-fastify) I understood what I was doing wrong.
Couldn't find this issue on my first few google searches, so fixing the readme should save a lot of trouble for other fastify users

