### PR TITLE
fix(socket.io): improve `close()` function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15507,7 +15507,7 @@
       }
     },
     "packages/engine.io": {
-      "version": "6.6.3",
+      "version": "6.6.4",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.12",

--- a/packages/socket.io/lib/index.ts
+++ b/packages/socket.io/lib/index.ts
@@ -821,7 +821,17 @@ export class Server<
     restoreAdapter();
 
     if (this.httpServer) {
-      this.httpServer.close(fn);
+      return new Promise<void>((resolve, reject) => {
+        this.httpServer.close((err) => {
+          if (err) {
+            fn && fn(err);
+            reject(err);
+          } else {
+            fn && fn();
+            resolve();
+          }
+        });
+      });
     } else {
       fn && fn();
     }


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

After https://github.com/socketio/socket.io/pull/4971 the usage of the `close()` function has become confusing and sometimes misleading.

Since `close()` now returns a Promise, I would expect the `httpServer` to close when the promise is resolved. However, this is not the case.

```ts
await io.close();
// httpServer not closed yet
```

Also, in order to catch all possible errors, I need to use a mixed style of async/await and callbacks:

```ts
io.close(error => {
  if (error) {
    // error here
  }
}).catch(error => {
  // another error here
});
```


### New behavior

```ts
await io.close();
// httpServer closed
```

```ts
io.close().catch(error => {
  // all errors here
});
```