### PR TITLE
feat(sio): add ackTimeout option and enable emitWithAck on io/namespace

### DIFF
--- a/packages/socket.io/lib/broadcast-operator.ts
+++ b/packages/socket.io/lib/broadcast-operator.ts
@@ -325,6 +325,14 @@ export class BroadcastOperator<EmitEvents extends EventsMap, SocketData>
     ev: Ev,
     ...args: AllButLast<EventParams<EmitEvents, Ev>>
   ): Promise<FirstNonErrorArg<Last<EventParams<EmitEvents, Ev>>>> {
+    const defaultTimeout = this.adapter.nsp.server?.opts?.ackTimeout;
+    const operator =
+      this.flags.timeout === undefined && defaultTimeout !== undefined
+        ? new BroadcastOperator(this.adapter, this.rooms, this.exceptRooms, {
+            ...this.flags,
+            timeout: defaultTimeout,
+          })
+        : this;
     return new Promise((resolve, reject) => {
       args.push((err, responses) => {
         if (err) {
@@ -334,7 +342,10 @@ export class BroadcastOperator<EmitEvents extends EventsMap, SocketData>
           return resolve(responses);
         }
       });
-      this.emit(ev, ...(args as any[] as EventParams<EmitEvents, Ev>));
+      (operator as this).emit(
+        ev,
+        ...(args as any[] as EventParams<EmitEvents, Ev>),
+      );
     });
   }
 

--- a/packages/socket.io/lib/index.ts
+++ b/packages/socket.io/lib/index.ts
@@ -45,6 +45,7 @@ import {
   RemoveAcknowledgements,
   EventNamesWithAck,
   FirstNonErrorArg,
+  EventNamesWithError,
 } from "./typed-events";
 import { patchAdapter, restoreAdapter, serveFile } from "./uws";
 import corsMiddleware from "cors";
@@ -97,7 +98,7 @@ interface ServerOptions extends EngineOptions, AttachOptions {
   /**
    * the default timeout in milliseconds used when waiting for an acknowledgement
    */
-  ackTimeout: number;
+  ackTimeout?: number;
   /**
    * Whether to enable the recovery of connection state when a client temporarily disconnects.
    *
@@ -1088,6 +1089,21 @@ export class Server<
    */
   public timeout(timeout: number) {
     return this.sockets.timeout(timeout);
+  }
+
+  /**
+   * Emits an event and waits for an acknowledgement from all clients.
+   *
+   * @example
+   * const responses = await io.emitWithAck("some-event");
+   *
+   * @return a Promise that will be fulfilled when all clients have acknowledged the event
+   */
+  public emitWithAck<Ev extends EventNamesWithError<EmitEvents>>(
+    ev: Ev,
+    ...args: AllButLast<EventParams<EmitEvents, Ev>>
+  ): Promise<FirstNonErrorArg<Last<EventParams<EmitEvents, Ev>>>> {
+    return this.sockets.emitWithAck(ev, ...args);
   }
 
   /**

--- a/packages/socket.io/lib/index.ts
+++ b/packages/socket.io/lib/index.ts
@@ -95,6 +95,10 @@ interface ServerOptions extends EngineOptions, AttachOptions {
    */
   connectTimeout: number;
   /**
+   * the default timeout in milliseconds used when waiting for an acknowledgement
+   */
+  ackTimeout: number;
+  /**
    * Whether to enable the recovery of connection state when a client temporarily disconnects.
    *
    * The connection state includes the missed packets, the rooms the socket was in and the `data` attribute.

--- a/packages/socket.io/lib/namespace.ts
+++ b/packages/socket.io/lib/namespace.ts
@@ -14,6 +14,7 @@ import {
   EventNamesWithAck,
   FirstNonErrorArg,
   EventNamesWithoutAck,
+  EventNamesWithError,
 } from "./typed-events";
 import type { Client } from "./client";
 import debugModule from "debug";
@@ -467,6 +468,23 @@ export class Namespace<
       ev,
       ...args,
     );
+  }
+
+  /**
+   * Emits an event and waits for an acknowledgement from all clients.
+   *
+   * @example
+   * const responses = await myNamespace.emitWithAck("some-event");
+   *
+   * @return a Promise that will be fulfilled when all clients have acknowledged the event
+   */
+  public emitWithAck<Ev extends EventNamesWithError<EmitEvents>>(
+    ev: Ev,
+    ...args: AllButLast<EventParams<EmitEvents, Ev>>
+  ): Promise<FirstNonErrorArg<Last<EventParams<EmitEvents, Ev>>>> {
+    return new BroadcastOperator<EmitEvents, SocketData>(
+      this.adapter,
+    ).emitWithAck(ev, ...args);
   }
 
   /**


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

`socket.to(room).emitWithAck()` requires an explicit `.timeout()` call, otherwise the operation immediately fails. There is also no  way to set a default acknowledgement timeout at the server level, unlike the client side `ackTimeout` option.
                                                                                                                                  
`io.emitWithAck()` and `namespace.emitWithAck()` are not available, as they were intentionally disabled due to the lack of a default timeout mechanism.

### New behavior

  A new `ackTimeout` option can be set on the server, mirroring the client side `ackTimeout` option. When set, it is used as the      
  default timeout for `emitWithAck()` calls that do not have an explicit `.timeout()` set.

```js                           
  const io = new Server(httpServer, { ackTimeout: 5000 });                                                                        
                                                                                                                                  
  // now works without explicit .timeout()                                                                                        
  const responses = await socket.to(room).emitWithAck("some-event");                                                              
                                                                                                                                  
  // io and namespace level emitWithAck are also now enabled                                                                      
  const responses = await io.emitWithAck("some-event");                                                                           
  const responses = await io.of("/chat").emitWithAck("some-event");                                                               
```                                                                                                                            
  An explicit .timeout() call still takes precedence over the default

### Other information (e.g. related issues)

https://github.com/socketio/socket.io/issues/5333