### PR TITLE
fix(engine): support Node 10 query parsing

### DIFF
--- a/packages/engine.io/lib/server.ts
+++ b/packages/engine.io/lib/server.ts
@@ -166,6 +166,23 @@ function parseSessionId(data: string): string | undefined {
   } catch (e) {}
 }
 
+export function parseQuery(params: URLSearchParams): Record<string, string> {
+  const query: Record<string, string> = {};
+
+  params.forEach((value, key) => {
+    // Define instead of assigning so a `__proto__` query parameter is kept as
+    // a regular own property, matching Object.fromEntries().
+    Object.defineProperty(query, key, {
+      value,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  return query;
+}
+
 // Object.hasOwn() was introduced in Node.js 16.9
 function hasOwn(obj: Record<string, any>, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(obj, key);
@@ -763,7 +780,7 @@ export class Server extends BaseServer {
     // try to leverage pre-existing `req._query` (e.g: from connect)
     if (!req._query) {
       const url = new URL(req.url, "https://socket.io");
-      req._query = Object.fromEntries(url.searchParams.entries());
+      req._query = parseQuery(url.searchParams);
     }
   }
 

--- a/packages/engine.io/lib/userver.ts
+++ b/packages/engine.io/lib/userver.ts
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-import { AttachOptions, BaseServer, Server } from "./server";
+import { AttachOptions, BaseServer, parseQuery, Server } from "./server";
 import { HttpRequest, HttpResponse, TemplatedApp } from "uWebSockets.js";
 import transports from "./transports-uws";
 import { EngineRequest } from "./transport";
@@ -42,7 +42,7 @@ export class uServer extends BaseServer {
     req.url = req.getUrl();
 
     const params = new URLSearchParams(req.getQuery());
-    req._query = Object.fromEntries(params.entries());
+    req._query = parseQuery(params);
 
     req.headers = {};
     req.forEach((key, value) => {

--- a/packages/engine.io/test/server.js
+++ b/packages/engine.io/test/server.js
@@ -42,6 +42,23 @@ describe("server", () => {
   });
 
   describe("verification", () => {
+    it("should support Node.js versions without Object.fromEntries", (done) => {
+      const fromEntries = Object.fromEntries;
+      Object.fromEntries = undefined;
+
+      engine = listen((port) => {
+        request
+          .get(`http://localhost:${port}/engine.io/`)
+          .query({ transport: "polling", EIO: 4 })
+          .end((err, res) => {
+            Object.fromEntries = fromEntries;
+            expect(err).to.be(null);
+            expect(res.status).to.be(200);
+            done();
+          });
+      });
+    });
+
     it("should disallow non-existent transports", (done) => {
       const partialDone = createPartialDone(done, 2);
 


### PR DESCRIPTION
## Summary

Fixes #5527.

Engine.IO advertises support for Node.js 10.2+, but both the standard HTTP server and the uWebSockets server parsed query strings with `Object.fromEntries()`, which was only added in Node.js 12. A polling handshake therefore threw before validation on supported Node 10 deployments.

Replace those calls with a shared `URLSearchParams` parser that uses `Object.defineProperty`. It preserves the previous last-value-wins behavior for duplicate keys and keeps `__proto__` as an ordinary own property rather than mutating the query object's prototype.

## Tests

- Added a regression test that removes `Object.fromEntries` and verifies a polling handshake still succeeds.
- `npm run compile --workspace=engine.io`
- `npx mocha --bail --exit test/server.js --grep 'without Object.fromEntries'`
- `npx prettier --check lib/server.ts lib/userver.ts test/server.js`
- `npx mocha --bail --exit` reached 90 passing tests (including the new regression and existing `__proto__` coverage); it then hit an existing xhr timeout after `npm ci --ignore-scripts` left the optional HTTP/3 native module unavailable on Windows.
