### PR TITLE
docs: fix various typos in test and documentation

### DIFF
--- a/docs/engine.io-protocol/v3.md
+++ b/docs/engine.io-protocol/v3.md
@@ -296,7 +296,7 @@ A payload is a series of encoded packets tied together. The payload encoding for
 <length1>:<packet1>[<length2>:<packet2>[...]]
 ```
 * length: length of the packet in __characters__
-* packet: actual packets as descriped above
+* packet: actual packets as described above
 
 When XHR2 is not supported, the same encoding principle is used also when
 binary data is sent, but it is sent as base64 encoded strings. For the purposes of decoding, an identifier `b` is

--- a/packages/engine.io/test/server.js
+++ b/packages/engine.io/test/server.js
@@ -581,7 +581,7 @@ describe("server", () => {
       });
     });
 
-    it("should not suggest upgrades when none are availble", (done) => {
+    it("should not suggest upgrades when none are available", (done) => {
       listen({ transports: ["polling"] }, (port) => {
         const socket = new ClientSocket(`ws://localhost:${port}`, {});
         socket.on("handshake", (obj) => {

--- a/packages/socket.io/test/socket.io.test-d.ts
+++ b/packages/socket.io/test/socket.io.test-d.ts
@@ -444,7 +444,7 @@ describe("server", () => {
           nio.emit<"noArgs">,
         );
         expectType<ToEmit<ServerToClientEventsNoAck, "helloFromServer">>(
-          // These errors will dissapear once the TS version is updated from 4.7.4
+          // These errors will disappear once the TS version is updated from 4.7.4
           // the TSD instance is using a newer version of TS than the workspace version
           // to enable the ability to compare against `any`
           sio.emit<"helloFromServer">,


### PR DESCRIPTION
Fixes a minor typo in test/server.js: 'availble' -> 'available'.