### PR TITLE
docs(examples): update create-react-app example docs links

### DIFF
--- a/examples/create-react-app-example/README.md
+++ b/examples/create-react-app-example/README.md
@@ -19,7 +19,7 @@ Starts the Socket.IO server.
 ### `yarn test`
 
 Launches the test runner in the interactive watch mode.<br />
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+See the section about [running tests](https://create-react-app.dev/docs/running-tests) for more information.
 
 ### `yarn build`
 
@@ -29,7 +29,7 @@ It correctly bundles React in production mode and optimizes the build for the be
 The build is minified and the filenames include the hashes.<br />
 Your app is ready to be deployed!
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+See the section about [deployment](https://create-react-app.dev/docs/deployment) for more information.
 
 ### `yarn eject`
 
@@ -37,36 +37,36 @@ See the section about [deployment](https://facebook.github.io/create-react-app/d
 
 If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
+Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you can tweak them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
 
 You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
 
 ## Learn More
 
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
+You can learn more in the [Create React App documentation](https://create-react-app.dev/docs/getting-started).
 
 To learn React, check out the [React documentation](https://reactjs.org/).
 
 ### Code Splitting
 
-This section has moved here: https://facebook.github.io/create-react-app/docs/code-splitting
+This section has moved here: https://create-react-app.dev/docs/code-splitting
 
 ### Analyzing the Bundle Size
 
-This section has moved here: https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size
+This section has moved here: https://create-react-app.dev/docs/analyzing-the-bundle-size
 
 ### Making a Progressive Web App
 
-This section has moved here: https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app
+This section has moved here: https://create-react-app.dev/docs/making-a-progressive-web-app
 
 ### Advanced Configuration
 
-This section has moved here: https://facebook.github.io/create-react-app/docs/advanced-configuration
+This section has moved here: https://create-react-app.dev/docs/advanced-configuration
 
 ### Deployment
 
-This section has moved here: https://facebook.github.io/create-react-app/docs/deployment
+This section has moved here: https://create-react-app.dev/docs/deployment
 
 ### `yarn build` fails to minify
 
-This section has moved here: https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify
+This section has moved here: https://create-react-app.dev/docs/troubleshooting#npm-run-build-fails-to-minify


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
`examples/create-react-app-example/README.md` still points at `https://facebook.github.io/create-react-app/docs/...`. Those pages return GET 404. CRA docs now live on `https://create-react-app.dev/docs/...`.

### New behavior
All of those documentation links now use the current `create-react-app.dev` URLs. The GitHub repo link for CRA itself is unchanged.

### Other information (e.g. related issues)
Verified replacements with GET:

- `https://facebook.github.io/create-react-app/docs/getting-started` -> 404
- `https://create-react-app.dev/docs/getting-started` -> 200
- same result for running-tests, deployment, code-splitting, analyzing-the-bundle-size, making-a-progressive-web-app, advanced-configuration, and troubleshooting
