### PR TITLE
fix(eio,eio-client): handle close packets consistently across transports

### DIFF
--- a/packages/engine.io-client/lib/transport.ts
+++ b/packages/engine.io-client/lib/transport.ts
@@ -139,6 +139,14 @@ export abstract class Transport extends Emitter<
    */
   protected onData(data: RawData) {
     const packet = decodePacket(data, this.socket.binaryType);
+    if ("close" === packet.type) {
+      debug("got close packet");
+      if (this.readyState === "opening" || this.readyState === "open") {
+        this.doClose();
+        this.onClose({ description: "transport closed by the server" });
+      }
+      return;
+    }
     this.onPacket(packet);
   }
 

--- a/packages/engine.io/lib/transport.ts
+++ b/packages/engine.io/lib/transport.ts
@@ -162,7 +162,13 @@ export abstract class Transport extends EventEmitter {
    * @protected
    */
   protected onData(data: RawData) {
-    this.onPacket(this.parser.decodePacket(data));
+    const packet = this.parser.decodePacket(data);
+    if ("close" === packet.type) {
+      debug("got close packet");
+      this.close();
+      return;
+    }
+    this.onPacket(packet);
   }
 
   /**

--- a/packages/engine.io/test/server.js
+++ b/packages/engine.io/test/server.js
@@ -1604,6 +1604,56 @@ describe("server", () => {
       });
     });
 
+    it("should close transport upon receiving a close packet (ws)", (done) => {
+      const opts = { allowUpgrades: false, transports: ["websocket"] };
+      const engine = listen(opts, (port) => {
+        engine.on("connection", (conn) => {
+          conn.transport.on("close", done);
+        });
+        const socket = new ClientSocket(`ws://localhost:${port}`, {
+          transports: ["websocket"],
+        });
+        socket.on("open", () => {
+          // bypass the client library entirely and send a raw close packet
+          // ("1", per the Engine.IO protocol), to make sure the server
+          // reacts the same way regardless of which client implementation
+          // is on the other end
+          socket.transport.ws.send("1");
+        });
+      });
+    });
+
+    if (!IS_CLIENT_V3) {
+      // the "engine.io-client-v3" package used when IS_CLIENT_V3 is set is a
+      // separately published legacy dependency, not the "engine.io-client"
+      // package touched by this fix, so this test only applies to the
+      // current (v4) client
+      it("should make the client close its transport upon receiving a close packet (ws)", (done) => {
+        const opts = { allowUpgrades: false, transports: ["websocket"] };
+        const engine = listen(opts, (port) => {
+          engine.on("connection", (conn) => {
+            // simulate a server sending a close packet without necessarily
+            // closing the underlying connection itself right away (e.g. a
+            // different server implementation), to make sure the client
+            // reacts to the packet itself rather than relying on the
+            // underlying WebSocket connection being closed by the server
+            conn.transport.send([{ type: "close" }]);
+          });
+          const socket = new ClientSocket(`ws://localhost:${port}`, {
+            transports: ["websocket"],
+          });
+          socket.on("close", (reason, description) => {
+            expect(reason).to.eql("transport close");
+            // same wording as the polling transport, for consistency
+            expect(description.description).to.eql(
+              "transport closed by the server",
+            );
+            done();
+          });
+        });
+      });
+    }
+
     it("should close transport upon parse error (polling)", (done) => {
       const opts = { allowUpgrades: false, transports: ["polling"] };
       const engine = listen(opts, (port) => {


### PR DESCRIPTION
## Summary

Fixes #5286.

The polling transport already closes the connection when it receives a "close" packet, but the WebSocket transport silently ignored it and kept the connection running - on both the server and the client. This is inconsistent with the Engine.IO protocol, where `close` is a formal packet type (independent of the underlying WebSocket connection's own close frame), so any conformant implementation may send it over any transport.

## Approach

Added the same check to the shared base `Transport#onData()` in both `engine.io` and `engine.io-client`, rather than duplicating polling's own override:
- On the server, this also covers the uWebSockets.js-based WebSocket transport for free, since it relies on the same base method and doesn't override `onData()`.
- On the client, the close details now match the polling transport's existing wording (`"transport closed by the server"`), for consistency between transports.

Both fixes call the transport's real close procedure (`close()` / `doClose()` + `onClose()`), not just the internal state transition - an earlier version of this fix called `onClose()` directly (mirroring polling's own shortcut), but that leaves the underlying WebSocket connection open indefinitely, since polling's shortcut is safe only because each poll is a short-lived HTTP request that Node's HTTP server cleans up on its own, which doesn't apply to a persistent WebSocket connection.

## Out of scope

While investigating, two related gaps were found but intentionally left out of this PR to keep it focused on the reported issue:
- The `WebTransport` transport has the same underlying gap (it decodes and dispatches packets directly, bypassing `onData()` entirely), but it isn't mentioned in the issue and is disabled by default. Happy to follow up separately if maintainers want it addressed.
- This PR only reproduces the specific direction described in the issue (server sending a close packet, and the reverse). Nothing further intentionally deferred beyond `WebTransport` above.

## Test plan

- [x] New test: server closes the transport upon receiving a close packet from a WebSocket client
- [x] New test: client closes the transport upon receiving a close packet from the server (matches the issue's reproduction), including asserting the close details match polling's wording
- [x] Reverted each fix individually (`git stash` on just that file) and confirmed the corresponding new test fails without it, then restored and reconfirmed it passes
- [x] Checked directly (not just via the `readyState` field) that the underlying raw WebSocket connection is actually closed on both the server and client side, not just marked closed at the Engine.IO layer
- [x] Existing `engine.io` suite passes for both protocol v4 and legacy v3 (`EIO_CLIENT=3`) - the client-side test is skipped under legacy v3 mode, since that mode exercises the separately-published `engine.io-client-v3` package rather than the `engine.io-client` package touched by this PR
- [x] Existing `engine.io-client` suite passes
