### PR TITLE
docs: document main namespace shortcuts

### DIFF
--- a/packages/socket.io/lib/index.ts
+++ b/packages/socket.io/lib/index.ts
@@ -128,6 +128,21 @@ interface ServerOptions extends EngineOptions, AttachOptions {
  *
  * const io = new Server();
  *
+ * The server exposes the main namespace (`"/"`) through a set of shorthand
+ * methods. For example, `io.on("connection")`, `io.use(...)` and
+ * `io.emit(...)` are equivalent to calling `io.of("/")` and then the
+ * corresponding {@link Namespace} method.
+ *
+ * @example
+ * io.on("connection", (socket) => {});
+ * io.use((socket, next) => { next(); });
+ * io.emit("hello");
+ *
+ * // are equivalent to:
+ * io.of("/").on("connection", (socket) => {});
+ * io.of("/").use((socket, next) => { next(); });
+ * io.of("/").emit("hello");
+ *
  * io.on("connection", (socket) => {
  *   console.log(`socket ${socket.id} connected`);
  *
@@ -220,6 +235,19 @@ export class Server<
     SocketData
   >
 > {
+  /**
+   * The main namespace, named `"/"`.
+   *
+   * Most namespace-level methods exposed by {@link Server}, such as
+   * `on("connection")`, `use()`, `emit()`, `to()`, `in()` and `except()`, are
+   * shortcuts for calling the same methods on this namespace.
+   *
+   * @example
+   * io.sockets.emit("hello");
+   *
+   * // is equivalent to:
+   * io.emit("hello");
+   */
   public readonly sockets: Namespace<
     ListenEvents,
     EmitEvents,


### PR DESCRIPTION
Fixes #4608

## Summary
- Document that `Server` methods like `io.on(connection)`, `io.use(...)`, and `io.emit(...)` are shortcuts for the main namespace.
- Add a short `io.sockets` note for the main namespace property.

## Verification
- `npx --yes prettier@3.3.2 --check packages/socket.io/lib/index.ts`
- `git diff --check`