### PR TITLE
fix(adapter): do not skip local broadcast when publishAndReturnOffset throws

### DIFF
--- a/packages/socket.io-adapter/lib/cluster-adapter.ts
+++ b/packages/socket.io-adapter/lib/cluster-adapter.ts
@@ -438,11 +438,7 @@ export abstract class ClusterAdapter extends Adapter {
         });
         this.addOffsetIfNecessary(packet, opts, offset);
       } catch (e) {
-        return debug(
-          "[%s] error while broadcasting message: %s",
-          this.uid,
-          e.message,
-        );
+        debug("[%s] error while broadcasting message: %s", this.uid, e.message);
       }
     }
 

--- a/packages/socket.io-adapter/test/cluster-adapter.ts
+++ b/packages/socket.io-adapter/test/cluster-adapter.ts
@@ -15,6 +15,7 @@ const NODES_COUNT = 3;
 
 class EventEmitterAdapter extends ClusterAdapterWithHeartbeat {
   private offset = 1;
+  public shouldFailPublish = false;
 
   constructor(
     nsp,
@@ -27,6 +28,9 @@ class EventEmitterAdapter extends ClusterAdapterWithHeartbeat {
   }
 
   protected doPublish(message: ClusterMessage): Promise<string> {
+    if (this.shouldFailPublish) {
+      return Promise.reject(new Error("publish failed"));
+    }
     this.eventBus.emit("message", message);
     return Promise.resolve(String(++this.offset));
   }
@@ -150,6 +154,19 @@ describe("cluster adapter", () => {
       clientSockets[2].on("test", shouldNotHappen(done));
 
       servers[0].local.emit("test");
+    });
+
+    it("broadcasts to local clients even when publishAndReturnOffset throws", (done) => {
+      const adapter = servers[0].of("/").adapter as EventEmitterAdapter;
+      adapter.shouldFailPublish = true;
+
+      clientSockets[0].on("test", (arg1) => {
+        expect(arg1).to.eql(1);
+        adapter.shouldFailPublish = false;
+        done();
+      });
+
+      servers[0].emit("test", 1);
     });
 
     it("broadcasts with multiple acknowledgements", (done) => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/socketio/socket.io/issues/5456

In `ClusterAdapter.broadcast()`, the `catch` block used `return debug(...)` which prevented `super.broadcast(packet, opts)` from ever being called when `publishAndReturnOffset()` rejected. This meant sockets connected to the **same server instance** that emitted the event would silently never receive it.

The fix removes the `return` keyword so that `super.broadcast()` is still called after logging the error — matching the pattern already used in `addSockets`, `delSockets`, and `disconnectSockets`.

- **Before:** remote publish error → `return debug(...)` → `super.broadcast()` skipped → local sockets get nothing
- **After:** remote publish error → `debug(...)` → `super.broadcast()` still runs → local sockets receive the event

## Test plan

- [x] Added test case: `"broadcasts to local clients even when publishAndReturnOffset throws"`
- [x] All 48 existing adapter tests still pass
- [x] `engine.io` tests pass (189/189)
- [x] `engine.io-client` tests pass (93/93)