### PR TITLE
chore(deps): ws@8.18.3, debug@4.4.1

### DIFF
--- a/examples/basic-websocket-client/package.json
+++ b/examples/basic-websocket-client/package.json
@@ -7,7 +7,7 @@
     "prettier": "^2.8.4",
     "rollup": "^3.20.2",
     "socket.io": "^4.6.1",
-    "ws": "^8.13.0"
+    "ws": "^8.18.3"
   },
   "scripts": {
     "bundle": "rollup -c",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2369,6 +2369,13 @@
         }
       }
     },
+    "node_modules/@puppeteer/browsers/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@puppeteer/browsers/node_modules/tar-fs": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
@@ -2768,6 +2775,24 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@socket.io/postgres-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/@socket.io/postgres-adapter/node_modules/socket.io-adapter": {
@@ -5986,11 +6011,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -6463,6 +6489,15 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/devtools/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/devtools/node_modules/node-fetch": {
       "version": "2.7.0",
@@ -10462,12 +10497,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/mocha/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
-    },
     "node_modules/mocha/node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -10505,9 +10534,10 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/mute-stream": {
       "version": "1.0.0",
@@ -12006,6 +12036,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/puppeteer-core/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/puppeteer-core/node_modules/proxy-agent": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.0.tgz",
@@ -13031,12 +13068,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
-    },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "node_modules/sentence-case": {
@@ -15457,9 +15488,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -15700,9 +15732,9 @@
         "base64id": "2.0.0",
         "cookie": "~0.7.2",
         "cors": "~2.8.5",
-        "debug": "~4.3.1",
+        "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1"
+        "ws": "~8.18.3"
       },
       "engines": {
         "node": ">=10.2.0"
@@ -15713,9 +15745,9 @@
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.1",
+        "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1",
+        "ws": "~8.18.3",
         "xmlhttprequest-ssl": "~2.1.1"
       }
     },
@@ -15750,6 +15782,12 @@
         }
       }
     },
+    "packages/engine.io/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
+    },
     "packages/socket.io": {
       "version": "4.8.1",
       "license": "MIT",
@@ -15757,7 +15795,7 @@
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
         "cors": "~2.8.5",
-        "debug": "~4.3.2",
+        "debug": "~4.4.1",
         "engine.io": "~6.6.0",
         "socket.io-adapter": "~2.5.2",
         "socket.io-parser": "~4.2.4"
@@ -15770,8 +15808,8 @@
       "version": "2.5.5",
       "license": "MIT",
       "dependencies": {
-        "debug": "~4.3.4",
-        "ws": "~8.17.1"
+        "debug": "~4.4.1",
+        "ws": "~8.18.3"
       }
     },
     "packages/socket.io-client": {
@@ -15779,7 +15817,7 @@
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.2",
+        "debug": "~4.4.1",
         "engine.io-client": "~6.6.1",
         "socket.io-parser": "~4.2.4"
       },
@@ -15803,13 +15841,19 @@
         }
       }
     },
+    "packages/socket.io-client/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
+    },
     "packages/socket.io-cluster-engine": {
       "name": "@socket.io/cluster-engine",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "~2.8.0",
-        "debug": "~4.3.3",
+        "debug": "~4.4.1",
         "engine.io": "~6.6.0",
         "engine.io-parser": "~5.2.3"
       },
@@ -15839,7 +15883,7 @@
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.1"
+        "debug": "~4.4.1"
       },
       "engines": {
         "node": ">=10.0.0"
@@ -15861,13 +15905,19 @@
         }
       }
     },
+    "packages/socket.io-parser/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
+    },
     "packages/socket.io-postgres-emitter": {
       "name": "@socket.io/postgres-emitter",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^2.7.0",
-        "debug": "~4.3.1"
+        "debug": "~4.4.1"
       }
     },
     "packages/socket.io-postgres-emitter/node_modules/debug": {
@@ -15886,6 +15936,12 @@
           "optional": true
         }
       }
+    },
+    "packages/socket.io-postgres-emitter/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "overrides": {
     "@types/estree": "0.0.52",
     "@types/lodash": "4.14.189",
