### PR TITLE
docs(engine.io): correct maxHttpBufferSize default in JSDoc (1e6 / 1 MB)

### DIFF
--- a/packages/engine.io/lib/server.ts
+++ b/packages/engine.io/lib/server.ts
@@ -75,7 +75,7 @@ export interface ServerOptions {
   upgradeTimeout?: number;
   /**
    * how many bytes or characters a message can be, before closing the session (to avoid DoS).
-   * @default 1e5 (100 KB)
+   * @default 1e6 (1 MB)
    */
   maxHttpBufferSize?: number;
   /**


### PR DESCRIPTION
## Description

The JSDoc `@default` for `maxHttpBufferSize` in `engine.io` is wrong — it documents `1e5 (100 KB)`, but the actual default applied in the server constructor is `1e6` (1 MB):

```ts
// packages/engine.io/lib/server.ts
/**
 * how many bytes or characters a message can be, before closing the session (to avoid DoS).
 * @default 1e5 (100 KB)   // <-- doc says 100 KB
 */
maxHttpBufferSize?: number;

// ...constructor defaults:
maxHttpBufferSize: 1e6,    // <-- actual default is 1 MB
```

So the documented value is off by 10× (1e5 vs 1e6) and the human-readable size is wrong (100 KB vs 1 MB). The official docs at <https://socket.io/docs/v4/server-options/#maxhttpbuffersize> confirm the real default is **`1e6` (1 MB)**.

This option is the DoS-protection message-size limit and the JSDoc shows up in editor IntelliSense / generated TypeDoc, so the wrong value is misleading.

## Fix

Update the JSDoc to `@default 1e6 (1 MB)` to match the actual constant. Comment-only change.
