### PR TITLE
fix(socket.io-adapter/#4645): message emits to all the rooms, if an empty array of rooms provided

### DIFF
--- a/packages/socket.io-adapter/lib/in-memory-adapter.ts
+++ b/packages/socket.io-adapter/lib/in-memory-adapter.ts
@@ -334,7 +334,7 @@ export class Adapter extends EventEmitter {
     const rooms = opts.rooms;
     const except = this.computeExceptSids(opts.except);
 
-    if (rooms.size) {
+    if (rooms.size !== undefined) {
       const ids = new Set();
       for (const room of rooms) {
         if (!this.rooms.has(room)) continue;


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix of https://github.com/socketio/socket.io/issues/4645
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

When broadcasting a message using `.to` with empty array, it broadacsts the message to every room:

```ts
io.to([]).emit("hello")
```

### New behavior

If an empty array provided, no message broadcasted


### Other information (e.g. related issues)

Fixes issue https://github.com/socketio/socket.io/issues/4645