### PR TITLE
fix(engine.io): emit initial_headers and headers events in uServer

### DIFF
--- a/packages/engine.io/lib/userver.ts
+++ b/packages/engine.io/lib/userver.ts
@@ -226,8 +226,22 @@ export class uServer extends BaseServer {
         }
       }
 
+      // emit headers events for WebSocket upgrades
+      const additionalHeaders = {};
+      const isInitialRequest = !id;
+
+      if (isInitialRequest) {
+        this.emit("initial_headers", additionalHeaders, req);
+      }
+
+      this.emit("headers", additionalHeaders, req);
+
       // calling writeStatus() triggers the flushing of any header added in a middleware
       req.res.writeStatus("101 Switching Protocols");
+
+      Object.keys(additionalHeaders).forEach((key) => {
+        req.res.writeHeader(key, additionalHeaders[key]);
+      });
 
       res.upgrade(
         {

--- a/packages/engine.io/test/server.js
+++ b/packages/engine.io/test/server.js
@@ -3598,10 +3598,7 @@ describe("server", () => {
     });
 
     it("should emit a 'initial_headers' event (websocket)", function (done) {
-      if (
-        process.env.EIO_WS_ENGINE === "eiows" ||
-        process.env.EIO_WS_ENGINE === "uws"
-      ) {
+      if (process.env.EIO_WS_ENGINE === "eiows") {
         return this.skip();
       }
       const partialDone = createPartialDone(done, 2);
@@ -3644,10 +3641,7 @@ describe("server", () => {
     });
 
     it("should emit several 'headers' events per connection", function (done) {
-      if (
-        process.env.EIO_WS_ENGINE === "eiows" ||
-        process.env.EIO_WS_ENGINE === "uws"
-      ) {
+      if (process.env.EIO_WS_ENGINE === "eiows") {
         return this.skip();
       }
       const partialDone = createPartialDone(done, 4);


### PR DESCRIPTION
## Summary

- The `uServer` (uWebSockets.js integration) was missing `initial_headers` and `headers` event emissions during WebSocket upgrades
- The regular `Server` emits these events via the `ws` library's `headers` event in `init()`, but `uServer.init()` was empty and `handleUpgrade()` never emitted them
- Added the missing event emissions in `uServer.handleUpgrade()` before the upgrade response is sent, matching the behavior of the regular `Server`
- Enabled the previously skipped tests for the `uws` engine (`should emit a 'initial_headers' event (websocket)` and `should emit several 'headers' events per connection`)

Fixes #5300

## Test plan

- [x] `npm run test:default` — 189 passing, 2 pending
- [x] `npm run test:uws` — 173 passing, 18 pending (the 3 headers tests now pass instead of being skipped)