### PR TITLE
docs: document dropping socket middleware packets

### DIFF
--- a/packages/socket.io/lib/socket.ts
+++ b/packages/socket.io/lib/socket.ts
@@ -842,6 +842,10 @@ export class Socket<
    *     if (isUnauthorized(event)) {
    *       return next(new Error("unauthorized event"));
    *     }
+   *     if (shouldDrop(event)) {
+   *       // return without next() to silently drop the packet
+   *       return;
+   *     }
    *     // do not forget to call next
    *     next();
    *   });


### PR DESCRIPTION
## Summary

- document that socket middleware can silently drop a packet by returning without calling `next()`
- keep the existing `next(error)` example for emitting authorization errors

Closes #3876

## Validation

- `git diff --check`