-    "ws": "8.17.1"
+    "ws": "8.18.3"
   },
   "devDependencies": {
     "@babel/core": "^7.24.7",

--- a/packages/engine.io-client/package.json
+++ b/packages/engine.io-client/package.json
@@ -53,9 +53,9 @@
   ],
   "dependencies": {
     "@socket.io/component-emitter": "~3.1.0",
-    "debug": "~4.3.1",
+    "debug": "~4.4.1",
     "engine.io-parser": "~5.2.1",
-    "ws": "~8.17.1",
+    "ws": "~8.18.3",
     "xmlhttprequest-ssl": "~2.1.1"
   },
   "scripts": {

--- a/packages/engine.io/package.json
+++ b/packages/engine.io/package.json
@@ -37,9 +37,9 @@
     "base64id": "2.0.0",
     "cookie": "~0.7.2",
     "cors": "~2.8.5",
-    "debug": "~4.3.1",
+    "debug": "~4.4.1",
     "engine.io-parser": "~5.2.1",
-    "ws": "~8.17.1"
+    "ws": "~8.18.3"
   },
   "scripts": {
     "compile": "rimraf ./build && tsc",

--- a/packages/socket.io-adapter/package.json
+++ b/packages/socket.io-adapter/package.json
@@ -17,8 +17,8 @@
   "types": "./dist/index.d.ts",
   "description": "default socket.io in-memory adapter",
   "dependencies": {
-    "debug": "~4.3.4",
-    "ws": "~8.17.1"
+    "debug": "~4.4.1",
+    "ws": "~8.18.3"
   },
   "scripts": {
     "compile": "rimraf ./dist && tsc",

--- a/packages/socket.io-client/package.json
+++ b/packages/socket.io-client/package.json
@@ -46,7 +46,7 @@
   "types": "./build/esm/index.d.ts",
   "dependencies": {
     "@socket.io/component-emitter": "~3.1.0",
-    "debug": "~4.3.2",
+    "debug": "~4.4.1",
     "engine.io-client": "~6.6.1",
     "socket.io-parser": "~4.2.4"
   },

--- a/packages/socket.io-cluster-engine/package.json
+++ b/packages/socket.io-cluster-engine/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@msgpack/msgpack": "~2.8.0",
-    "debug": "~4.3.3",
+    "debug": "~4.4.1",
     "engine.io": "~6.6.0",
     "engine.io-parser": "~5.2.3"
   },

--- a/packages/socket.io-parser/package.json
+++ b/packages/socket.io-parser/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@socket.io/component-emitter": "~3.1.0",
-    "debug": "~4.3.1"
+    "debug": "~4.4.1"
   },
   "scripts": {
     "compile": "rimraf ./build && tsc && tsc -p tsconfig.esm.json && ./postcompile.sh",

--- a/packages/socket.io-postgres-emitter/package.json
+++ b/packages/socket.io-postgres-emitter/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@msgpack/msgpack": "^2.7.0",
-    "debug": "~4.3.1"
+    "debug": "~4.4.1"
   },
   "keywords": [
     "socket.io",

--- a/packages/socket.io/package.json
+++ b/packages/socket.io/package.json
@@ -53,7 +53,7 @@
     "accepts": "~1.3.4",
     "base64id": "~2.0.0",
     "cors": "~2.8.5",
-    "debug": "~4.3.2",
+    "debug": "~4.4.1",
     "engine.io": "~6.6.0",
     "socket.io-adapter": "~2.5.2",
     "socket.io-parser": "~4.2.4"


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other - deps upgrade

### Current behavior

Packages use older minors of ws and debug.

### New behavior

Upgraded to latest versions of ws and debug.

### Other information (e.g. related issues)

Noticed these cause multiple versions on our end and conflict with openai's peerDep of ws 8.18.x. Had to do an override to get it sorted, so here's a PR.

https://github.com/websockets/ws/releases/tag/8.18.3
https://github.com/debug-js/debug/releases/tag/4.4.1