### PR TITLE
fix: correctly consume `ws` package

### DIFF
--- a/packages/engine.io-client/lib/transports/websocket.node.ts
+++ b/packages/engine.io-client/lib/transports/websocket.node.ts
@@ -1,4 +1,4 @@
-import { WebSocket } from "ws";
+import * as ws from "ws";
 import type { Packet, RawData } from "engine.io-parser";
 import { BaseWS } from "./websocket.js";
 
@@ -27,7 +27,7 @@ export class WS extends BaseWS {
         opts.headers.cookie.push(`${name}=${cookie.value}`);
       }
     }
-    return new WebSocket(uri, protocols, opts);
+    return new ws.WebSocket(uri, protocols, opts);
   }
 
   doWrite(packet: Packet, data: RawData) {


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

```
SyntaxError: Named export 'WebSocket' not found. The requested module 'ws' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'ws';
const { WebSocket } = pkg;
```

### New behavior

Works

### Other information (e.g. related issues)

Hitting this in https://github.com/immich-app/immich

I also saw a couple projects hitting this error when searching online, but didn't look closely at them to see if they're using `socket.io`/`engine.io`:
- https://web3auth.io/community/t/web3auth-version-7-0-4-build-issues-resolved/5789
- https://github.com/wevm/viem/issues/1202