### PR TITLE
Move WebSocketCtor reference inside createSocket method to support WebSocket mocking

### DIFF
--- a/packages/engine.io-client/lib/transports/websocket.ts
+++ b/packages/engine.io-client/lib/transports/websocket.ts
@@ -152,8 +152,6 @@ export abstract class BaseWS extends Transport {
   }
 }
 
-const WebSocketCtor = globalThis.WebSocket || globalThis.MozWebSocket;
-
 /**
  * WebSocket transport based on the built-in `WebSocket` object.
  *
@@ -169,6 +167,8 @@ export class WS extends BaseWS {
     protocols: string | string[] | undefined,
     opts: Record<string, any>,
   ) {
+    const WebSocketCtor = globalThis.WebSocket || globalThis.MozWebSocket;
+
     return !isReactNative
       ? protocols
         ? new WebSocketCtor(uri, protocols)


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behavior
The `WebSocketCtor` is defined at module scope which captures WebSocket reference before mocking libraries like MSW can intercept it. Since bundlers (webpack/vite) typically load engine.io-client before MSW, the original WebSocket implementation is used even when mocks are applied later.

### New behavior
`WebSocketCtor` reference is moved inside the `createSocket` method, ensuring it always uses the current value of globalThis.WebSocket at call time. This allows mocking libraries to properly intercept WebSocket connections in Socket.IO.

### Other information (e.g. related issues)
Fixes https://github.com/mswjs/socket.io-binding/issues/12
I've tested this solution with both webpack and vite, confirming it resolves the issue in both bundlers.
