### PR TITLE
fix(eio): make _query optional in EngineRequest

### DIFF
--- a/packages/engine.io/lib/transport.ts
+++ b/packages/engine.io/lib/transport.ts
@@ -13,7 +13,7 @@ function noop() {}
 type ReadyState = "open" | "closing" | "closed";
 
 export type EngineRequest = IncomingMessage & {
-  _query: Record<string, string>;
+  _query?: Record<string, string>;
   res?: ServerResponse;
   cleanup?: Function;
   websocket?: WebSocket & {
@@ -89,9 +89,9 @@ export abstract class Transport extends EventEmitter {
    *
    * @param {EngineRequest} req
    */
-  constructor(req: { _query: Record<string, string> }) {
+  constructor(req: { _query?: Record<string, string> }) {
     super();
-    this.protocol = req._query.EIO === "4" ? 4 : 3; // 3rd revision by default
+    this.protocol = req._query?.EIO === "4" ? 4 : 3; // 3rd revision by default
     this.parser = this.protocol === 4 ? parser_v4 : parser_v3;
     this.supportsBinary = !(req._query && req._query.b64);
   }

--- a/packages/engine.io/lib/transports/index.ts
+++ b/packages/engine.io/lib/transports/index.ts
@@ -14,7 +14,7 @@ export default {
  * Polling polymorphic constructor.
  */
 function polling(req: EngineRequest) {
-  if ("string" === typeof req._query.j) {
+  if ("string" === typeof req._query?.j) {
     return new JSONP(req);
   } else {
     return new XHR(req);


### PR DESCRIPTION
Fixes #5468

`EngineRequest` declared `_query` as required, but the property is set lazily by `prepare()` and doesn't exist on a raw `IncomingMessage`. This caused a TypeScript error when passing a plain `IncomingMessage` where an `EngineRequest` is expected; for example, in Nuxt integrations following the official guide.

Before: Any code that worked with `EngineRequest` directly would get a TypeScript mismatch error because `_query` was required but not present on the underlying `IncomingMessage`.

After: `_query` is typed as optional in `EngineRequest` and in the `Transport` constructor, which correctly reflects the lifecycle of the property: it may not be set at construction time, but is always guaranteed to be present by the time any transport logic runs. `transports/index.ts` is also updated for consistency.

No tests added - this is a TypeScript-only change with no runtime behavior difference.