### PR TITLE
refactor: default transport in type

### DIFF
--- a/packages/engine.io-client/lib/socket.ts
+++ b/packages/engine.io-client/lib/socket.ts
@@ -85,7 +85,7 @@ export interface SocketOptions {
    *
    * @default ['polling','websocket', 'webtransport']
    */
-  transports?: string[] | TransportCtor[];
+  transports?: ("polling" | "websocket" | "webtransport" | string)[] | TransportCtor[];
 
   /**
    * Whether all the transports should be tested, instead of just the first one.

--- a/packages/engine.io-client/lib/socket.ts
+++ b/packages/engine.io-client/lib/socket.ts
@@ -85,7 +85,9 @@ export interface SocketOptions {
    *
    * @default ['polling','websocket', 'webtransport']
    */
-  transports?: ("polling" | "websocket" | "webtransport" | string)[] | TransportCtor[];
+  transports?:
+    | ("polling" | "websocket" | "webtransport" | string)[]
+    | TransportCtor[];
 
   /**
    * Whether all the transports should be tested, instead of just the first one.


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behavior
ah! I tried to specify transports, but it doesn't autocomplete.
Because current type of transport is string[].
I have to check JSDOC to see  ['polling','websocket', 'webtransport'].

### New behavior
Be comfortable with auto-completion without typos.

### Other information (e.g. related issues)
#5187 

