### PR TITLE
feat(socket.io): allow passing a Set to to(), in(), and except()

### DIFF
--- a/packages/socket.io/lib/broadcast-operator.ts
+++ b/packages/socket.io/lib/broadcast-operator.ts
@@ -39,12 +39,12 @@ export class BroadcastOperator<EmitEvents extends EventsMap, SocketData>
    * // with multiple chained calls
    * io.to("room-101").to("room-102").emit("foo", "bar");
    *
-   * @param room - a room, or an array of rooms
+   * @param room - a room, or an array of rooms, or a Set of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public to(room: Room | Room[]) {
+  public to(room: Room | Room[] | Set<Room>) {
     const rooms = new Set(this.rooms);
-    if (Array.isArray(room)) {
+    if (Array.isArray(room) || room instanceof Set) {
       room.forEach((r) => rooms.add(r));
     } else {
       rooms.add(room);
@@ -64,10 +64,10 @@ export class BroadcastOperator<EmitEvents extends EventsMap, SocketData>
    * // disconnect all clients in the "room-101" room
    * io.in("room-101").disconnectSockets();
    *
-   * @param room - a room, or an array of rooms
+   * @param room - a room, or an array of rooms, or a Set of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public in(room: Room | Room[]) {
+  public in(room: Room | Room[] | Set<Room>) {
     return this.to(room);
   }
 
@@ -84,12 +84,12 @@ export class BroadcastOperator<EmitEvents extends EventsMap, SocketData>
    * // with multiple chained calls
    * io.except("room-101").except("room-102").emit("foo", "bar");
    *
-   * @param room - a room, or an array of rooms
+   * @param room - a room, or an array of rooms, or a Set of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public except(room: Room | Room[]) {
+  public except(room: Room | Room[] | Set<Room>) {
     const exceptRooms = new Set(this.exceptRooms);
-    if (Array.isArray(room)) {
+    if (Array.isArray(room) || room instanceof Set) {
       room.forEach((r) => exceptRooms.add(r));
     } else {
       exceptRooms.add(room);

--- a/packages/socket.io/lib/index.ts
+++ b/packages/socket.io/lib/index.ts
@@ -884,10 +884,10 @@ export class Server<
    * // with multiple chained calls
    * io.to("room-101").to("room-102").emit("foo", "bar");
    *
-   * @param room - a room, or an array of rooms
+   * @param room - a room, or an array of rooms, or a Set of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public to(room: Room | Room[]) {
+  public to(room: Room | Room[] | Set<Room>) {
     return this.sockets.to(room);
   }
 
@@ -898,10 +898,10 @@ export class Server<
    * // disconnect all clients in the "room-101" room
    * io.in("room-101").disconnectSockets();
    *
-   * @param room - a room, or an array of rooms
+   * @param room - a room, or an array of rooms, or a Set of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public in(room: Room | Room[]) {
+  public in(room: Room | Room[] | Set<Room>) {
     return this.sockets.in(room);
   }
 
@@ -918,10 +918,10 @@ export class Server<
    * // with multiple chained calls
    * io.except("room-101").except("room-102").emit("foo", "bar");
    *
-   * @param room - a room, or an array of rooms
+   * @param room - a room, or an array of rooms, or a Set of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public except(room: Room | Room[]) {
+  public except(room: Room | Room[] | Set<Room>) {
     return this.sockets.except(room);
   }
 
@@ -1127,7 +1127,7 @@ export class Server<
    * // make all socket instances in the "room1" room join the "room2" and "room3" rooms
    * io.in("room1").socketsJoin(["room2", "room3"]);
    *
-   * @param room - a room, or an array of rooms
+   * @param room - a room, or an array of rooms, or a Set of rooms
    */
   public socketsJoin(room: Room | Room[]) {
     return this.sockets.socketsJoin(room);
@@ -1145,7 +1145,7 @@ export class Server<
    * // make all socket instances in the "room1" room leave the "room2" and "room3" rooms
    * io.in("room1").socketsLeave(["room2", "room3"]);
    *
-   * @param room - a room, or an array of rooms
+   * @param room - a room, or an array of rooms, or a Set of rooms
    */
   public socketsLeave(room: Room | Room[]) {
     return this.sockets.socketsLeave(room);

--- a/packages/socket.io/lib/namespace.ts
+++ b/packages/socket.io/lib/namespace.ts
@@ -272,10 +272,10 @@ export class Namespace<
    * // with multiple chained calls
    * myNamespace.to("room-101").to("room-102").emit("foo", "bar");
    *
-   * @param room - a room, or an array of rooms
+   * @param room - a room, or an array of rooms, or a Set of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public to(room: Room | Room[]) {
+  public to(room: Room | Room[] | Set<Room>) {
     return new BroadcastOperator<
       DecorateAcknowledgementsWithMultipleResponses<EmitEvents>,
       SocketData
@@ -291,10 +291,10 @@ export class Namespace<
    * // disconnect all clients in the "room-101" room
    * myNamespace.in("room-101").disconnectSockets();
    *
-   * @param room - a room, or an array of rooms
+   * @param room - a room, or an array of rooms, or a Set of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public in(room: Room | Room[]) {
+  public in(room: Room | Room[] | Set<Room>) {
     return new BroadcastOperator<
       DecorateAcknowledgementsWithMultipleResponses<EmitEvents>,
       SocketData
@@ -316,10 +316,10 @@ export class Namespace<
    * // with multiple chained calls
    * myNamespace.except("room-101").except("room-102").emit("foo", "bar");
    *
-   * @param room - a room, or an array of rooms
+   * @param room - a room, or an array of rooms, or a Set of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public except(room: Room | Room[]) {
+  public except(room: Room | Room[] | Set<Room>) {
     return new BroadcastOperator<
       DecorateAcknowledgementsWithMultipleResponses<EmitEvents>,
       SocketData
@@ -733,7 +733,7 @@ export class Namespace<
    * // make all socket instances in the "room1" room join the "room2" and "room3" rooms
    * myNamespace.in("room1").socketsJoin(["room2", "room3"]);
    *
-   * @param room - a room, or an array of rooms
+   * @param room - a room, or an array of rooms, or a Set of rooms
    */
   public socketsJoin(room: Room | Room[]) {
     return new BroadcastOperator<EmitEvents, SocketData>(
@@ -755,7 +755,7 @@ export class Namespace<
    * // make all socket instances in the "room1" room leave the "room2" and "room3" rooms
    * myNamespace.in("room1").socketsLeave(["room2", "room3"]);
    *
-   * @param room - a room, or an array of rooms
+   * @param room - a room, or an array of rooms, or a Set of rooms
    */
   public socketsLeave(room: Room | Room[]) {
     return new BroadcastOperator<EmitEvents, SocketData>(

--- a/packages/socket.io/lib/socket.ts
+++ b/packages/socket.io/lib/socket.ts
@@ -349,10 +349,10 @@ export class Socket<
    *   socket.to("room-101").to("room-102").emit("foo", "bar");
    * });
    *
-   * @param room - a room, or an array of rooms
+   * @param room - a room, or an array of rooms, or a Set of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public to(room: Room | Room[]) {
+  public to(room: Room | Room[] | Set<Room>) {
     return this.newBroadcastOperator().to(room);
   }
 
@@ -365,10 +365,10 @@ export class Socket<
    *   socket.in("room-101").disconnectSockets();
    * });
    *
-   * @param room - a room, or an array of rooms
+   * @param room - a room, or an array of rooms, or a Set of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public in(room: Room | Room[]) {
+  public in(room: Room | Room[] | Set<Room>) {
     return this.newBroadcastOperator().in(room);
   }
 
@@ -388,10 +388,10 @@ export class Socket<
    *   socket.except("room-101").except("room-102").emit("foo", "bar");
    * });
    *
-   * @param room - a room, or an array of rooms
+   * @param room - a room, or an array of rooms, or a Set of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public except(room: Room | Room[]) {
+  public except(room: Room | Room[] | Set<Room>) {
     return this.newBroadcastOperator().except(room);
   }
 

--- a/packages/socket.io/test/messaging-many.ts
+++ b/packages/socket.io/test/messaging-many.ts
@@ -135,6 +135,32 @@ describe("messaging many", () => {
     });
   });
 
+  it("emits to rooms with a Set", (done) => {
+    const io = new Server(0);
+    const socket1 = createClient(io, "/", { multiplex: false });
+    const socket2 = createClient(io, "/", { multiplex: false });
+
+    socket2.on("a", () => {
+      done(new Error("not"));
+    });
+    socket1.on("a", () => {
+      success(done, io, socket1, socket2);
+    });
+    socket1.emit("join", "woot");
+    socket1.emit("emit", "woot");
+
+    io.on("connection", (socket) => {
+      socket.on("join", (room, fn) => {
+        socket.join(room);
+        fn && fn();
+      });
+
+      socket.on("emit", (room) => {
+        io.in(new Set([room])).emit("a");
+      });
+    });
+  });
+
   it("emits to rooms avoiding dupes", (done) => {
     const io = new Server(0);
     const socket1 = createClient(io, "/", { multiplex: false });


### PR DESCRIPTION
## Summary

Closes https://github.com/socketio/socket.io/issues/5418

The `to()`, `in()`, and `except()` methods now accept `Set<Room>` in addition to `Room` and `Room[]`. This is a natural extension of the array support added in [085d1de](https://github.com/socketio/socket.io/commit/085d1de9df909651de8b313cc6f9f253374b702e).

```typescript
// before (workaround needed)
const rooms = new Set(["room1", "room2"]);
io.to(Array.from(rooms)).emit("hello");

// after
io.to(rooms).emit("hello");
```

Updated across all entry points: `BroadcastOperator`, `Namespace`, `Socket`, and `Server`.

## Test plan

- [x] Added test: `"emits to rooms with a Set"`
- [x] All 204 socket.io unit tests pass
- [x] Type tests (`tsd`) pass
- [x] Formatting checks pass