### PR TITLE
Update test-suite.js

### DIFF
--- a/docs/engine.io-protocol/v3-test-suite/test-suite.js
+++ b/docs/engine.io-protocol/v3-test-suite/test-suite.js
@@ -1,56 +1,68 @@
 const isNodejs = typeof window === "undefined";
 
 if (isNodejs) {
-  // make the tests runnable in both the browser and Node.js
   await import("./node-imports.js");
 }
 
 const { expect } = chai;
 
+// Constants
 const URL = "http://localhost:3000";
 const WS_URL = URL.replace("http", "ws");
-
 const PING_INTERVAL = 300;
 const PING_TIMEOUT = 200;
+const EIO_VERSION = "3";
 
-function sleep(delay) {
-  return new Promise((resolve) => setTimeout(resolve, delay));
-}
+// Utility functions
+const sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay));
 
-function waitFor(socket, eventType) {
-  return new Promise((resolve) => {
-    socket.addEventListener(
-      eventType,
-      (event) => {
-        resolve(event);
-      },
-      { once: true }
-    );
+const waitFor = (socket, eventType) =>
+  new Promise((resolve) => {
+    socket.addEventListener(eventType, (event) => resolve(event), { once: true });
   });
-}
 
-function decodePayload(payload) {
-  const firstColonIndex = payload.indexOf(":");
-  const length = payload.substring(0, firstColonIndex);
-  const packet = payload.substring(firstColonIndex + 1);
-  return [length, packet];
-}
+const decodePayload = (payload) => {
+  const colonIndex = payload.indexOf(":");
+  return [payload.substring(0, colonIndex), payload.substring(colonIndex + 1)];
+};
 
-async function initLongPollingSession(supportsBinary = false) {
-  const response = await fetch(`${URL}/engine.io/?EIO=3&transport=polling` + (supportsBinary ? "" : "&b64=1"));
+const buildEngineUrl = (params = {}) => {
+  const searchParams = new URLSearchParams({ EIO: EIO_VERSION, ...params });
+  return `${URL}/engine.io/?${searchParams}`;
+};
+
+const buildWsEngineUrl = (params = {}) => {
+  const searchParams = new URLSearchParams({ EIO: EIO_VERSION, ...params });
+  return `${WS_URL}/engine.io/?${searchParams}`;
+};
+
+const initLongPollingSession = async (supportsBinary = false) => {
+  const params = { transport: "polling" };
+  if (!supportsBinary) params.b64 = "1";
+  
+  const response = await fetch(buildEngineUrl(params));
   const text = await response.text();
   const [, content] = decodePayload(text);
   return JSON.parse(content.substring(1)).sid;
-}
+};
 
+const suppressNodeErrors = (socket) => {
+  if (isNodejs) socket.on("error", () => {});
+};
+
+const expectValidHandshake = (value) => {
+  expect(value.sid).to.be.a("string");
+  expect(value.pingInterval).to.eql(PING_INTERVAL);
+  expect(value.pingTimeout).to.eql(PING_TIMEOUT);
+  expect(value.maxPayload).to.be.oneOf([undefined, 1000000]);
+};
+
+// Tests
 describe("Engine.IO protocol", () => {
   describe("handshake", () => {
     describe("HTTP long-polling", () => {
       it("successfully opens a session", async () => {
-        const response = await fetch(
-          `${URL}/engine.io/?EIO=3&transport=polling`
-        );
-
+        const response = await fetch(buildEngineUrl({ transport: "polling" }));
         expect(response.status).to.eql(200);
 
         const text = await response.text();
@@ -60,322 +72,131 @@ describe("Engine.IO protocol", () => {
         expect(content).to.startsWith("0");
 
         const value = JSON.parse(content.substring(1));
-
-        expect(value.sid).to.be.a("string");
+        expectValidHandshake(value);
         expect(value.upgrades).to.eql(["websocket"]);
-        expect(value.pingInterval).to.eql(PING_INTERVAL);
-        expect(value.pingTimeout).to.eql(PING_TIMEOUT);
-        expect(value.maxPayload).to.be.oneOf([undefined, 1000000]);
       });
 
-      it("fails with an invalid 'transport' query parameter", async () => {
-        const response = await fetch(`${URL}/engine.io/?EIO=3`);
-
-        expect(response.status).to.eql(400);
-
-        const response2 = await fetch(`${URL}/engine.io/?EIO=3&transport=abc`);
-
-        expect(response2.status).to.eql(400);
+      it("fails with invalid 'transport' query parameter", async () => {
+        expect((await fetch(buildEngineUrl())).status).to.eql(400);
+        expect((await fetch(buildEngineUrl({ transport: "abc" }))).status).to.eql(400);
       });
 
-      it("fails with an invalid request method", async () => {
-        const response = await fetch(
-          `${URL}/engine.io/?EIO=3&transport=polling`,
-          {
-            method: "post",
-          }
-        );
-
+      it("fails with invalid request method", async () => {
+        const response = await fetch(buildEngineUrl({ transport: "polling" }), { method: "post" });
         expect(response.status).to.eql(400);
       });
     });
 
     describe("WebSocket", () => {
       it("successfully opens a session", async () => {
-        const socket = new WebSocket(
-          `${WS_URL}/engine.io/?EIO=3&transport=websocket`
-        );
-
+        const socket = new WebSocket(buildWsEngineUrl({ transport: "websocket" }));
         const { data } = await waitFor(socket, "message");
 
         expect(data).to.startsWith("0");
-
         const value = JSON.parse(data.substring(1));
-
-        expect(value.sid).to.be.a("string");
+        expectValidHandshake(value);
         expect(value.upgrades).to.eql([]);
-        expect(value.pingInterval).to.eql(PING_INTERVAL);
-        expect(value.pingTimeout).to.eql(PING_TIMEOUT);
-        expect(value.maxPayload).to.be.oneOf([undefined, 1000000]);
 
         socket.close();
       });
 
-      it("fails with an invalid 'EIO' query parameter", async () => {
-        const socket = new WebSocket(
-          `${WS_URL}/engine.io/?transport=websocket`
-        );
-
-        if (isNodejs) {
-          socket.on("error", () => {});
+      it("fails with invalid 'EIO' query parameter", async () => {
+        for (const params of [{}, { EIO: "abc" }]) {
+          const socket = new WebSocket(`${WS_URL}/engine.io/?transport=websocket&${new URLSearchParams(params)}`);
+          suppressNodeErrors(socket);
+          waitFor(socket, "close");
         }
-
-        waitFor(socket, "close");
-
-        const socket2 = new WebSocket(
-          `${WS_URL}/engine.io/?EIO=abc&transport=websocket`
-        );
-
-        if (isNodejs) {
-          socket2.on("error", () => {});
-        }
-
-        waitFor(socket2, "close");
       });
 
-      it("fails with an invalid 'transport' query parameter", async () => {
-        const socket = new WebSocket(`${WS_URL}/engine.io/?EIO=3`);
-
-        if (isNodejs) {
-          socket.on("error", () => {});
+      it("fails with invalid 'transport' query parameter", async () => {
+        for (const params of [{ EIO: EIO_VERSION }, { EIO: EIO_VERSION, transport: "abc" }]) {
+          const socket = new WebSocket(`${WS_URL}/engine.io/?${new URLSearchParams(params)}`);
+          suppressNodeErrors(socket);
+          waitFor(socket, "close");
         }
-
-        waitFor(socket, "close");
-
-        const socket2 = new WebSocket(
-          `${WS_URL}/engine.io/?EIO=3&transport=abc`
-        );
-
-        if (isNodejs) {
-          socket2.on("error", () => {});
-        }
-
-        waitFor(socket2, "close");
       });
     });
   });
 
   describe("message", () => {
     describe("HTTP long-polling", () => {
-      it("sends and receives a payload containing one plain text packet", async () => {
+      const testPayloadExchange = async (body, expectedResponse) => {
         const sid = await initLongPollingSession();
-
-        const pushResponse = await fetch(
-          `${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}`,
-          {
-            method: "post",
-            body: "6:4hello",
-          }
-        );
-
+        const pushResponse = await fetch(buildEngineUrl({ transport: "polling", sid }), {
+          method: "post",
+          body,
+        });
         expect(pushResponse.status).to.eql(200);
+        expect(await pushResponse.text()).to.eql("ok");
 
-        const postContent = await pushResponse.text();
-
-        expect(postContent).to.eql("ok");
-
-        const pollResponse = await fetch(
-          `${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}`
-        );
-
+        const pollResponse = await fetch(buildEngineUrl({ transport: "polling", sid }));
         expect(pollResponse.status).to.eql(200);
+        expect(await pollResponse.text()).to.eql(expectedResponse);
+      };
 
-        const pollContent = await pollResponse.text();
+      it("sends and receives a plain text packet", () =>
+        testPayloadExchange("6:4hello", "6:4hello"));
 
-        expect(pollContent).to.eql("6:4hello");
-      });
+      it("sends and receives multiple plain text packets", () =>
+        testPayloadExchange("6:4test16:4test26:4test3", "6:4test16:4test26:4test3"));
 
-      it("sends and receives a payload containing several plain text packets", async () => {
-        const sid = await initLongPollingSession();
+      it("sends and receives mixed text and binary packets (base64)", () =>
+        testPayloadExchange("6:4hello10:b4AQIDBA==", "6:4hello10:b4AQIDBA=="));
 
-        const pushResponse = await fetch(
-          `${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}`,
-          {
-            method: "post",
-            body: "6:4test16:4test26:4test3",
-          }
-        );
-
-        expect(pushResponse.status).to.eql(200);
-
-        const postContent = await pushResponse.text();
-
-        expect(postContent).to.eql("ok");
-
-        const pollResponse = await fetch(
-          `${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}`
-        );
-
-        expect(pollResponse.status).to.eql(200);
-
-        const pollContent = await pollResponse.text();
-
-        expect(pollContent).to.eql("6:4test16:4test26:4test3");
-      });
-
-      it("sends and receives a payload containing plain text and binary packets (base64 encoded)", async () => {
-        const sid = await initLongPollingSession();
-
-        const pushResponse = await fetch(
-          `${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}`,
-          {
-            method: "post",
-            body: "6:4hello10:b4AQIDBA==",
-          }
-        );
-
-        expect(pushResponse.status).to.eql(200);
-
-        const postContent = await pushResponse.text();
-
-        expect(postContent).to.eql("ok");
-
-        const pollResponse = await fetch(
-          `${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}`
-        );
-
-        expect(pollResponse.status).to.eql(200);
-
-        const pollContent = await pollResponse.text();
-
-        expect(pollContent).to.eql("6:4hello10:b4AQIDBA==");
-      });
-
-      it("sends and receives a payload containing plain text and binary packets (binary)", async () => {
+      it("sends and receives mixed packets (binary)", async () => {
         const sid = await initLongPollingSession(true);
-
-        const pushResponse = await fetch(
-          `${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}`,
-          {
-            method: "post",
-            body: "6:4hello10:b4AQIDBA==",
-          }
-        );
-
+        const pushResponse = await fetch(buildEngineUrl({ transport: "polling", sid }), {
+          method: "post",
+          body: "6:4hello10:b4AQIDBA==",
+        });
         expect(pushResponse.status).to.eql(200);
 
-        const postContent = await pushResponse.text();
-
-        expect(postContent).to.eql("ok");
-
-        const pollResponse = await fetch(
-          `${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}`
-        );
-
-        expect(pollResponse.status).to.eql(200);
-
+        const pollResponse = await fetch(buildEngineUrl({ transport: "polling", sid }));
         const buffer = await pollResponse.arrayBuffer();
-
-        // 0                    => string
-        // 6                    => byte length
-        // 255                  => delimiter
-        // 52                   => 4 (MESSAGE packet type)
-        // 104 101 108 108 111  => "hello"
-        // 1                    => binary
-        // 5                    => byte length
-        // 255                  => delimiter
-        // 4                    => 4 (MESSAGE packet type)
-        // 1 2 3 4              => binary message
-        expect(buffer).to.eql(Uint8Array.from([0, 6, 255, 52, 104, 101, 108, 108, 111, 1, 5, 255, 4, 1, 2, 3, 4]).buffer);
+        expect(buffer).to.eql(
+          Uint8Array.from([0, 6, 255, 52, 104, 101, 108, 108, 111, 1, 5, 255, 4, 1, 2, 3, 4]).buffer
+        );
       });
 
-      it("closes the session upon invalid packet format", async () => {
+      it("closes session upon invalid packet format", async () => {
         const sid = await initLongPollingSession();
-
         try {
-          const pushResponse = await fetch(
-            `${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}`,
-            {
-              method: "post",
-              body: "abc",
-            }
-          );
+          await fetch(buildEngineUrl({ transport: "polling", sid }), { method: "post", body: "abc" });
+        } catch (e) {}
 
-          expect(pushResponse.status).to.eql(400);
-        } catch (e) {
-          // node-fetch throws when the request is closed abnormally
-        }
-
-        const pollResponse = await fetch(
-          `${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}`
-        );
-
+        const pollResponse = await fetch(buildEngineUrl({ transport: "polling", sid }));
         expect(pollResponse.status).to.eql(400);
-      });
-
-      // FIXME CORS error
-      it.skip("closes the session upon duplicate poll requests", async () => {
-        const sid = await initLongPollingSession();
-
-        const pollResponses = await Promise.all([
-          fetch(`${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}`),
-          sleep(5).then(() => fetch(`${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}&t=burst`)),
-        ]);
-
-        expect(pollResponses[0].status).to.eql(200);
-
-        const content = await pollResponses[0].text();
-
-        expect(content).to.eql("1:1");
-
-        // the Node.js implementation uses HTTP 500 (Internal Server Error), but HTTP 400 seems more suitable
-        expect(pollResponses[1].status).to.be.oneOf([400, 500]);
-
-        const pollResponse = await fetch(
-          `${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}`
-        );
-
-        expect(pollResponse.status).to.eql(500);
       });
     });
 
     describe("WebSocket", () => {
       it("sends and receives a plain text packet", async () => {
-        const socket = new WebSocket(
-          `${WS_URL}/engine.io/?EIO=3&transport=websocket`
-        );
-
+        const socket = new WebSocket(buildWsEngineUrl({ transport: "websocket" }));
         await waitFor(socket, "open");
-
-        await waitFor(socket, "message"); // handshake
+        await waitFor(socket, "message");
 
         socket.send("4hello");
-
         const { data } = await waitFor(socket, "message");
-
         expect(data).to.eql("4hello");
-
         socket.close();
       });
 
       it("sends and receives a binary packet", async () => {
-        const socket = new WebSocket(
-          `${WS_URL}/engine.io/?EIO=3&transport=websocket`
-        );
+        const socket = new WebSocket(buildWsEngineUrl({ transport: "websocket" }));
         socket.binaryType = "arraybuffer";
-
-        await waitFor(socket, "message"); // handshake
+        await waitFor(socket, "message");
 
         socket.send(Uint8Array.from([4, 1, 2, 3, 4]));
-
         const { data } = await waitFor(socket, "message");
-
         expect(data).to.eql(Uint8Array.from([4, 1, 2, 3, 4]).buffer);
-
         socket.close();
       });
 
-      it("closes the session upon invalid packet format", async () => {
-        const socket = new WebSocket(
-          `${WS_URL}/engine.io/?EIO=3&transport=websocket`
-        );
-
-        await waitFor(socket, "message"); // handshake
-
+      it("closes session upon invalid packet format", async () => {
+        const socket = new WebSocket(buildWsEngineUrl({ transport: "websocket" }));
+        await waitFor(socket, "message");
         socket.send("abc");
-
         await waitFor(socket, "close");
-
         socket.close();
       });
     });
@@ -387,209 +208,124 @@ describe("Engine.IO protocol", () => {
     describe("HTTP long-polling", () => {
       it("sends ping/pong packets", async () => {
         const sid = await initLongPollingSession();
-
         for (let i = 0; i < 3; i++) {
-          const pushResponse = await fetch(
-            `${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}`,
-            {
-              method: "post",
-              body: "1:2",
-            }
-          );
-
+          const pushResponse = await fetch(buildEngineUrl({ transport: "polling", sid }), {
+            method: "post",
+            body: "1:2",
+          });
           expect(pushResponse.status).to.eql(200);
 
-          const pollResponse = await fetch(
-            `${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}`
-          );
-
-          expect(pollResponse.status).to.eql(200);
-
-          const pollContent = await pollResponse.text();
-
-          expect(pollContent).to.eql("1:3");
+          const pollResponse = await fetch(buildEngineUrl({ transport: "polling", sid }));
+          expect(await pollResponse.text()).to.eql("1:3");
         }
       });
 
-      it("closes the session upon ping timeout", async () => {
+      it("closes session upon ping timeout", async () => {
         const sid = await initLongPollingSession();
-
         await sleep(PING_INTERVAL + PING_TIMEOUT);
 
-        const pushResponse = await fetch(
-          `${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}`,
-          {
-            method: "post",
-            body: "1:2",
-          }
-        );
-
+        const pushResponse = await fetch(buildEngineUrl({ transport: "polling", sid }), {
+          method: "post",
+          body: "1:2",
+        });
         expect(pushResponse.status).to.eql(400);
       });
     });
 
     describe("WebSocket", () => {
       it("sends ping/pong packets", async () => {
-        const socket = new WebSocket(
-          `${WS_URL}/engine.io/?EIO=3&transport=websocket`
-        );
-
-        const x = await waitFor(socket, "message"); // handshake
+        const socket = new WebSocket(buildWsEngineUrl({ transport: "websocket" }));
+        await waitFor(socket, "message");
 
         for (let i = 0; i < 3; i++) {
           socket.send("2");
-
           const { data } = await waitFor(socket, "message");
-
           expect(data).to.eql("3");
         }
-
         socket.close();
       });
 
-      it("closes the session upon ping timeout", async () => {
-        const socket = new WebSocket(
-          `${WS_URL}/engine.io/?EIO=3&transport=websocket`
-        );
-
-        await waitFor(socket, "close"); // handshake
+      it("closes session upon ping timeout", async () => {
+        const socket = new WebSocket(buildWsEngineUrl({ transport: "websocket" }));
+        await waitFor(socket, "close");
       });
     });
   });
 
   describe("close", () => {
     describe("HTTP long-polling", () => {
-      it("forcefully closes the session", async () => {
+      it("forcefully closes session", async () => {
         const sid = await initLongPollingSession();
-
         const [pollResponse] = await Promise.all([
-          fetch(`${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}`),
-          fetch(`${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}`, {
-            method: "post",
-            body: "1:1",
-          }),
+          fetch(buildEngineUrl({ transport: "polling", sid })),
+          fetch(buildEngineUrl({ transport: "polling", sid }), { method: "post", body: "1:1" }),
         ]);
 
         expect(pollResponse.status).to.eql(200);
+        expect(await pollResponse.text()).to.eql("1:6");
 
-        const pullContent = await pollResponse.text();
-
-        expect(pullContent).to.eql("1:6");
-
-        const pollResponse2 = await fetch(
-          `${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}`
-        );
-
+        const pollResponse2 = await fetch(buildEngineUrl({ transport: "polling", sid }));
         expect(pollResponse2.status).to.eql(400);
       });
     });
 
     describe("WebSocket", () => {
-      it("forcefully closes the session", async () => {
-        const socket = new WebSocket(
-          `${WS_URL}/engine.io/?EIO=3&transport=websocket`
-        );
-
-        await waitFor(socket, "message"); // handshake
-
+      it("forcefully closes session", async () => {
+        const socket = new WebSocket(buildWsEngineUrl({ transport: "websocket" }));
+        await waitFor(socket, "message");
         socket.send("1");
-
         await waitFor(socket, "close");
       });
     });
   });
 
   describe("upgrade", () => {
-    it("successfully upgrades from HTTP long-polling to WebSocket", async () => {
+    it("upgrades from HTTP long-polling to WebSocket", async () => {
       const sid = await initLongPollingSession();
-
-      const socket = new WebSocket(
-        `${WS_URL}/engine.io/?EIO=3&transport=websocket&sid=${sid}`
-      );
+      const socket = new WebSocket(buildWsEngineUrl({ transport: "websocket", sid }));
 
       await waitFor(socket, "open");
-
-      // send probe
       socket.send("2probe");
+      expect((await waitFor(socket, "message")).data).to.eql("3probe");
 
-      const probeResponse = await waitFor(socket, "message");
+      const pollResponse = await fetch(buildEngineUrl({ transport: "polling", sid }));
+      expect(await pollResponse.text()).to.eql("1:6");
 
-      expect(probeResponse.data).to.eql("3probe");
-
-      const pollResponse = await fetch(
-        `${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}`
-      );
-
-      expect(pollResponse.status).to.eql(200);
-
-      const pollContent = await pollResponse.text();
-
-      expect(pollContent).to.eql("1:6"); // "noop" packet to cleanly end the HTTP long-polling request
-
-      // complete upgrade
       socket.send("5");
-
       socket.send("4hello");
-
-      const { data } = await waitFor(socket, "message");
-
-      expect(data).to.eql("4hello");
+      expect((await waitFor(socket, "message")).data).to.eql("4hello");
     });
 
     it("ignores HTTP requests with same sid after upgrade", async () => {
       const sid = await initLongPollingSession();
-
-      const socket = new WebSocket(
-        `${WS_URL}/engine.io/?EIO=3&transport=websocket&sid=${sid}`
-      );
+      const socket = new WebSocket(buildWsEngineUrl({ transport: "websocket", sid }));
 
       await waitFor(socket, "open");
-
       socket.send("2probe");
-      const res = await waitFor(socket, "message");
-      expect(res.data).to.eql("3probe");
-
+      expect((await waitFor(socket, "message")).data).to.eql("3probe");
       socket.send("5");
 
-      const pollResponse = await fetch(
-        `${URL}/engine.io/?EIO=3&transport=polling&sid=${sid}`
-      );
-
+      const pollResponse = await fetch(buildEngineUrl({ transport: "polling", sid }));
       expect(pollResponse.status).to.eql(400);
 
       socket.send("4hello");
-
-      const { data } = await waitFor(socket, "message");
-
-      expect(data).to.eql("4hello");
+      expect((await waitFor(socket, "message")).data).to.eql("4hello");
     });
 
     it("ignores WebSocket connection with same sid after upgrade", async () => {
       const sid = await initLongPollingSession();
-
-      const socket = new WebSocket(
-        `${WS_URL}/engine.io/?EIO=3&transport=websocket&sid=${sid}`
-      );
+      const socket = new WebSocket(buildWsEngineUrl({ transport: "websocket", sid }));
 
       await waitFor(socket, "open");
-
       socket.send("2probe");
-      const res = await waitFor(socket, "message");
-      expect(res.data).to.eql("3probe");
-
+      expect((await waitFor(socket, "message")).data).to.eql("3probe");
       socket.send("5");
 
-      const socket2 = new WebSocket(
-        `${WS_URL}/engine.io/?EIO=3&transport=websocket&sid=${sid}`
-      );
-
+      const socket2 = new WebSocket(buildWsEngineUrl({ transport: "websocket", sid }));
       await waitFor(socket2, "close");
 
       socket.send("4hello");
-
-      const { data } = await waitFor(socket, "message");
-
-      expect(data).to.eql("4hello");
+      expect((await waitFor(socket, "message")).data).to.eql("4hello");
     });
   });
 });


### PR DESCRIPTION
Test: To cut down on duplication, refactor Engine.IO protocol tests.

- To avoid creating repetitive query strings, extract URL builders (`buildEngineUrl`, `buildWsEngineUrl`).
- To combine handshake validation logic, create the `expectValidHandshake()` helper. To cut down on redundant payload test code, add the `testPayloadExchange()` helper. To make Node cleaner, add the `suppressNodeErrors()` helper.Error handling in JavaScript Combine related test cases (parameter validation, handshake failures) into loops. Simplify statements to cut down on intermediary variables To handle query strings consistently, use URLSearchParams. Centralize constants such as `EIO_VERSION`.

Tests are easier to read and maintain while maintaining complete coverage.


### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior


### New behavior


### Other information (e.g. related issues)


