### PR TITLE
fix: track socket before run middlewares

### DIFF
--- a/packages/socket.io/lib/namespace.ts
+++ b/packages/socket.io/lib/namespace.ts
@@ -322,6 +322,9 @@ export class Namespace<
     debug("adding socket to nsp %s", this.name);
     const socket = await this._createSocket(client, auth);
 
+    // track socket
+    this.sockets.set(socket.id, socket);
+
     if (
       // @ts-ignore
       this.server.opts.connectionStateRecovery?.skipMiddlewares &&
@@ -389,9 +392,6 @@ export class Namespace<
       socket: Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>
     ) => void
   ) {
-    // track socket
-    this.sockets.set(socket.id, socket);
-
     // it's paramount that the internal `onconnect` logic
     // fires before user-set events to prevent state order
     // violations (such as a disconnection before the connection


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
the socket is not tracked when run the middlewares

### New behavior
track socket before run middlewares

### Other information (e.g. related issues)
fix: https://github.com/socketio/socket.io/issues/5139

