### PR TITLE
chore(deps): update cookie to 0.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5643,14 +5643,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
-    "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -15170,7 +15162,7 @@
         "@types/node": ">=10.0.0",
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
-        "cookie": "~0.4.1",
+        "cookie": "~0.7.0",
         "cors": "~2.8.5",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
@@ -15206,6 +15198,15 @@
         "node": ">=10.0.0"
       }
     },
+    "packages/engine.io/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "packages/engine.io/node_modules/debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -15223,7 +15224,7 @@
       }
     },
     "packages/socket.io": {
-      "version": "4.7.5",
+      "version": "4.8.0",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.4",
@@ -15247,7 +15248,7 @@
       }
     },
     "packages/socket.io-client": {
-      "version": "4.7.5",
+      "version": "4.8.0",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",

--- a/packages/engine.io/package.json
+++ b/packages/engine.io/package.json
@@ -36,7 +36,7 @@
     "@types/node": ">=10.0.0",
     "accepts": "~1.3.4",
     "base64id": "2.0.0",
-    "cookie": "~0.4.1",
+    "cookie": "~0.7.0",
     "cors": "~2.8.5",
     "debug": "~4.3.1",
     "engine.io-parser": "~5.2.1",


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behavior

An existing dependency "[cookie](https://www.npmjs.com/package/cookie)" has a vulnerability.

### New behavior

 - "cookie" has been updated to a version that fixes the vulnerability.
 - The contents of the `package-lock.json` seem to have been inconsistent (see diff). I ran `npm i` to correct it.

close #5206

### Other information (e.g. related issues)

https://github.com/advisories/GHSA-pxg6-pf52-xh8x
https://avd.aquasec.com/nvd/2024/cve-2024-47764/
https://security.snyk.io/vuln/SNYK-JS-COOKIE-8163060