### PR TITLE
fix(socket.io-client): export reserved-events types to fix ts(4023) on declaration emit

### DIFF
--- a/packages/engine.io-client/lib/globals.node.ts
+++ b/packages/engine.io-client/lib/globals.node.ts
@@ -6,7 +6,7 @@ export function createCookieJar() {
   return new CookieJar();
 }
 
-interface Cookie {
+export interface Cookie {
   name: string;
   value: string;
   expires?: Date;

--- a/packages/engine.io-client/lib/index.ts
+++ b/packages/engine.io-client/lib/index.ts
@@ -2,16 +2,23 @@ import { Socket } from "./socket.js";
 
 export { Socket };
 export {
+  HandshakeData,
   SocketOptions,
+  SocketReservedEvents,
   SocketWithoutUpgrade,
   SocketWithUpgrade,
+  WriteOptions,
 } from "./socket.js";
 export const protocol = Socket.protocol;
-export { Transport, TransportError } from "./transport.js";
+export {
+  Transport,
+  TransportError,
+  TransportReservedEvents,
+} from "./transport.js";
 export { transports } from "./transports/index.js";
 export { installTimerFunctions } from "./util.js";
 export { parse } from "./contrib/parseuri.js";
-export { nextTick } from "./globals.node.js";
+export { Cookie, nextTick } from "./globals.node.js";
 
 export { Fetch } from "./transports/polling-fetch.js";
 export { XHR as NodeXHR } from "./transports/polling-xhr.node.js";

--- a/packages/engine.io-client/lib/socket.ts
+++ b/packages/engine.io-client/lib/socket.ts
@@ -266,7 +266,7 @@ type BaseSocketOptions = Omit<SocketOptions, "transports"> & {
   transports: TransportCtor[];
 };
 
-interface HandshakeData {
+export interface HandshakeData {
   sid: string;
   upgrades: string[];
   pingInterval: number;
@@ -274,7 +274,7 @@ interface HandshakeData {
   maxPayload: number;
 }
 
-interface SocketReservedEvents {
+export interface SocketReservedEvents {
   open: () => void;
   handshake: (data: HandshakeData) => void;
   packet: (packet: Packet) => void;
@@ -295,7 +295,7 @@ interface SocketReservedEvents {
 
 type SocketState = "opening" | "open" | "closing" | "closed";
 
-interface WriteOptions {
+export interface WriteOptions {
   compress?: boolean;
 }
 

--- a/packages/engine.io-client/lib/transport.ts
+++ b/packages/engine.io-client/lib/transport.ts
@@ -25,7 +25,7 @@ export interface CloseDetails {
   context?: unknown; // context should be typed as CloseEvent | XMLHttpRequest, but these types are not available on non-browser platforms
 }
 
-interface TransportReservedEvents {
+export interface TransportReservedEvents {
   open: () => void;
   error: (err: TransportError) => void;
   packet: (packet: Packet) => void;

--- a/packages/socket.io-client/lib/index.ts
+++ b/packages/socket.io-client/lib/index.ts
@@ -1,6 +1,11 @@
 import { url } from "./url.js";
-import { Manager, ManagerOptions } from "./manager.js";
-import { DisconnectDescription, Socket, SocketOptions } from "./socket.js";
+import { Manager, ManagerOptions, ManagerReservedEvents } from "./manager.js";
+import {
+  DisconnectDescription,
+  Socket,
+  SocketOptions,
+  SocketReservedEvents,
+} from "./socket.js";
 import debugModule from "debug"; // debug()
 
 const debug = debugModule("socket.io-client"); // debug()
@@ -94,8 +99,10 @@ export {
   DisconnectDescription,
   Manager,
   ManagerOptions,
+  ManagerReservedEvents,
   Socket,
   SocketOptions,
+  SocketReservedEvents,
   lookup as io,
   lookup as connect,
   lookup as default,

--- a/packages/socket.io-client/lib/manager.ts
+++ b/packages/socket.io-client/lib/manager.ts
@@ -86,7 +86,7 @@ export interface ManagerOptions extends EngineOptions {
   parser: any;
 }
 
-interface ManagerReservedEvents {
+export interface ManagerReservedEvents {
   open: () => void;
   error: (err: Error) => void;
   ping: () => void;

--- a/packages/socket.io-client/lib/socket.ts
+++ b/packages/socket.io-client/lib/socket.ts
@@ -111,7 +111,7 @@ export type DisconnectDescription =
       context?: unknown; // context should be typed as CloseEvent | XMLHttpRequest, but these types are not available on non-browser platforms
     };
 
-interface SocketReservedEvents {
+export interface SocketReservedEvents {
   connect: () => void;
   connect_error: (err: Error) => void;
   disconnect: (

--- a/packages/socket.io-client/test/types/ts4023.test.ts
+++ b/packages/socket.io-client/test/types/ts4023.test.ts
@@ -1,0 +1,18 @@
+import { io } from "socket.io-client";
+
+// Reproduces https://github.com/socketio/socket.io/issues/5307
+//
+// The public types of Socket / Manager (and the underlying Engine.IO Socket and
+// its Transport) are parameterized by "reserved events" maps (SocketReservedEvents,
+// ManagerReservedEvents, TransportReservedEvents, ...) that were not exported.
+// An exported value whose inferred type references those maps therefore cannot
+// be named during declaration emit: `tsc --declaration` fails with ts(4023).
+const socket = io("https://example.com");
+
+// `listeners` / `write` return (or accept) types that reference the reserved-events
+// maps, forcing the declaration emitter to name them.
+export const socketListeners = socket.listeners;
+export const managerListeners = socket.io.listeners;
+export const engineListeners = socket.io.engine.listeners;
+export const transportListeners = socket.io.engine.transport.listeners;
+export const engineWrite = socket.io.engine.write;

--- a/packages/socket.io-client/test/types/tsconfig.json
+++ b/packages/socket.io-client/test/types/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": false,
+    "skipLibCheck": true,
+    "declaration": true,
+    "noEmit": true,
+    "types": ["node"],
+    "lib": ["es2018", "dom"],
+    "paths": {
+      "@socket.io/component-emitter": [
+        "../../../../packages/socket.io-component-emitter/lib/cjs/index.d.ts"
+      ],
+      "socket.io-client": [
+        "../../../../packages/socket.io-client/lib/index.ts"
+      ],
+      "engine.io-client": [
+        "../../../../packages/engine.io-client/lib/index.ts"
+      ],
+      "socket.io-parser": [
+        "../../../../packages/socket.io-parser/lib/index.ts"
+      ],
+      "engine.io-parser": ["../../../../packages/engine.io-parser/lib/index.ts"]
+    }
+  },
+  "include": ["ts4023.test.ts"]
+}


### PR DESCRIPTION
### Description

Fixes #5307.

When a downstream consumer re-exports a value whose (inferred) type references `socket.io-client`'s `Socket` / `Manager` types, TypeScript's declaration emitter must be able to name the "reserved events" maps those classes are parameterized with. Those maps were not exported, so any `tsc --declaration` pass over such a consumer failed with:

```
Exported variable 'X' has or is using name 'SocketReservedEvents' from external module "..." but cannot be named.ts(4023)
```

As diagnosed in the issue discussion, the failing names (`SocketReservedEvents`, `ManagerReservedEvents`, `HandshakeData`, `WriteOptions`, `TransportReservedEvents`, `Cookie`) are all unexported interfaces.

### Changes

Type-only additions (no runtime behaviour change):

- `packages/socket.io-client/lib/socket.ts`: export `SocketReservedEvents`
- `packages/socket.io-client/lib/manager.ts`: export `ManagerReservedEvents`
- `packages/engine.io-client/lib/socket.ts`: export `SocketReservedEvents`, `HandshakeData`, `WriteOptions`
- `packages/engine.io-client/lib/transport.ts`: export `TransportReservedEvents`
- `packages/engine.io-client/lib/globals.node.ts`: export `Cookie` (referenced by the exported `parse`/`CookieJar`)
- re-export the new types from both packages' `lib/index.ts`, following the pattern used for `DisconnectDescription` in #5392

### Test

Added a declaration-emit regression fixture at `packages/socket.io-client/test/types/ts4023.test.ts` that mirrors the issue's reproducer (an exported value whose inferred type references the reserved-events maps of `Socket`, `Manager`, the Engine.IO `Socket` and its `Transport`). On `main` it fails with the exact ts(4023) errors reported in the issue:

```
./node_modules/.bin/tsc -p packages/socket.io-client/test/types/tsconfig.json
```

After the fix, the same command exits cleanly (verified with the TypeScript version pinned in this repo, `^6.0.3`).

### Related

- #5392 exported `DisconnectDescription` in the same manner and was merged.