### PR TITLE
fix(engine.io): make _query optional in EngineRequest

### DIFF
--- a/packages/engine.io/lib/transport.ts
+++ b/packages/engine.io/lib/transport.ts
@@ -13,7 +13,7 @@ function noop() {}
 type ReadyState = "open" | "closing" | "closed";
 
 export type EngineRequest = IncomingMessage & {
-  _query: Record<string, string>;
+  _query?: Record<string, string>;
   res?: ServerResponse;
   cleanup?: Function;
   websocket?: WebSocket & {

--- a/packages/engine.io/lib/transports/websocket.ts
+++ b/packages/engine.io/lib/transports/websocket.ts
@@ -15,7 +15,12 @@ export class WebSocket extends Transport {
    * @param {EngineRequest} req
    */
   constructor(req: EngineRequest) {
-    super(req);
+    if (!req._query) {
+      throw new Error("Missing _query in request");
+    }
+
+    super(req as { _query: Record<string, string> });
+
     this.socket = req.websocket;
     this.socket.on("message", (data, isBinary) => {
       const message = isBinary ? data : data.toString();


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

The `_query` field in `EngineRequest` is typed as required (`Record<string, string>`), while in practice it is initialized later in the `prepare()` method. This creates a mismatch between the TypeScript definition and the runtime behavior, leading to type errors in certain environments (e.g. when following the Nuxt integration tutorial).

### New behavior

The `_query` field is now marked as optional in the `EngineRequest` type to accurately reflect its initialization lifecycle.

Additionally, a runtime check ensures that `_query` is defined before being passed to the Transport constructor, preserving type safety where `_query` is expected to be available.

### Other information (e.g. related issues)

Related to the discussion about `_query` initialization and type mismatch when using Engine.IO with certain frameworks (e.g. Nuxt).
