### PR TITLE
link to in-monorepo package versions 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "socket.io",
       "workspaces": [
         "packages/socket.io-component-emitter",
         "packages/engine.io-parser",
@@ -15246,7 +15247,7 @@
         "base64id": "~2.0.0",
         "cors": "~2.8.5",
         "debug": "~4.3.2",
-        "engine.io": "~6.5.2",
+        "engine.io": "~6.6.0",
         "socket.io-adapter": "~2.5.2",
         "socket.io-parser": "~4.2.4"
       },
@@ -15268,7 +15269,7 @@
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
-        "engine.io-client": "~6.5.2",
+        "engine.io-client": "~6.6.0",
         "socket.io-parser": "~4.2.4"
       },
       "engines": {
@@ -15291,19 +15292,8 @@
         }
       }
     },
-    "packages/socket.io-client/node_modules/engine.io-client": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
-      "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.1",
-        "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1",
-        "xmlhttprequest-ssl": "~2.0.0"
-      }
-    },
     "packages/socket.io-cluster-engine": {
+      "name": "@socket.io/cluster-engine",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -15358,26 +15348,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "packages/socket.io/node_modules/engine.io": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
-      "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
-      "dependencies": {
-        "@types/cookie": "^0.4.1",
-        "@types/cors": "^2.8.12",
-        "@types/node": ">=10.0.0",
-        "accepts": "~1.3.4",
-        "base64id": "2.0.0",
-        "cookie": "~0.4.1",
-        "cors": "~2.8.5",
-        "debug": "~4.3.1",
-        "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1"
-      },
-      "engines": {
-        "node": ">=10.2.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "socket.io",
   "private": true,
   "workspaces": [
     "packages/socket.io-component-emitter",

--- a/packages/socket.io-client/package.json
+++ b/packages/socket.io-client/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@socket.io/component-emitter": "~3.1.0",
     "debug": "~4.3.2",
-    "engine.io-client": "~6.5.2",
+    "engine.io-client": "~6.6.0",
     "socket.io-parser": "~4.2.4"
   },
   "scripts": {

--- a/packages/socket.io/package.json
+++ b/packages/socket.io/package.json
@@ -54,7 +54,7 @@
     "base64id": "~2.0.0",
     "cors": "~2.8.5",
     "debug": "~4.3.2",
-    "engine.io": "~6.5.2",
+    "engine.io": "~6.6.0",
     "socket.io-adapter": "~2.5.2",
     "socket.io-parser": "~4.2.4"
   },


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

`socket.io` uses npm version of `engine.io`, not the version in repo. So is `socket.io-client` using npm `engine.io-client`.

IMHO this is not really making full use of monorepo .

### New behavior

Latest in-tree version used. `npm list` now shows:

```
├─┬ socket.io@4.7.5 -> ./packages/socket.io
│ ├── accepts@1.3.8 deduped
│ ├── base64id@2.0.0 deduped
│ ├── cors@2.8.5 deduped
│ ├── debug@4.3.5 deduped
│ ├── engine.io@6.6.0 deduped -> ./packages/engine.io                    # change
│ ├── socket.io-adapter@2.5.5 deduped -> ./packages/socket.io-adapter
│ └── socket.io-parser@4.2.4 deduped -> ./packages/socket.io-parser
```

### Other information (e.g. related issues)

Related to https://github.com/socketio/socket.io/issues/5161 
