### PR TITLE
exclude the sender during the broadcast process, even if the sender has left the default room

### DIFF
--- a/packages/socket.io-adapter/lib/in-memory-adapter.ts
+++ b/packages/socket.io-adapter/lib/in-memory-adapter.ts
@@ -357,12 +357,22 @@ export class Adapter extends EventEmitter {
     }
   }
 
+  /**
+   * Computation of SIDs to exclude
+   * Even if the room does not exist, add it to exceptSids if it is a sid
+   *
+   * @param exceptRooms - Rooms and Sids(for broadcast)
+   */
   private computeExceptSids(exceptRooms?: Set<Room>) {
     const exceptSids = new Set();
     if (exceptRooms && exceptRooms.size > 0) {
       for (const room of exceptRooms) {
         if (this.rooms.has(room)) {
           this.rooms.get(room).forEach((sid) => exceptSids.add(sid));
+          continue;
+        }
+        if (this.sids.has(room)) {
+          exceptSids.add(room);
         }
       }
     }


### PR DESCRIPTION
Related issue: https://github.com/socketio/socket.io/issues/4524

### The kind of change this PR introduces

* [x] Bug fix  
* [ ] New feature  
* [ ] Documentation update  
* [ ] Code change to improve performance  
* [ ] Other  

### Current Behavior

When a client leaves the default room, they are not added to `exceptSids` in the `computeExceptSids` function during the broadcast process. The `sids` in the default room should be added to `exceptSids`, but the default room gets deleted when the client leaves it.

So, the sender that should be excluded during broadcasting ends up receiving the message.

<img width="1645" alt="image" src="https://github.com/user-attachments/assets/71de59f3-29a4-4432-bb70-9fa3ec8c0872" />

### New Behavior

If a room is not found in `this.rooms`, it checks whether the room exists in `this.sids`. If it does, the room is added to `exceptSids`. This ensures that the client is excluded from the broadcast if they are the sender, even when they are no longer in the default room.

So, as shown in the image below, the sender is successfully excluded as intended.

<img width="1670" alt="image" src="https://github.com/user-attachments/assets/0e6528de-5ac0-4186-8823-954a44549cc2" />


### Other Information (e.g., related issues)

Related issue: #4524  

### add one or more test cases, in order to avoid any regression in the future
<details>
<summary> packages/socket.io-adapter/test/index.ts </summary>

```typescript
it("should exclude the sender from broadcasting, even if they have left the default room.", () => {
    let ids: string[] = [];
    function socket(id: string, isSender: boolean = false) {
      return [
        id,
        {
          id,
          isSender,
          rooms: new Set<string>(),
          client: {
            writeToEngine(payload: any, opts: any) {
              if (!isSender) {
                ids.push(id);
              } else {
                throw new Error("Sender should not receive broadcast");
              }
            },
          },
        },
      ];
    }
    const nsp = {
      server: {
        encoder: {
          encode() {
            return ["123"];
          },
        },
      },
      // @ts-ignore
      sockets: new Map([socket("s1", true), socket("s2"), socket("s3")]),
    };
    const adapter = new Adapter(nsp);
    adapter.addAll("s1", new Set(["r1", "s1"]));
    adapter.addAll("s2", new Set(["r1"]));
    adapter.addAll("s3", new Set());

    // sender leaves default room
    adapter.del("s1", "s1");

    adapter.broadcast([], {
      rooms: new Set(),
      except: new Set(["s1"]),
    });
    expect(ids).to.eql(["s2", "s3"]);
  });
```
</details>

### make sure existing tests still pass
<details>
<summary> tests pass including new test </summary>

```bash
  cluster adapter
    broadcast
      ✔ broadcasts to all clients
      ✔ broadcasts to all clients in a namespace
      ✔ broadcasts to all clients in a room
      ✔ broadcasts to all clients except in room
      ✔ broadcasts to local clients only
      ✔ broadcasts with multiple acknowledgements (54ms)
      ✔ broadcasts with multiple acknowledgements (binary content)
      ✔ broadcasts with multiple acknowledgements (no client)
      ✔ broadcasts with multiple acknowledgements (timeout) (51ms)
      ✔ broadcasts with a single acknowledgement (local)
      ✔ broadcasts with a single acknowledgement (remote)
    socketsJoin
      ✔ makes all socket instances join the specified room
      ✔ makes the matching socket instances join the specified room
      ✔ makes the given socket instance join the specified room
    socketsLeave
      ✔ makes all socket instances leave the specified room
      ✔ makes the matching socket instances leave the specified room
      ✔ makes the given socket instance leave the specified room
    disconnectSockets
      ✔ makes all socket instances disconnect
      ✔ sends a packet before all socket instances disconnect
    fetchSockets
      ✔ returns all socket instances
      ✔ returns a single socket instance
      ✔ returns only local socket instances
    serverSideEmit
      ✔ sends an event to other server instances
      ✔ sends an event and receives a response from the other server instances
      ✔ sends an event but timeout if one server does not respond (5004ms)
      ✔ succeeds even if an instance leaves the cluster

  socket.io-adapter
    ✔ should exclude the sender from broadcasting, even if they have left the default room.
    ✔ should precompute the WebSocket frames when broadcasting
    utility methods
      fetchSockets
        ✔ returns the matching socket instances
        ✔ returns the matching socket instances within room
    events
      ✔ should emit a 'create-room' event
      ✔ should not emit a 'create-room' event if the room already exists
      ✔ should emit a 'join-room' event
      ✔ should not emit a 'join-room' event if the sid is already in the room
      ✔ should emit a 'leave-room' event with del method
      ✔ should not throw when calling del twice
      ✔ should emit a 'leave-room' event with delAll method
      ✔ should emit a 'delete-room' event
      ✔ should not emit a 'delete-room' event if there is another sid in the room
    connection state recovery
      ✔ should persist and restore session
      ✔ should restore missed packets
      ✔ should fail to restore an unknown session
      ✔ should fail to restore a known session with an unknown offset


  43 passing (5s)

```
</details>