### PR TITLE
fix: make Namespace._fns private

### DIFF
--- a/packages/socket.io/lib/namespace.ts
+++ b/packages/socket.io/lib/namespace.ts
@@ -161,7 +161,7 @@ export class Namespace<
     SocketData
   >;
 
-  protected _fns: Array<
+  private _fns: Array<
     (
       socket: Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>,
       next: (err?: ExtendedError) => void,

--- a/packages/socket.io/lib/parent-namespace.ts
+++ b/packages/socket.io/lib/parent-namespace.ts
@@ -67,7 +67,7 @@ export class ParentNamespace<
   ): Namespace<ListenEvents, EmitEvents, ServerSideEvents, SocketData> {
     debug("creating child namespace %s", name);
     const namespace = new Namespace(this.server, name);
-    this._fns.forEach((fn) => namespace.use(fn));
+    this["_fns"].forEach((fn) => namespace.use(fn));
     this.listeners("connect").forEach((listener) =>
       namespace.on("connect", listener),
     );


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Other information (e.g. related issues)

Issue: #5179

**This is a variant for PR #5195, please only merge one of these!** I created two PRs for the related issue, providing both suggested solutions. This one uses the index signature trick as suggested in the issue.

I tried adding a test to prevent regression, but didn't manage to reproduce the error that caused all this inside the socket.io test suite. I assume this is because we use a stricter TypeScript configuration in our own codebase, but didn't bother verifying it.
