### PR TITLE
docs: fix broken download badge link and grammar typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,9 +75,9 @@ This repository is a [monorepo](https://en.wikipedia.org/wiki/Monorepo) which co
 | `engine.io`                    | The server-side implementation of the low-level communication layer.                                                                  |
 | `engine.io-client`             | The client-side implementation of the low-level communication layer.                                                                  |
 | `engine.io-parser`             | The parser responsible for encoding and decoding Engine.IO packets, used by both the `engine.io` and `engine.io-client` packages.     |
-| `socket.io`                    | The server-side implementation of the bidirectional channel, built on top on the `engine.io` package.                                 |
+| `socket.io`                    | The server-side implementation of the bidirectional channel, built on top of the `engine.io` package.                                 |
 | `socket.io-adapter`            | An extensible component responsible for broadcasting a packet to all connected clients, used by the `socket.io` package.              |
-| `socket.io-client`             | The client-side implementation of the bidirectional channel, built on top on the `engine.io-client` package.                          |
+| `socket.io-client`             | The client-side implementation of the bidirectional channel, built on top of the `engine.io-client` package.                          |
 | `@socket.io/cluster-engine`    | A cluster-friendly engine to share load between multiple Node.js processes (without sticky sessions)                                  |
 | `@socket.io/component-emitter` | An `EventEmitter` implementation, similar to the one provided by [Node.js](https://nodejs.org/api/events.html) but for all platforms. |
 | `socket.io-parser`             | The parser responsible for encoding and decoding Socket.IO packets, used by both the `socket.io` and `socket.io-client` packages.     |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest NPM version](https://img.shields.io/npm/v/socket.io.svg)](https://www.npmjs.com/package/socket.io)
 [![Build status](https://github.com/socketio/socket.io/actions/workflows/ci-socket.io.yml/badge.svg?branch=main)](https://github.com/socketio/socket.io/actions/workflows/ci-socket.io.yml)
-[![Downloads per month](https://img.shields.io/npm/dm/socket.io.svg)]((https://www.npmjs.com/package/socket.io))
+[![Downloads per month](https://img.shields.io/npm/dm/socket.io.svg)](https://www.npmjs.com/package/socket.io)
 
 ## Getting Started
 


### PR DESCRIPTION

<img width="796" height="112" alt="image" src="https://github.com/user-attachments/assets/d3a3ba9c-f1be-4df0-b49c-adf1ff9c2333" />

<img width="784" height="89" alt="image" src="https://github.com/user-attachments/assets/e15e6ee7-b1db-4837-b5a4-5d37514a7d7b" />


### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

The "Downloads per month" badge in `README.md` has a duplicated opening parenthesis (`]((`), which breaks the Markdown link so it does not point to the npm package page.

The package table in `CONTRIBUTING.md` describes `socket.io` and `socket.io-client` as "built on top on the ... package", which is grammatically incorrect.

### New behavior

The badge link is well-formed and points to the npm package page.

The two package descriptions read "built on top of the ... package".

### Other information (e.g. related issues)

No related issue
