### PR TITLE
Drain queue before emitting connect event.

### DIFF
--- a/packages/socket.io-client/lib/socket.ts
+++ b/packages/socket.io-client/lib/socket.ts
@@ -834,8 +834,8 @@ export class Socket<
     this._pid = pid; // defined only if connection state recovery is enabled
     this.connected = true;
     this.emitBuffered();
-    this.emitReserved("connect");
     this._drainQueue(true);
+    this.emitReserved("connect");
   }
 
   /**


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

Fixes: #5258 

### Current behavior
When the retries option is enabled in the Socket.IO client, the client emits the initial event twice inside the 'connect' handler.

### New behavior
The event inside the 'connect' handler should be emitted only once, regardless of whether the retries option is enabled or  disabled.

### Other information (e.g. related issues)
We can drain the queue before emitting the connect event.

