### PR TITLE
specify return type for node websocket create funciton

### DIFF
--- a/packages/engine.io-client/lib/transports/websocket.node.ts
+++ b/packages/engine.io-client/lib/transports/websocket.node.ts
@@ -15,7 +15,7 @@ export class WS extends BaseWS {
     uri: string,
     protocols: string | string[] | undefined,
     opts: Record<string, any>,
-  ) {
+  ): WebSocket {
     if (this.socket?._cookieJar) {
       opts.headers = opts.headers || {};
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
This error appeared when updating from v4.7.5 to v4.8.0 of socket-io-client
```
node_modules/engine.io-client/build/esm/transports/websocket.node.d.ts:12:101 - error TS1340: Module 'ws' does not refer to a type, but is used as a type here. Did you mean 'typeof import('ws')'?

12     createSocket(uri: string, protocols: string | string[] | undefined, opts: Record<string, any>): import("ws");
                                                                                                       ~~~~~~~~~~~~


```

Not sure why the type inference isn't working properly and `websocket.node.d.ts` does indeed specify the return type of that function as the whole of `import("ws")` which doesn't make sense as the error states. 

### New behavior
With the return type specified in `websocket.node.ts` transport the type declaration now looks like this.

```
import { WebSocket } from "ws";
import type { Packet, RawData } from "engine.io-parser";
import { BaseWS } from "./websocket.js";
/**
 * WebSocket transport based on the `WebSocket` object provided by the `ws` package.
 *
 * Usage: Node.js, Deno (compat), Bun (compat)
 *
 * @see https://developer.mozilla.org/en-US/docs/Web/API/WebSocket
 * @see https://caniuse.com/mdn-api_websocket
 */
export declare class WS extends BaseWS {
    createSocket(uri: string, protocols: string | string[] | undefined, opts: Record<string, any>): WebSocket;
    doWrite(packet: Packet, data: RawData): void;
}
```

### Other information (e.g. related issues)


