### PR TITLE
fix(engine.io-client): prevent mutation of user-provided options

### DIFF
--- a/packages/engine.io-client/lib/socket.ts
+++ b/packages/engine.io-client/lib/socket.ts
@@ -1167,7 +1167,7 @@ export class Socket extends SocketWithUpgrade {
   constructor(uri?: string, opts?: SocketOptions);
   constructor(opts: SocketOptions);
   constructor(uri?: string | SocketOptions, opts: SocketOptions = {}) {
-    const o = typeof uri === "object" ? uri : opts;
+    const o = typeof uri === "object" ? { ...uri } : { ...opts };
 
     if (
       !o.transports ||

--- a/packages/engine.io-client/test/socket.js
+++ b/packages/engine.io-client/test/socket.js
@@ -23,6 +23,14 @@ describe("Socket", function () {
     });
   });
 
+  it("should not mutate the options object", () => {
+    const options = { transports: ["websocket", "polling"] };
+    const originalTransports = [...options.transports];
+    const socket = new Socket(options);
+    expect(options.transports).to.eql(originalTransports);
+    socket.close();
+  });
+
   it("throws an error when no transports are available", (done) => {
     const socket = new Socket({ transports: [] });
     let errorMessage = "";


### PR DESCRIPTION
## Problem

When creating a socket with `io(url, options)`, the `transports` array in the user-provided options object is mutated from string names (`["websocket", "polling"]`) to transport constructor classes (`[class WS, class XHR]`).

This is unexpected behavior — the caller's options object should remain untouched after being passed to `io()`.

```js
const options = { transports: ["websocket", "polling"] };
const socket = io("http://localhost", options);
console.log(options.transports); // [class WS, class XHR] — mutated!
```

## Root cause

In `packages/engine.io-client/lib/socket.ts`, the `Socket` constructor assigns `o` directly to the caller's options reference:

```ts
const o = typeof uri === "object" ? uri : opts;
```

Then `o.transports` is reassigned with mapped constructor classes, which mutates the original object.

## Fix

Shallow-clone the options before processing:

```ts
const o = typeof uri === "object" ? { ...uri } : { ...opts };
```

This ensures modifications stay internal and the caller's object is never touched.

## Test

Added a regression test in `packages/engine.io-client/test/socket.js` that verifies `options.transports` remains unchanged after constructing a `Socket`.

Fixes #5462