### PR TITLE
fix(eio): expose EventEmitter interface on WebSocket upgrade response

### DIFF
--- a/packages/engine.io/lib/server.ts
+++ b/packages/engine.io/lib/server.ts
@@ -669,13 +669,17 @@ export abstract class BaseServer extends EventEmitter {
  *
  * @see https://nodejs.org/api/http.html#class-httpserverresponse
  */
-class WebSocketResponse {
+class WebSocketResponse extends EventEmitter {
   constructor(
     readonly req,
     readonly socket: Duplex,
   ) {
+    super();
     // temporarily store the response headers on the req object (see the "headers" event)
     req[kResponseHeaders] = {};
+    // some middlewares (like pino-http) rely on the "close" event to know when the response is done, which the
+    // underlying socket does not expose by default
+    socket.once("close", () => this.emit("close"));
   }
 
   public setHeader(name: string, value: any) {
@@ -695,6 +699,7 @@ class WebSocketResponse {
   public writeHead() {}
 
   public end() {
+    this.emit("finish");
     // we could return a proper error code, but the WebSocket client will emit an "error" event anyway.
     this.socket.destroy();
   }

--- a/packages/engine.io/lib/userver.ts
+++ b/packages/engine.io/lib/userver.ts
@@ -1,4 +1,5 @@
 import debugModule from "debug";
+import { EventEmitter } from "events";
 import { AttachOptions, BaseServer, Server } from "./server";
 import { HttpRequest, HttpResponse, TemplatedApp } from "uWebSockets.js";
 import transports from "./transports-uws";
@@ -76,7 +77,7 @@ export class uServer extends BaseServer {
     (app as TemplatedApp)
       .any(path, this.handleRequest.bind(this))
       //
-      .ws<{ transport: any }>(path, {
+      .ws<{ transport: any; response?: ResponseWrapper }>(path, {
         compression: options.compression,
         idleTimeout: options.idleTimeout,
         maxBackpressure: options.maxBackpressure,
@@ -94,7 +95,9 @@ export class uServer extends BaseServer {
           );
         },
         close: (ws, code, message) => {
-          ws.getUserData().transport.onClose(code, message);
+          const { transport, response } = ws.getUserData();
+          transport.onClose(code, message);
+          response?.emit("close");
         },
       });
   }
@@ -246,6 +249,10 @@ export class uServer extends BaseServer {
       res.upgrade(
         {
           transport,
+          // only set when middlewares are registered (see _applyMiddlewares); used to emit "close" on the
+          // response object once the WebSocket connection actually closes (see the `close` handler below) —
+          // unlike the plain Node.js HTTP server, UWS does not expose a persistent socket to listen on here
+          response: req.res instanceof ResponseWrapper ? req.res : undefined,
         },
         req.getHeader("sec-websocket-key"),
         req.getHeader("sec-websocket-protocol"),
@@ -288,12 +295,21 @@ export class uServer extends BaseServer {
   }
 }
 
-class ResponseWrapper {
+class ResponseWrapper extends EventEmitter {
   private statusWritten: boolean = false;
   private headers = [];
   private isAborted = false;
 
-  constructor(readonly res: HttpResponse) {}
+  constructor(readonly res: HttpResponse) {
+    super();
+    // some middlewares (like pino-http) rely on the "close" event to know when the response is done, which
+    // uWebSockets.js does not expose directly — mirrors WebSocketResponse in server.ts
+    res.onAborted(() => {
+      // Any attempt to use the UWS response object after abort will throw!
+      this.isAborted = true;
+      this.emit("close");
+    });
+  }
 
   public set statusCode(status: number) {
     if (!status) {
@@ -356,6 +372,7 @@ class ResponseWrapper {
   public end(data) {
     if (this.isAborted) return;
 
+    this.emit("finish");
     this.res.cork(() => {
       if (!this.statusWritten) {
         // status will be inferred as "200 OK"
@@ -372,13 +389,10 @@ class ResponseWrapper {
   }
 
   public onAborted(fn) {
-    if (this.isAborted) return;
-
-    this.res.onAborted(() => {
-      // Any attempt to use the UWS response object after abort will throw!
-      this.isAborted = true;
-      fn();
-    });
+    // kept for backward compatibility; the actual UWS-level abort handler is registered once in the
+    // constructor (UWS only supports a single onAborted() callback per response), so this now just
+    // subscribes to the "close" event it emits
+    this.on("close", fn);
   }
 
   public cork(fn) {

--- a/packages/engine.io/test/middlewares.js
+++ b/packages/engine.io/test/middlewares.js
@@ -56,6 +56,29 @@ describe("middlewares", () => {
     });
   });
 
+  it("should expose EventEmitter methods on the response object during upgrade (regression for pino-http)", (done) => {
+    const engine = listen((port) => {
+      engine.use((req, res, next) => {
+        expect(res.on).to.be.a("function");
+        res.on("close", () => {
+          if (engine.httpServer) {
+            engine.httpServer.close();
+          }
+          done();
+        });
+        next();
+      });
+
+      const socket = new WebSocket(
+        `ws://localhost:${port}/engine.io/?EIO=4&transport=websocket`,
+      );
+
+      socket.on("open", () => {
+        socket.close();
+      });
+    });
+  });
+
   it("should apply all middlewares in order", (done) => {
     const engine = listen((port) => {
       let count = 0;


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

Fixes #5072. During a WebSocket upgrade, `engine.io` applies middlewares against a `WebSocketResponse` object that only implements a small subset of `http.ServerResponse` (`setHeader`/`getHeader`/`removeHeader`/`write`/`writeHead`/`end`). It does not implement `EventEmitter`, so any middleware that calls `res.on(...)`, for example `pino-http`, which listens for `"close"` to know when the request finished, crashes with `TypeError: res.on is not a function`.

### New behavior

`WebSocketResponse` now extends `EventEmitter` and emits `"close"` when the underlying socket closes, and `"finish"` when `end()` is called, mirroring the events a real `http.ServerResponse` emits. Added a regression test in `test/middlewares.js` that registers a `res.on("close", ...)` listener during a WebSocket upgrade and asserts it fires.

### Other information (e.g. related issues)

Parts of this fix (root-cause analysis and implementation) were produced with the help of Claude Code. I reviewed and understood the change before opening this PR.

Verification performed:
- Added unit test passes, along with the full existing `middlewares.js`/`server.js`/`engine.io.js` suite (175 passing, 2 pre-existing unrelated pending), no regressions.
- Reproduced the exact bug report with the real `pino-http` package against an unpatched build (crashes with `res.on is not a function`), then confirmed the same script completes cleanly with this fix applied.
- `prettier --check` passes on the changed files.
