### PR TITLE
fix(sio): reset regex lastIndex when matching dynamic namespaces

### DIFF
--- a/packages/socket.io/lib/index.ts
+++ b/packages/socket.io/lib/index.ts
@@ -788,10 +788,12 @@ export class Server<
       if (typeof name === "function") {
         this.parentNsps.set(name, parentNsp);
       } else {
-        this.parentNsps.set(
-          (nsp, conn, next) => next(null, (name as RegExp).test(nsp)),
-          parentNsp,
-        );
+        this.parentNsps.set((nsp, conn, next) => {
+          // Reset lastIndex so a regex created with the global or sticky flag
+          // matches consistently across connections.
+          (name as RegExp).lastIndex = 0;
+          next(null, (name as RegExp).test(nsp));
+        }, parentNsp);
         this.parentNamespacesFromRegExp.set(name, parentNsp);
       }
       if (fn) {
@@ -806,6 +808,9 @@ export class Server<
     let nsp = this._nsps.get(name);
     if (!nsp) {
       for (const [regex, parentNamespace] of this.parentNamespacesFromRegExp) {
+        // Reset lastIndex so a regex created with the global or sticky flag
+        // matches consistently across connections.
+        regex.lastIndex = 0;
         if (regex.test(name as string)) {
           debug("attaching namespace %s to parent namespace %s", name, regex);
           return parentNamespace.createChild(name as string);


### PR DESCRIPTION
A dynamic namespace registered with a `RegExp` that carries the global (`g`) or
sticky (`y`) flag rejects connections intermittently.

`Server.of` and the parent-namespace matcher call `.test()` on the user supplied
regex as if it were a stateless predicate. Per the ECMAScript spec,
`RegExp.prototype.test()` advances `lastIndex` when the regex has the `g` or `y`
flag and resumes from it on the next call, so a shared regex object returns
alternating results across connections.

Concretely, `io.of(/^\/room-\d+$/g)` connects `/room-1`, then rejects `/room-2`
with `connect_error: "Invalid namespace"`, then connects `/room-3`, and so on:

    const re = /^\/room-\d+$/g
    re.test('/room-1') // true
    re.test('/room-2') // false (wrong)
    re.test('/room-3') // true

The pattern is correct; only the leftover `lastIndex` state causes the rejection.

The fix resets `lastIndex` to 0 immediately before each `.test()` at both call
sites. It is a no-op for regexes without the `g` or `y` flag, so existing
behavior is unchanged.
