### PR TITLE
fix(engine.io-client): include query params in WebTransport URI

### DIFF
--- a/packages/engine.io-client/lib/transports/webtransport.ts
+++ b/packages/engine.io-client/lib/transports/webtransport.ts
@@ -29,7 +29,7 @@ export class WT extends Transport {
     try {
       // @ts-ignore
       this._transport = new WebTransport(
-        this.createUri("https"),
+        this.createUri("https", this.query),
         this.opts.transportOptions[this.name],
       );
     } catch (err) {

--- a/packages/engine.io-client/test/transport.js
+++ b/packages/engine.io-client/test/transport.js
@@ -198,6 +198,35 @@ describe("Transport", () => {
       expect(ws.uri()).to.be("wss://test/engine.io");
     });
 
+    it("should include query parameters in WebTransport uris", () => {
+      let actualUri;
+      const previousWebTransport = globalThis.WebTransport;
+      globalThis.WebTransport = function (uri) {
+        actualUri = uri;
+        this.closed = new Promise(() => {});
+        this.ready = new Promise(() => {});
+      };
+
+      try {
+        new eio.transports.webtransport({
+          path: "/engine.io",
+          hostname: "test",
+          secure: true,
+          query: { token: "abc", EIO: "4", transport: "webtransport" },
+          transportOptions: { webtransport: {} },
+        }).open();
+      } finally {
+        globalThis.WebTransport = previousWebTransport;
+      }
+
+      const url = new URL(actualUri);
+      expect(url.origin).to.be("https://test");
+      expect(url.pathname).to.be("/engine.io");
+      expect(url.searchParams.get("token")).to.be("abc");
+      expect(url.searchParams.get("EIO")).to.be("4");
+      expect(url.searchParams.get("transport")).to.be("webtransport");
+    });
+
     it("should timestamp ws uris", () => {
       const ws = new eio.transports.websocket({
         path: "/engine.io",

--- a/packages/engine.io-client/test/webtransport.mjs
+++ b/packages/engine.io-client/test/webtransport.mjs
@@ -50,6 +50,14 @@ async function setup(opts, cb) {
 
   await h3Server.ready;
 
+  h3Server.setRequestCallback(async ({ header }) => {
+    const url = new URL(header[":path"], "http://localhost");
+    if (url.pathname === "/engine.io/") {
+      return { status: 200, path: url.pathname };
+    }
+    return { status: 404 };
+  });
+
   cb({ engine, h3Server, certificate });
 }
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

The WebTransport client creates its session URL without passing the transport query object, so query parameters from the original Engine.IO URL are dropped.

### New behavior

The WebTransport client now passes the same query object used by the other transports when constructing its URL, preserving original query parameters along with Engine.IO transport metadata.

### Other information (e.g. related issues)

Fixes #5496.

Validation:

- `npm run format:check --workspace=engine.io-client`
- `npm run compile --workspace=engine.io-parser && npm run compile --workspace=engine.io-client`
- `npx mocha --bail --require test/support/hooks.js test/transport.js`
- `npm run test:node --workspace=engine.io-client -- --grep "autoRef option" --timeout 10000`
- `git diff --check`

Note: `npm test --workspace=engine.io-client` timed out in the existing `node.js > autoRef option > should stop once the timer is triggered` test with the default 2s timeout on Node v22 in this environment; the isolated autoRef test group passed with a higher timeout.
