### PR TITLE
fix(parser): honor toJSON() when deconstructing a binary packet

### DIFF
--- a/packages/socket.io-parser/lib/binary.ts
+++ b/packages/socket.io-parser/lib/binary.ts
@@ -17,7 +17,7 @@ export function deconstructPacket(packet) {
   return { packet: pack, buffers: buffers };
 }
 
-function _deconstructPacket(data, buffers) {
+function _deconstructPacket(data, buffers, toJSON?) {
   if (!data) return data;
 
   if (isBinary(data)) {
@@ -31,6 +31,9 @@ function _deconstructPacket(data, buffers) {
     }
     return newData;
   } else if (typeof data === "object" && !(data instanceof Date)) {
+    if (data.toJSON && typeof data.toJSON === "function" && !toJSON) {
+      return _deconstructPacket(data.toJSON(), buffers, true);
+    }
     const newData = {};
     for (const key in data) {
       if (Object.prototype.hasOwnProperty.call(data, key)) {

--- a/packages/socket.io-parser/test/buffer.js
+++ b/packages/socket.io-parser/test/buffer.js
@@ -1,4 +1,4 @@
-const { PacketType, Decoder } = require("../");
+const { PacketType, Decoder, Encoder } = require("../");
 const helpers = require("./helpers.js");
 const expect = require("expect.js");
 
@@ -27,6 +27,36 @@ describe("Buffer", () => {
       data: ["a", Buffer.from("xxx", "utf8"), {}],
       id: 127,
       nsp: "/back",
+    });
+  });
+
+  it("encodes a Buffer nested in an object with a toJSON() method", () => {
+    class Message {
+      constructor(file) {
+        this.internal = file;
+      }
+      toJSON() {
+        return { file: this.internal };
+      }
+    }
+
+    return new Promise((resolve) => {
+      const encoder = new Encoder();
+      const encodedPackets = encoder.encode({
+        type: PacketType.EVENT,
+        data: ["a", new Message(Buffer.from("abc", "utf8"))],
+        nsp: "/",
+      });
+
+      const decoder = new Decoder();
+      decoder.on("decoded", (packet) => {
+        expect(packet.data).to.eql(["a", { file: Buffer.from("abc", "utf8") }]);
+        resolve();
+      });
+
+      for (let i = 0; i < encodedPackets.length; i++) {
+        decoder.add(encodedPackets[i]);
+      }
     });
   });
 


### PR DESCRIPTION
## Description

`socket.io-parser` gives a binary packet a different shape depending on whether it contains binary, because `deconstructPacket` does not honor `toJSON()`.

`hasBinary()` (which decides whether a packet takes the binary-encoding path) follows an object's `toJSON()`. But `_deconstructPacket()` walked the original object instead of its `toJSON()` output. So for a class instance whose `toJSON()` returns the data to send:

- the wire used the object's own (often private) property names instead of the `toJSON()` keys, and
- binary nested inside the `toJSON()` result was never extracted as an attachment (a `Buffer` returned directly by `toJSON()` was corrupted into `{"0":..,"1":..}`).

The same object is therefore delivered with a different structure depending only on whether it carries binary.

## Reproduction

Emitting a model instance (Mongoose document, ORM entity, DTO) that exposes `toJSON()` and holds a file or avatar buffer, a common pattern:

```js
class Doc {
  #buf = Buffer.from("abc");
  toJSON() { return { file: this.#buf }; }
}
socket.emit("save", new Doc());
// received as { internal: <Buffer> } (private field name) instead of { file: <Buffer> }
```

## Fix

Apply `toJSON()` in `_deconstructPacket()` with the same one-shot recursion guard that `hasBinary()` and `JSON.stringify` use, so both the binary-detection and the deconstruction paths walk an identical tree. The pre-existing `Date` guard is preserved, so `Date` serialization is unchanged.

## Test

Added a case to `packages/socket.io-parser/test/buffer.js` for a `Buffer` nested behind a `toJSON()`. It fails before the change (private key leaks, attachment shape wrong) and passes after. Full parser suite stays green (34 passing).
