### PR TITLE
fix(types): allow emitWithAck for events with void callbacks

### DIFF
--- a/packages/socket.io/lib/typed-events.ts
+++ b/packages/socket.io/lib/typed-events.ts
@@ -22,8 +22,6 @@ export type EventNames<Map extends EventsMap> = keyof Map & (string | symbol);
 
 /**
  * Returns a union type containing all the keys of an event map that have an acknowledgement callback.
- *
- * That also have *some* data coming in.
  */
 export type EventNamesWithAck<
   Map extends EventsMap,
@@ -32,11 +30,11 @@ export type EventNamesWithAck<
   Last<Parameters<Map[K]>> | Map[K],
   K,
   K extends (
-    Last<Parameters<Map[K]>> extends (...args: any[]) => any
-      ? FirstNonErrorArg<Last<Parameters<Map[K]>>> extends void
-        ? never
-        : K
-      : never
+    Parameters<Map[K]> extends never[]
+      ? never
+      : Last<Parameters<Map[K]>> extends (...args: any[]) => any
+        ? K
+        : never
   )
     ? K
     : never

--- a/packages/socket.io/test/socket.io.test-d.ts
+++ b/packages/socket.io/test/socket.io.test-d.ts
@@ -265,15 +265,11 @@ describe("server", () => {
   interface ServerToClientEventsWithMultipleWithAck {
     ackFromServer: (a: boolean, b: string) => Promise<boolean[]>;
     ackFromServerSingleArg: (a: boolean, b: string) => Promise<string[]>;
-    // This should technically be `undefined[]`, but this doesn't work currently *only* with emitWithAck
-    // you can use an empty callback with emit, but not emitWithAck
     onlyCallback: () => Promise<undefined>;
   }
   interface ServerToClientEventsWithAck {
     ackFromServer: (a: boolean, b: string) => Promise<boolean>;
     ackFromServerSingleArg: (a: boolean, b: string) => Promise<string>;
-    // This doesn't work currently *only* with emitWithAck
-    // you can use an empty callback with emit, but not emitWithAck
     onlyCallback: () => Promise<undefined>;
   }
   describe("Emitting Types", () => {
@@ -420,8 +416,9 @@ describe("server", () => {
         sio.timeout(0).emitWithAck("noArgs");
         // @ts-expect-error - "helloFromServer" doesn't have a callback and is thus excluded
         sio.timeout(0).emitWithAck("helloFromServer");
-        // @ts-expect-error - "onlyCallback" doesn't have a callback and is thus excluded
-        sio.timeout(0).emitWithAck("onlyCallback");
+        expectType<
+          ToEmitWithAck<ServerToClientEventsWithMultipleWithAck, "onlyCallback">
+        >(sio.timeout(0).emitWithAck<"onlyCallback">);
         expectType<
           ToEmitWithAck<
             ServerToClientEventsWithMultipleWithAck,
@@ -496,10 +493,12 @@ describe("server", () => {
           s.emitWithAck("noArgs");
           // @ts-expect-error - "helloFromServer" doesn't have a callback and is thus excluded
           s.emitWithAck("helloFromServer");
-          // @ts-expect-error - "onlyCallback" doesn't have a callback and is thus excluded
-          s.emitWithAck("onlyCallback");
-          // @ts-expect-error - "onlyCallback" doesn't have a callback and is thus excluded
-          s.timeout(0).emitWithAck("onlyCallback");
+          expectType<
+            ToEmitWithAck<ServerToClientEventsWithAck, "onlyCallback">
+          >(s.emitWithAck<"onlyCallback">);
+          expectType<
+            ToEmitWithAck<ServerToClientEventsWithAck, "onlyCallback">
+          >(s.timeout(0).emitWithAck<"onlyCallback">);
           expectType<
             ToEmitWithAck<ServerToClientEventsWithAck, "ackFromServerSingleArg">
           >(s.emitWithAck<"ackFromServerSingleArg">);


### PR DESCRIPTION
Fixes #5257

`EventNamesWithAck` was filtering out events whose acknowledgement callback had no non-error arguments (like `(cb: () => void) => void` or `(cb: (err: Error) => void) => void`). This meant you couldn't use `emitWithAck` as a simple ack mechanism without passing data back — even though `emit` worked fine with those same event signatures.

The root cause was the `FirstNonErrorArg<...> extends void ? never : K` check. For callbacks like `() => void`, `FirstNonErrorArg` resolves to `undefined` (since there are no params), and `undefined extends void` is true in TypeScript, so the event name got mapped to `never`.

The fix removes that void exclusion while keeping the guard for events with no parameters at all (`Parameters<Map[K]> extends never[]`), so events like `noArgs: () => void` are still correctly excluded from `emitWithAck`.

**Before:**
```ts
interface ServerToClientEvents {
  someEvent: (callback: (err: Error) => void) => void;
  ackOnly: (callback: () => void) => void;
}

// Both give: Argument of type 'string' is not assignable to parameter of type 'never'
await socket.emitWithAck("someEvent");
await socket.emitWithAck("ackOnly");
```

**After:**
```ts
// Both work correctly, returning Promise<undefined>
await socket.emitWithAck("someEvent");
await socket.emitWithAck("ackOnly");
```

All existing type tests and unit tests pass.