### PR TITLE
fix(engine.io-client): preserve caller transport options

### DIFF
--- a/packages/engine.io-client/lib/socket.ts
+++ b/packages/engine.io-client/lib/socket.ts
@@ -1167,7 +1167,8 @@ export class Socket extends SocketWithUpgrade {
   constructor(uri?: string, opts?: SocketOptions);
   constructor(opts: SocketOptions);
   constructor(uri?: string | SocketOptions, opts: SocketOptions = {}) {
-    const o = typeof uri === "object" ? uri : opts;
+    const isOptionsOnly = typeof uri === "object";
+    const o = isOptionsOnly ? { ...uri } : { ...opts };
 
     if (
       !o.transports ||
@@ -1178,6 +1179,9 @@ export class Socket extends SocketWithUpgrade {
         .filter((t) => !!t);
     }
 
-    super(uri as string, o as BaseSocketOptions);
+    super(
+      isOptionsOnly ? (o as BaseSocketOptions) : uri,
+      o as BaseSocketOptions,
+    );
   }
 }

--- a/packages/engine.io-client/test/socket.js
+++ b/packages/engine.io-client/test/socket.js
@@ -23,6 +23,19 @@ describe("Socket", function () {
     });
   });
 
+  it("should not mutate the caller's transports option", () => {
+    const optsWithUri = { transports: ["websocket", "polling"] };
+    const optsWithoutUri = { transports: ["polling"] };
+
+    const socketWithUri = new Socket("http://localhost", optsWithUri);
+    const socketWithoutUri = new Socket(optsWithoutUri);
+
+    expect(optsWithUri.transports).to.eql(["websocket", "polling"]);
+    expect(optsWithoutUri.transports).to.eql(["polling"]);
+    socketWithUri.close();
+    socketWithoutUri.close();
+  });
+
   it("throws an error when no transports are available", (done) => {
     const socket = new Socket({ transports: [] });
     let errorMessage = "";


### PR DESCRIPTION
## Summary
- clone Socket constructor options before mapping transport names to constructors
- pass the cloned options through the options-only overload as well
- add a regression test for both URI and options-only construction

Fixes #5462

## Tests
- `npm run compile --workspace=engine.io-parser`
- `npm run compile --workspace=engine.io`
- `npm run compile --workspace=engine.io-client`
- `npm run format:check --workspace=engine.io-client`
- `npm run test:node --workspace=engine.io-client -- --grep "caller's transports option"`
- `npm run test:node --workspace=engine.io-client -- --grep "Socket"`
- `npm run test:node --workspace=engine.io-client`
- `git diff --check`