### PR TITLE
fix(eio): do not close the connection if other packets are received while waiting for a ping/pong

### DIFF
--- a/packages/engine.io-client/lib/socket.ts
+++ b/packages/engine.io-client/lib/socket.ts
@@ -348,6 +348,13 @@ export class SocketWithoutUpgrade extends Emitter<
    * callback is not fired on time. This can happen for example when a laptop is suspended or when a phone is locked.
    */
   private _pingTimeoutTime = Infinity;
+  /**
+   * Timestamp of the last packet received from the server, of any type. Used
+   * by the ping timeout check as a cheap liveness signal, so a server that is
+   * clearly still sending data isn't considered dead just because its next
+   * ping happens to be delayed (e.g. behind a backlog on its own end).
+   */
+  private _lastPacketTime: number = Date.now();
   private clearTimeoutFn: typeof clearTimeout;
   private readonly _beforeunloadEventListener: () => void;
   private readonly _offlineEventListener: () => void;
@@ -603,6 +610,7 @@ export class SocketWithoutUpgrade extends Emitter<
 
       // Socket is live - any packet counts
       this.emitReserved("heartbeat");
+      this._lastPacketTime = Date.now();
 
       switch (packet.type) {
         case "open":
@@ -662,11 +670,43 @@ export class SocketWithoutUpgrade extends Emitter<
     const delay = this._pingInterval + this._pingTimeout;
     this._pingTimeoutTime = Date.now() + delay;
     this._pingTimeoutTimer = this.setTimeoutFn(() => {
-      this._onClose("ping timeout");
+      this._checkPingTimeout(delay);
     }, delay);
     if (this.opts.autoUnref) {
       this._pingTimeoutTimer.unref();
     }
+  }
+
+  /**
+   * Called when the ping timeout timer fires. Rather than closing the
+   * connection unconditionally, this checks whether any packet has been
+   * received recently enough that the server is clearly still alive, and if
+   * so, extends the wait instead of giving up - mirroring the same check on
+   * the server side (see `Socket#checkPingTimeout` in the `engine.io`
+   * package), which needed the equivalent client-side change to actually take
+   * effect: without it, a client that stopped hearing new pings (because the
+   * server's own next ping was delayed while it waited on a slow pong) would
+   * disconnect on its own regardless of what the server decided.
+   *
+   * @param delay - the ping timeout duration to apply, in milliseconds
+   * @private
+   */
+  private _checkPingTimeout(delay: number) {
+    const elapsedSinceLastPacket = Date.now() - this._lastPacketTime;
+
+    if (elapsedSinceLastPacket < delay) {
+      const remaining = delay - elapsedSinceLastPacket;
+      this._pingTimeoutTime = Date.now() + remaining;
+      this._pingTimeoutTimer = this.setTimeoutFn(() => {
+        this._checkPingTimeout(delay);
+      }, remaining);
+      if (this.opts.autoUnref) {
+        this._pingTimeoutTimer.unref();
+      }
+      return;
+    }
+
+    this._onClose("ping timeout");
   }
 
   /**

--- a/packages/engine.io/lib/socket.ts
+++ b/packages/engine.io/lib/socket.ts
@@ -58,6 +58,13 @@ export class Socket extends EventEmitter {
   private cleanupFn: any[] = [];
   private pingTimeoutTimer;
   private pingIntervalTimer;
+  /**
+   * Timestamp of the last packet received from the client, of any type. Used by
+   * the ping timeout check as a cheap liveness signal: a client that is clearly
+   * still sending data shouldn't be dropped just because its next expected pong
+   * happens to be delayed behind other traffic.
+   */
+  private lastPacketTime: number = Date.now();
 
   /**
    * This is the session identifier that the client will use in the subsequent HTTP requests. It must not be shared with
@@ -157,6 +164,7 @@ export class Socket extends EventEmitter {
     // export packet event
     debug(`received packet ${packet.type}`);
     this.emit("packet", packet);
+    this.lastPacketTime = Date.now();
 
     switch (packet.type) {
       case "ping":
@@ -227,15 +235,51 @@ export class Socket extends EventEmitter {
    */
   private resetPingTimeout() {
     clearTimeout(this.pingTimeoutTimer);
-    this.pingTimeoutTimer = setTimeout(
-      () => {
-        if (this.readyState === "closed") return;
-        this.onClose("ping timeout");
-      },
+    const timeout =
       this.protocol === 3
         ? this.server.opts.pingInterval + this.server.opts.pingTimeout
-        : this.server.opts.pingTimeout,
+        : this.server.opts.pingTimeout;
+    this.pingTimeoutTimer = setTimeout(
+      () => this.checkPingTimeout(timeout),
+      timeout,
     );
+  }
+
+  /**
+   * Called when the ping timeout timer fires. Rather than closing the
+   * connection unconditionally, this checks whether any packet (not
+   * necessarily the expected pong) has been received recently enough that the
+   * connection is clearly still alive, and if so, extends the wait instead of
+   * giving up.
+   *
+   * A previous attempt at this refreshed the ping timeout timer on every
+   * incoming packet, which was reverted for allocating a new timer per packet
+   * (wasteful under high message volume) and for not actually delaying the
+   * next scheduled ping, since only the timeout timer was touched, not the
+   * interval timer that governs it. Tracking a plain timestamp instead of
+   * touching any timer on the common (packet received, no timeout pending)
+   * path avoids the first problem, and only ever affects whether *this*
+   * already-scheduled check closes the connection or is extended - the
+   * server's own ping schedule (`pingIntervalTimer`) is never touched, so
+   * there's no change to when pings are sent.
+   *
+   * @param timeout - the ping timeout duration to apply, in milliseconds
+   * @private
+   */
+  private checkPingTimeout(timeout: number) {
+    if (this.readyState === "closed") return;
+
+    const elapsedSinceLastPacket = Date.now() - this.lastPacketTime;
+
+    if (elapsedSinceLastPacket < timeout) {
+      this.pingTimeoutTimer = setTimeout(
+        () => this.checkPingTimeout(timeout),
+        timeout - elapsedSinceLastPacket,
+      );
+      return;
+    }
+
+    this.onClose("ping timeout");
   }
 
   /**

--- a/packages/engine.io/test/server.js
+++ b/packages/engine.io/test/server.js
@@ -970,6 +970,101 @@ describe("server", () => {
       });
     });
 
+    it("should not trigger a ping timeout on the server if other packets are received while waiting for the pong", (done) => {
+      // pingInterval/pingTimeout are kept short and distinct so a bug here
+      // reliably shows up as a premature close within the test's own window,
+      // without needing to wait out multiple full cycles.
+      const opts = { allowUpgrades: false, pingInterval: 50, pingTimeout: 30 };
+      const engine = listen(opts, (port) => {
+        const socket = new ClientSocket(`ws://localhost:${port}`);
+        let serverClosed = false;
+        let messageInterval;
+
+        engine.on("connection", (conn) => {
+          conn.on("close", () => {
+            serverClosed = true;
+          });
+        });
+
+        socket.on("open", () => {
+          // This test is scoped to the server's own decision, so the client's
+          // independent ping timeout watchdog (covered separately below) is
+          // neutralized here - otherwise the client would eventually give up
+          // waiting for a next ping of its own accord (since the server never
+          // gets to send one without a pong to resume its own cycle from),
+          // which would mask whether the server's check is actually correct.
+          socket._resetPingTimeout = () => {};
+
+          // Suppress the client's automatic "ping" -> "pong" reply (simulating
+          // a pong that is delayed or lost behind other traffic), while still
+          // dispatching every other packet type as usual.
+          socket[sendPacketMethod] = (
+            (original) => (type, data, options, fn) => {
+              if (type === "pong") return;
+              return original(type, data, options, fn);
+            }
+          )(socket[sendPacketMethod].bind(socket));
+
+          // Keep sending "message" packets well within pingTimeout (30ms) of
+          // each other, so the connection should look alive to the server
+          // even though no pong ever arrives.
+          messageInterval = setInterval(() => socket.send("still here"), 10);
+        });
+
+        setTimeout(() => {
+          clearInterval(messageInterval);
+          expect(serverClosed).to.be(false);
+          socket.close();
+          engine.httpServer.close();
+          done();
+        }, 250); // several multiples of pingInterval + pingTimeout
+      });
+    });
+
+    it("should not trigger a ping timeout on the client if other packets are received while waiting for the next ping", (done) => {
+      // Symmetric counterpart of the test above: here the *server's* ping
+      // schedule is what's stalled (simulating it never getting a pong to
+      // resume its own cycle from), while both ends keep exchanging ordinary
+      // "message" packets. The client should not give up on its own accord
+      // just because no fresh ping arrives.
+      const opts = { allowUpgrades: false, pingInterval: 50, pingTimeout: 30 };
+      const engine = listen(opts, (port) => {
+        const socket = new ClientSocket(`ws://localhost:${port}`);
+        let clientClosed = false;
+        let clientMessageInterval;
+
+        socket.on("open", () => {
+          clientMessageInterval = setInterval(
+            () => socket.send("client alive"),
+            10,
+          );
+        });
+        socket.on("close", () => {
+          clientClosed = true;
+        });
+
+        engine.on("connection", (conn) => {
+          const originalSendPacket = conn.sendPacket.bind(conn);
+          conn.sendPacket = (type, data, options, fn) => {
+            if (type === "ping") return;
+            return originalSendPacket(type, data, options, fn);
+          };
+          const serverMessageInterval = setInterval(() => {
+            if (conn.readyState === "open") conn.send("still here");
+          }, 10);
+          conn.on("close", () => clearInterval(serverMessageInterval));
+        });
+
+        setTimeout(() => {
+          clearInterval(clientMessageInterval);
+          expect(clientClosed).to.be(false);
+          socket.close();
+          engine.httpServer.close();
+          done();
+        }, 250);
+      });
+    });
+
     it("should trigger when server closes a client", (done) => {
       const engine = listen({ allowUpgrades: false }, (port) => {
         const socket = new ClientSocket(`ws://localhost:${port}`);


### PR DESCRIPTION
## Summary

Fixes #5450.

The ping timeout timer only ever considered the one specific packet it was waiting for (the pong on the server side, the next ping on the client side), so a connection could be closed as unresponsive even while it was actively exchanging other packets - e.g. a high-throughput client whose pong happens to be delayed behind a backlog of its own outgoing messages, as described in the issue.

## Approach

Both `engine.io` (server) and `engine.io-client` now track the timestamp of the last packet received, of any type. When the ping timeout timer fires, instead of closing unconditionally, it checks whether a packet has arrived recently enough that the connection is clearly still alive, and if so, extends the wait (rescheduled for the remaining time) instead of giving up.

This needed to be applied on **both** sides to actually help: the server's own re-ping schedule is only resumed once it receives a pong, so if only the server were patched, an indefinitely-delayed pong would eventually cause the *client's own*, independent ping-timeout watchdog to give up instead (it also only resets on receiving a fresh ping) - just moving which side reports the disconnect, not fixing it. With both sides checking "has anything arrived lately" before giving up, a connection with ongoing traffic in either direction survives a delayed/lost specific ping or pong, as long as evidence of liveness keeps arriving.

### Why not just refresh the timer on every packet (the previous attempt)

A previous attempt at exactly this ([engine.io@be7b4e7](https://github.com/socketio/engine.io/commit/be7b4e7478132a9409603327b27d1aa1970dd1d9)) refreshed the ping timeout timer directly on every incoming packet, and was reverted ([socket.io@5359bae](https://github.com/socketio/socket.io/commit/5359bae683e2a25742bd4989d0355a8fc10d294e)) for two reasons, quoted from the revert commit message:

- "a new timer is allocated every time a packet is received, which is wasteful"
- "the next heartbeat is not actually delayed, since it's the timeout timer which gets reset, and not the interval timer... delaying the next heartbeat would be a breaking change"

This PR avoids both: tracking a plain timestamp on every packet is a cheap property write, not a timer allocation, on the common (nothing overdue) path. And the check only ever runs when a ping-timeout timer that's *already scheduled* fires - it never touches the interval timer that governs when the next ping is sent, so there's no change to the ping schedule itself, and no breaking change.

## Test plan

- Two new tests in `packages/engine.io/test/server.js`, one exercising the server-side check (with the client's own independent watchdog neutralized, to isolate the server's decision) and one exercising the client-side check (with the server's ping schedule stalled, to isolate the client's decision), both passing.
- Verified each new test actually catches a regression: with the corresponding fix reverted, the same test fails with a premature close at the expected time (confirmed via manual revert + re-run, not just inspection).
- Full existing suite passes, both protocol v4 (`npm run test:default`, 195 passing) and legacy protocol v3 (`npm run test:compat-v3`, 153 passing), no regressions.
- `engine.io-client`'s own test suite (`npm test`) passes, 94 passing.
- `npm run compile` and `npm run format:check` clean on both packages.

## Checklist

- [x] add one or more test cases, in order to avoid any regression in the future
- [x] make sure existing tests still pass