### PR TITLE
docs: replace broken Slack badges with Discord

### DIFF
--- a/packages/socket.io-client/README.md
+++ b/packages/socket.io-client/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://github.com/socketio/socket.io-client/workflows/CI/badge.svg?branch=main)](https://github.com/socketio/socket.io-client/actions)
 [![NPM version](https://badge.fury.io/js/socket.io-client.svg)](https://www.npmjs.com/package/socket.io-client)
 ![Downloads](http://img.shields.io/npm/dm/socket.io-client.svg?style=flat)
-[![](http://slack.socket.io/badge.svg?)](http://slack.socket.io)
+[![Discord](https://img.shields.io/badge/discord-online-brightgreen.svg)](https://discord.gg/G7Qnnhy)
 
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/socket.svg)](https://saucelabs.com/u/socket)
 

--- a/packages/socket.io/Readme.md
+++ b/packages/socket.io/Readme.md
@@ -4,7 +4,7 @@
 [![Build Status](https://github.com/socketio/socket.io/workflows/CI/badge.svg)](https://github.com/socketio/socket.io/actions)
 [![NPM version](https://badge.fury.io/js/socket.io.svg)](https://www.npmjs.com/package/socket.io)
 ![Downloads](https://img.shields.io/npm/dm/socket.io.svg?style=flat)
-[![](https://slackin-socketio.now.sh/badge.svg)](https://slackin-socketio.now.sh)
+[![Discord](https://img.shields.io/badge/discord-online-brightgreen.svg)](https://discord.gg/G7Qnnhy)
 
 ## Features
 


### PR DESCRIPTION
## Summary
- The Slack badges on the `socket.io` and `socket.io-client` package READMEs point at hosts that no longer resolve (`slackin-socketio.now.sh` and `slack.socket.io`).
- Swap them for the Discord badge already used in the NestJS example (`https://discord.gg/G7Qnnhy`).

Fixes #5229.

## Test plan
- [ ] Open both README badge links and confirm they reach Discord
- [ ] Confirm no remaining `slack.socket.io` / `slackin-socketio.now.sh` references in those READMEs