### PR TITLE
fix: off-by-one in binary attachment array sizing (#5504)

### DIFF
--- a/packages/engine.io-client/lib/transports/webtransport.ts
+++ b/packages/engine.io-client/lib/transports/webtransport.ts
@@ -29,7 +29,7 @@ export class WT extends Transport {
     try {
       // @ts-ignore
       this._transport = new WebTransport(
-        this.createUri("https"),
+        this.createUri("https", this.query),
         this.opts.transportOptions[this.name],
       );
     } catch (err) {


### PR DESCRIPTION
Fixes https://github.com/socketio/socket.io/issues/5504