### PR TITLE
fix: make Namespace._fns private

### DIFF
--- a/packages/socket.io/lib/namespace.ts
+++ b/packages/socket.io/lib/namespace.ts
@@ -161,7 +161,7 @@ export class Namespace<
     SocketData
   >;
 
-  protected _fns: Array<
+  private _fns: Array<
     (
       socket: Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>,
       next: (err?: ExtendedError) => void,
@@ -185,6 +185,23 @@ export class Namespace<
     this.server = server;
     this.name = name;
     this._initAdapter();
+  }
+
+  protected static copyMiddleware<
+    ListenEvents extends EventsMap,
+    EmitEvents extends EventsMap,
+    ServerSideEvents extends EventsMap,
+    SocketData
+  >(
+    destination: Namespace<
+      ListenEvents,
+      EmitEvents,
+      ServerSideEvents,
+      SocketData
+    >,
+    source: Namespace<ListenEvents, EmitEvents, ServerSideEvents, SocketData>
+  ) {
+    source._fns.forEach((fn) => destination.use(fn));
   }
 
   /**

--- a/packages/socket.io/lib/parent-namespace.ts
+++ b/packages/socket.io/lib/parent-namespace.ts
@@ -67,7 +67,7 @@ export class ParentNamespace<
   ): Namespace<ListenEvents, EmitEvents, ServerSideEvents, SocketData> {
     debug("creating child namespace %s", name);
     const namespace = new Namespace(this.server, name);
-    this._fns.forEach((fn) => namespace.use(fn));
+    Namespace.copyMiddleware(namespace, this);
     this.listeners("connect").forEach((listener) =>
       namespace.on("connect", listener),
     );


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Other information (e.g. related issues)

Issue: #5179

**This is a variant for PR #5196, please only merge one of these!** I created two PRs for the related issue, providing both suggested solutions. I personally prefer this one as it more cleanly encapsulates implementation details.

I tried adding a test to prevent regression, but didn't manage to reproduce the error that caused all this inside the socket.io test suite. I assume this is because we use a stricter TypeScript configuration in our own codebase, but didn't bother verifying it.
