### PR TITLE
fix(eio): use Node 10-safe query parser on the uWS server

### DIFF
--- a/packages/engine.io/lib/userver.ts
+++ b/packages/engine.io/lib/userver.ts
@@ -3,6 +3,7 @@ import { AttachOptions, BaseServer, Server } from "./server";
 import { HttpRequest, HttpResponse, TemplatedApp } from "uWebSockets.js";
 import transports from "./transports-uws";
 import { EngineRequest } from "./transport";
+import { objectFromEntries } from "./utils/objectFromEntries";
 
 const debug = debugModule("engine:uws");
 
@@ -42,7 +43,7 @@ export class uServer extends BaseServer {
     req.url = req.getUrl();
 
     const params = new URLSearchParams(req.getQuery());
-    req._query = Object.fromEntries(params.entries());
+    req._query = objectFromEntries(params.entries());
 
     req.headers = {};
     req.forEach((key, value) => {


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

`engine.io` still advertises `engines.node: >=10.2.0`. The HTTP server path was restored to a Node 10-compatible query parser in ae7fb46, but the uWebSockets server still parses the query string with `Object.fromEntries()`, which does not exist on Node 10/11.

A handshake on the uWS transport therefore throws before validation on the Node versions the package still claims to support.

### New behavior

`packages/engine.io/lib/userver.ts` now uses the existing `objectFromEntries` helper, matching `server.ts`.

### Other information (e.g. related issues)

Follow-up to #5527 / ae7fb46. The HTTP path is already fixed; this is the leftover uWS call site.
