### PR TITLE
comment: write js docs in on

### DIFF
--- a/packages/socket.io-client/lib/socket.ts
+++ b/packages/socket.io-client/lib/socket.ts
@@ -120,7 +120,7 @@ interface SocketReservedEvents {
   connect_error: (err: Error) => void;
   disconnect: (
     reason: Socket.DisconnectReason,
-    description?: DisconnectDescription
+    description?: DisconnectDescription,
   ) => void;
 }
 
@@ -555,7 +555,7 @@ export class Socket<
           debug(
             "packet [%d] is discarded after %d tries",
             packet.id,
-            packet.tryCount
+            packet.tryCount,
           );
           this._queue.shift();
           if (ack) {
@@ -592,7 +592,7 @@ export class Socket<
     if (packet.pending && !force) {
       debug(
         "packet [%d] has already been sent and is waiting for an ack",
-        packet.id
+        packet.id,
       );
       return;
     }
@@ -666,7 +666,7 @@ export class Socket<
    */
   private onclose(
     reason: Socket.DisconnectReason,
-    description?: DisconnectDescription
+    description?: DisconnectDescription,
   ): void {
     debug("close (%s)", reason);
     this.connected = false;
@@ -684,7 +684,7 @@ export class Socket<
   private _clearAcks() {
     Object.keys(this.acks).forEach((id) => {
       const isBuffered = this.sendBuffer.some(
-        (packet) => String(packet.id) === id
+        (packet) => String(packet.id) === id,
       );
       if (!isBuffered) {
         // note: handlers that do not accept an error as first argument are ignored here
@@ -717,8 +717,8 @@ export class Socket<
           this.emitReserved(
             "connect_error",
             new Error(
-              "It seems you are trying to reach a Socket.IO server in v2.x with a v3.x client, but they are not compatible (more information here: https://socket.io/docs/v3/migrating-from-2-x-to-3-0/)"
-            )
+              "It seems you are trying to reach a Socket.IO server in v2.x with a v3.x client, but they are not compatible (more information here: https://socket.io/docs/v3/migrating-from-2-x-to-3-0/)",
+            ),
           );
         }
         break;
@@ -968,7 +968,7 @@ export class Socket<
    * @returns self
    */
   public timeout(
-    timeout: number
+    timeout: number,
   ): Socket<ListenEvents, DecorateAcknowledgements<EmitEvents>> {
     this.flags.timeout = timeout;
     return this;
@@ -1161,7 +1161,7 @@ export class Socket<
    */
   public on<Ev extends ReservedOrUserEventNames<ReservedEvents, ListenEvents>>(
     ev: Ev,
-    listener: ReservedOrUserListener<ReservedEvents, ListenEvents, Ev>
+    listener: ReservedOrUserListener<ReservedEvents, ListenEvents, Ev>,
   ): this {
     return super.on<Ev>(ev, listener);
   }

--- a/packages/socket.io-component-emitter/lib/cjs/index.d.ts
+++ b/packages/socket.io-component-emitter/lib/cjs/index.d.ts
@@ -82,6 +82,11 @@ export class Emitter<
      *
      * @param ev Name of the event
      * @param listener Callback function
+     * @reserved
+     * - "connect": This event is fired by the Socket instance upon connection **and** reconnection.
+     * - "connect_error": This event is fired upon connection failure.
+     * - "disconnect": This event is fired upon disconnection.
+     * @see [client-api-events](https://socket.io/docs/v4/client-api/#events-1)
      */
     on<Ev extends ReservedOrUserEventNames<ReservedEvents, ListenEvents>>(
         ev: Ev,

--- a/packages/socket.io-component-emitter/lib/cjs/index.d.ts
+++ b/packages/socket.io-component-emitter/lib/cjs/index.d.ts
@@ -82,11 +82,6 @@ export class Emitter<
      *
      * @param ev Name of the event
      * @param listener Callback function
-     * @reserved
-     * - "connect": This event is fired by the Socket instance upon connection **and** reconnection.
-     * - "connect_error": This event is fired upon connection failure.
-     * - "disconnect": This event is fired upon disconnection.
-     * @see [client-api-events](https://socket.io/docs/v4/client-api/#events-1)
      */
     on<Ev extends ReservedOrUserEventNames<ReservedEvents, ListenEvents>>(
         ev: Ev,


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behavior
- About `socket-io-client-emitter/Emitter` `on` method.
- It was difficult for us to know what the reserved event names were without looking at the docs.

### New behavior
![image](https://github.com/user-attachments/assets/57432ff9-f0ce-4a5f-a6af-a1b7e7d59841)
- I thought it would be better to use JSDoc without changing the types. This is because there is an advantage of auto-completion when using union, etc., but developers often use custom event names, so I thought the type could actually cause confusion.
- So I used JSDoc. If the user checks the JSDoc, they can see the scheduled event name and its brief description.
If developers are curious about more, I have linked [the docs](https://socket.io/docs/v4/client-api/#events-1).

### Other information (e.g. related issues)
- If you want to edit, change or delete content, please always leave a comment.
- I've only written about `on` at the moment, so if you think it would be good to write about something else as well, please let me know.

