### PR TITLE
Export DisconnectDescription type directly from 'socket.io-client'

### DIFF
--- a/packages/socket.io-client/lib/index.ts
+++ b/packages/socket.io-client/lib/index.ts
@@ -1,6 +1,6 @@
 import { url } from "./url.js";
 import { Manager, ManagerOptions } from "./manager.js";
-import { Socket, SocketOptions } from "./socket.js";
+import { DisconnectDescription, Socket, SocketOptions } from "./socket.js";
 import debugModule from "debug"; // debug()
 
 const debug = debugModule("socket.io-client"); // debug()
@@ -91,6 +91,7 @@ export { protocol } from "socket.io-parser";
  */
 
 export {
+  DisconnectDescription,
   Manager,
   ManagerOptions,
   Socket,


### PR DESCRIPTION

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
The type `DisconnectDescription` is only accessible from 'socket.io-client/build/esm/socket'.

### New behavior
The type `DisconnectDescription` is accessible from 'socket.io-client'

### Other information (e.g. related issues)


