### PR TITLE
feat(socket.io): allow passing a Set to to(), in(), and except()

### DIFF
--- a/packages/socket.io/lib/broadcast-operator.ts
+++ b/packages/socket.io/lib/broadcast-operator.ts
@@ -45,9 +45,9 @@ export class BroadcastOperator<EmitEvents extends EventsMap, SocketData>
    * @param room - a room, or an array of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public to(room: Room | Room[]) {
+  public to(room: Room | Room[] | Set<Room>) {
     const rooms = new Set(this.rooms);
-    if (Array.isArray(room)) {
+    if (room instanceof Set || Array.isArray(room)) {
       room.forEach((r) => rooms.add(r));
     } else {
       rooms.add(room);
@@ -70,7 +70,7 @@ export class BroadcastOperator<EmitEvents extends EventsMap, SocketData>
    * @param room - a room, or an array of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public in(room: Room | Room[]) {
+  public in(room: Room | Room[] | Set<Room>) {
     return this.to(room);
   }
 
@@ -90,9 +90,9 @@ export class BroadcastOperator<EmitEvents extends EventsMap, SocketData>
    * @param room - a room, or an array of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public except(room: Room | Room[]) {
+  public except(room: Room | Room[] | Set<Room>) {
     const exceptRooms = new Set(this.exceptRooms);
-    if (Array.isArray(room)) {
+    if (room instanceof Set || Array.isArray(room)) {
       room.forEach((r) => exceptRooms.add(r));
     } else {
       exceptRooms.add(room);
@@ -413,14 +413,14 @@ export class BroadcastOperator<EmitEvents extends EventsMap, SocketData>
    *
    * @param room - a room, or an array of rooms
    */
-  public socketsJoin(room: Room | Room[]): void {
+  public socketsJoin(room: Room | Room[] | Set<Room>): void {
     this.adapter.addSockets(
       {
         rooms: this.rooms,
         except: this.exceptRooms,
         flags: this.flags,
       },
-      Array.isArray(room) ? room : [room],
+      room instanceof Set ? [...room] : Array.isArray(room) ? room : [room],
     );
   }
 
@@ -438,14 +438,14 @@ export class BroadcastOperator<EmitEvents extends EventsMap, SocketData>
    *
    * @param room - a room, or an array of rooms
    */
-  public socketsLeave(room: Room | Room[]): void {
+  public socketsLeave(room: Room | Room[] | Set<Room>): void {
     this.adapter.delSockets(
       {
         rooms: this.rooms,
         except: this.exceptRooms,
         flags: this.flags,
       },
-      Array.isArray(room) ? room : [room],
+      room instanceof Set ? [...room] : Array.isArray(room) ? room : [room],
     );
   }
 
@@ -554,7 +554,7 @@ export class RemoteSocket<EmitEvents extends EventsMap, SocketData>
    *
    * @param {String|Array} room - room or array of rooms
    */
-  public join(room: Room | Room[]): void {
+  public join(room: Room | Room[] | Set<Room>): void {
     return this.operator.socketsJoin(room);
   }
 

--- a/packages/socket.io/lib/index.ts
+++ b/packages/socket.io/lib/index.ts
@@ -887,7 +887,7 @@ export class Server<
    * @param room - a room, or an array of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public to(room: Room | Room[]) {
+  public to(room: Room | Room[] | Set<Room>) {
     return this.sockets.to(room);
   }
 
@@ -901,7 +901,7 @@ export class Server<
    * @param room - a room, or an array of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public in(room: Room | Room[]) {
+  public in(room: Room | Room[] | Set<Room>) {
     return this.sockets.in(room);
   }
 
@@ -921,7 +921,7 @@ export class Server<
    * @param room - a room, or an array of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public except(room: Room | Room[]) {
+  public except(room: Room | Room[] | Set<Room>) {
     return this.sockets.except(room);
   }
 
@@ -1129,7 +1129,7 @@ export class Server<
    *
    * @param room - a room, or an array of rooms
    */
-  public socketsJoin(room: Room | Room[]) {
+  public socketsJoin(room: Room | Room[] | Set<Room>) {
     return this.sockets.socketsJoin(room);
   }
 
@@ -1147,7 +1147,7 @@ export class Server<
    *
    * @param room - a room, or an array of rooms
    */
-  public socketsLeave(room: Room | Room[]) {
+  public socketsLeave(room: Room | Room[] | Set<Room>) {
     return this.sockets.socketsLeave(room);
   }
 

--- a/packages/socket.io/lib/namespace.ts
+++ b/packages/socket.io/lib/namespace.ts
@@ -275,7 +275,7 @@ export class Namespace<
    * @param room - a room, or an array of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public to(room: Room | Room[]) {
+  public to(room: Room | Room[] | Set<Room>) {
     return new BroadcastOperator<
       DecorateAcknowledgementsWithMultipleResponses<EmitEvents>,
       SocketData
@@ -294,7 +294,7 @@ export class Namespace<
    * @param room - a room, or an array of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public in(room: Room | Room[]) {
+  public in(room: Room | Room[] | Set<Room>) {
     return new BroadcastOperator<
       DecorateAcknowledgementsWithMultipleResponses<EmitEvents>,
       SocketData
@@ -319,7 +319,7 @@ export class Namespace<
    * @param room - a room, or an array of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public except(room: Room | Room[]) {
+  public except(room: Room | Room[] | Set<Room>) {
     return new BroadcastOperator<
       DecorateAcknowledgementsWithMultipleResponses<EmitEvents>,
       SocketData
@@ -735,7 +735,7 @@ export class Namespace<
    *
    * @param room - a room, or an array of rooms
    */
-  public socketsJoin(room: Room | Room[]) {
+  public socketsJoin(room: Room | Room[] | Set<Room>) {
     return new BroadcastOperator<EmitEvents, SocketData>(
       this.adapter,
     ).socketsJoin(room);
@@ -757,7 +757,7 @@ export class Namespace<
    *
    * @param room - a room, or an array of rooms
    */
-  public socketsLeave(room: Room | Room[]) {
+  public socketsLeave(room: Room | Room[] | Set<Room>) {
     return new BroadcastOperator<EmitEvents, SocketData>(
       this.adapter,
     ).socketsLeave(room);

--- a/packages/socket.io/lib/socket.ts
+++ b/packages/socket.io/lib/socket.ts
@@ -352,7 +352,7 @@ export class Socket<
    * @param room - a room, or an array of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public to(room: Room | Room[]) {
+  public to(room: Room | Room[] | Set<Room>) {
     return this.newBroadcastOperator().to(room);
   }
 
@@ -368,7 +368,7 @@ export class Socket<
    * @param room - a room, or an array of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public in(room: Room | Room[]) {
+  public in(room: Room | Room[] | Set<Room>) {
     return this.newBroadcastOperator().in(room);
   }
 
@@ -391,7 +391,7 @@ export class Socket<
    * @param room - a room, or an array of rooms
    * @return a new {@link BroadcastOperator} instance for chaining
    */
-  public except(room: Room | Room[]) {
+  public except(room: Room | Room[] | Set<Room>) {
     return this.newBroadcastOperator().except(room);
   }
 
@@ -458,12 +458,12 @@ export class Socket<
    * @param {String|Array} rooms - room or array of rooms
    * @return a Promise or nothing, depending on the adapter
    */
-  public join(rooms: Room | Array<Room>): Promise<void> | void {
+  public join(rooms: Room | Array<Room> | Set<Room>): Promise<void> | void {
     debug("join room %s", rooms);
 
     return this.adapter.addAll(
       this.id,
-      new Set(Array.isArray(rooms) ? rooms : [rooms]),
+      new Set(rooms instanceof Set ? rooms : Array.isArray(rooms) ? rooms : [rooms]),
     );
   }
 

--- a/packages/socket.io/test/messaging-many.ts
+++ b/packages/socket.io/test/messaging-many.ts
@@ -170,6 +170,41 @@ describe("messaging many", () => {
     });
   });
 
+  it("emits to rooms with a Set", (done) => {
+    const io = new Server(0);
+    const socket1 = createClient(io, "/", { multiplex: false });
+    const socket2 = createClient(io, "/", { multiplex: false });
+
+    const partialDone = createPartialDone(
+      2,
+      successFn(done, io, socket1, socket2),
+    );
+
+    socket2.on("a", () => {
+      done(new Error("not"));
+    });
+    socket1.on("a", partialDone);
+    socket2.on("b", partialDone);
+
+    socket1.emit("join", "woot");
+    socket1.emit("join", "test");
+    socket2.emit("join", "third", () => {
+      socket2.emit("emit");
+    });
+
+    io.on("connection", (socket) => {
+      socket.on("join", (room, fn) => {
+        socket.join(room);
+        fn && fn();
+      });
+
+      socket.on("emit", () => {
+        io.in(new Set(["woot", "test"])).emit("a");
+        io.in(new Set(["third"])).emit("b");
+      });
+    });
+  });
+
   it("broadcasts to rooms", (done) => {
     const io = new Server(0);
     const socket1 = createClient(io, "/", { multiplex: false });


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
Currently, the `to()`, `in()`, and `except()` methods only accept `Room` or `Room[]`. If a developer wants to pass a Set of rooms, they have to manually convert it to an array first (e.g., using `Array.from()`).

### New behavior
The `to()`, `in()`, and `except()` methods now natively accept `Set<Room>` in addition to `Room` and `Room[]`. This is a natural extension of the existing array support.

Updated across all entry points: `BroadcastOperator`, `Namespace`, `Socket`, and `Server`. 
I have also added the relevant unit test (`"emits to rooms with a Set"`) to ensure the functionality works as expected.

### Other information (e.g. related issues)
Closes #5418