### PR TITLE
Fix ArrayBuffer detached error with uWebSockets.js

### DIFF
--- a/packages/engine.io/lib/userver.ts
+++ b/packages/engine.io/lib/userver.ts
@@ -88,7 +88,7 @@ export class uServer extends BaseServer {
         },
         message: (ws, message, isBinary) => {
           ws.getUserData().transport.onData(
-            isBinary ? message : Buffer.from(message).toString(),
+            isBinary ? message.slice(0, message.byteLength) : Buffer.from(message).toString(),
           );
         },
         close: (ws, code, message) => {

--- a/packages/engine.io/wrapper.mjs
+++ b/packages/engine.io/wrapper.mjs
@@ -7,4 +7,5 @@ export {
   attach,
   parser,
   protocol,
+  uServer
 } from "./build/engine.io.js";


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
When using `engine.io` server with `uWebSockets.js`, the message buffer becomes detached after executing some async tasks, and throws `TypeError` when trying to access the buffer later on.
```
import uWebSocket from "uWebSockets.js";
import { uServer as Engine } from "engine.io";

const httpServer = uWebSocket.App().any("/*", (res, req) => {
	// handle regular HTTP request
}).listen("0.0.0.0", 808080, () => {
	console.log("HTTP server started!");
});

const eio = new Engine({
	transports: ["polling", "websocket"]
});

eio.on("connection", (socket) => {
	socket.on("close", () => {
		console.log("Socket closed");
	});
	socket.on("message", (buffer) => {
		console.log(buffer.toString()); // ok here

		someAsyncTask().then(() => {
			console.log(buffer.subarray(0, 3).toString()); // TypeError: Cannot perform Construct on a detached ArrayBuffer
		});
	});
});

eio.attach(httpServer);
```

### New behavior
The original `ArrayBuffer` passed by the `uWebSockets.js` is always copied to prevent it being detached. This matches the behavior for a regular `engine.io` server using the built-in `http` module.

The documentation of `uWebSockets.js` states that for the `message` handler, the given ArrayBuffer is valid during the lifetime of this callback (until first await or return) and will be neutered.

### Other information (e.g. related issues)


