### PR TITLE
feat(socket.io): leave multiple rooms at once

### DIFF
--- a/packages/socket.io-adapter/test/index.ts
+++ b/packages/socket.io-adapter/test/index.ts
@@ -26,6 +26,19 @@ describe("socket.io-adapter", () => {
     expect(adapter.sids.has("s2")).to.be(false);
   });
 
+  it("should remove multiple rooms with a single call", () => {
+    const adapter = new Adapter({ server: { encoder: null } });
+    adapter.addAll("s1", new Set(["r1", "r2", "r3"]));
+
+    adapter.del("s1", new Set(["r1", "r3"]));
+
+    expect(adapter.rooms.has("r1")).to.be(false);
+    expect(adapter.rooms.has("r3")).to.be(false);
+    expect(adapter.rooms.has("r2")).to.be(true);
+    expect(adapter.sids.get("s1").size).to.be(1);
+    expect(adapter.sids.get("s1").has("r2")).to.be(true);
+  });
+
   it("should return a list of sockets", async () => {
     const adapter = new Adapter({
       server: { encoder: null },

--- a/packages/socket.io/lib/socket.ts
+++ b/packages/socket.io/lib/socket.ts
@@ -476,16 +476,19 @@ export class Socket<
    *   socket.leave("room1");
    *
    *   // leave multiple rooms
-   *   socket.leave("room1").leave("room2");
+   *   socket.leave(["room1", "room2"]);
    * });
    *
-   * @param {String} room
+   * @param {String|Array} rooms - room or array of rooms
    * @return a Promise or nothing, depending on the adapter
    */
-  public leave(room: string): Promise<void> | void {
-    debug("leave room %s", room);
+  public leave(rooms: Room | Array<Room>): Promise<void> | void {
+    debug("leave room %s", rooms);
 
-    return this.adapter.del(this.id, room);
+    return this.adapter.del(
+      this.id,
+      new Set(Array.isArray(rooms) ? rooms : [rooms]),
+    );
   }
 
   /**

--- a/packages/socket.io/test/socket.ts
+++ b/packages/socket.io/test/socket.ts
@@ -941,6 +941,23 @@ describe("socket", () => {
     });
   });
 
+  it("should leave multiple rooms at once", (done) => {
+    const io = new Server(0);
+    const client = createClient(io, "/");
+
+    io.on("connection", (socket) => {
+      Promise.resolve(socket.join(["room1", "room2"]))
+        .then(() => Promise.resolve(socket.leave(["room1", "room2"])))
+        .then(() => {
+          const adapter = io.of("/").adapter;
+          expect(adapter.rooms.has("room1")).to.be(false);
+          expect(adapter.rooms.has("room2")).to.be(false);
+          success(done, io, client);
+        })
+        .catch(done);
+    });
+  });
+
   describe("onAny", () => {
     it("should call listener", (done) => {
       const io = new Server(0);


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
Can only leave single room with Socket.leave() method

### New behavior
Server-side sockets can now leave several rooms in a single socket.leave([...]) call. The in-memory adapter (and tests) were updated so Adapter.del() accepts a Set<Room>, keeping server state consistent without per-room calls.

### Other information (e.g. related issues)
#5391 

