### PR TITLE
add package.json entry point in socket.io package.json

### DIFF
--- a/packages/socket.io/package.json
+++ b/packages/socket.io/package.json
@@ -26,9 +26,12 @@
   "type": "commonjs",
   "main": "./dist/index.js",
   "exports": {
-    "types": "./dist/index.d.ts",
-    "import": "./wrapper.mjs",
-    "require": "./dist/index.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./wrapper.mjs",
+      "require": "./dist/index.js"
+     },
+    "./package.json": "./package.json"
   },
   "types": "./dist/index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behavior
For the `socket.io` package, its entry points don't include the `package.json` file

### New behavior
From now, it is included

### Other information (e.g. related issues)
This allows this entry to be `required` to perform additional checks

