### PR TITLE
fix: engine.io-client transport _port handle error

### DIFF
--- a/packages/engine.io-client/lib/transport.ts
+++ b/packages/engine.io-client/lib/transport.ts
@@ -192,7 +192,7 @@ export abstract class Transport extends Emitter<
   private _port() {
     if (
       this.opts.port &&
-      ((this.opts.secure && Number(this.opts.port !== 443)) ||
+      ((this.opts.secure && Number(this.opts.port) !== 443) ||
         (!this.opts.secure && Number(this.opts.port) !== 80))
     ) {
       return ":" + this.opts.port;


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
when port is "443" and this.opts.secure will return ":443"

### New behavior
when port is "443" and this.opts.secure will return ""

### Other information (e.g. related issues)


