### PR TITLE
feat: emit a "session-expiry" event when a session has expired

### DIFF
--- a/packages/socket.io-adapter/lib/in-memory-adapter.ts
+++ b/packages/socket.io-adapter/lib/in-memory-adapter.ts
@@ -423,6 +423,7 @@ export class SessionAwareAdapter extends Adapter {
         const hasExpired = session.disconnectedAt < threshold;
         if (hasExpired) {
           this.sessions.delete(sessionId);
+          this.emit("session-expiry", session.sid);
         }
       });
       for (let i = this.packets.length - 1; i >= 0; i--) {
@@ -456,6 +457,7 @@ export class SessionAwareAdapter extends Adapter {
     if (hasExpired) {
       // the session has expired
       this.sessions.delete(pid);
+      this.emit("session-expiry", session.sid);
       return null;
     }
     const index = this.packets.findIndex((packet) => packet.id === offset);

--- a/packages/socket.io-adapter/test/index.ts
+++ b/packages/socket.io-adapter/test/index.ts
@@ -551,5 +551,39 @@ describe("socket.io-adapter", () => {
 
       expect(session).to.be(null);
     });
+
+    it("should emit a 'session-expiry' event when a session has expired", async () => {
+      const adapter = new SessionAwareAdapter({
+        server: {
+          encoder: {
+            encode(packet) {
+              return packet;
+            },
+          },
+          opts: {
+            connectionStateRecovery: {
+              maxDisconnectionDuration: -1,
+            },
+          },
+        },
+      });
+
+      adapter.persistSession({
+        sid: "abc",
+        pid: "def",
+        data: "ghi",
+        rooms: ["r1", "r2"],
+      });
+
+      let expiredSid: string | undefined;
+      adapter.on("session-expiry", (sid) => {
+        expiredSid = sid;
+      });
+
+      const session = await adapter.restoreSession("def", "some-offset");
+
+      expect(session).to.be(null);
+      expect(expiredSid).to.eql("abc");
+    });
   });
 });


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

When a session expires and is removed in SessionAwareAdapter, no event is emitted, making it impossible for external consumers to detect when a session has expired.  

### New behavior

SessionAwareAdapter now emits a "session-expiry" event whenever an expired session is deleted. The event handler receives the sid of the expired session as an argument.  

### Other information (e.g. related issues)

https://github.com/socketio/socket.io/issues/5250
