### PR TITLE
fix(sio): parse Engine.v3 namespace query without Object.fromEntries

### DIFF
--- a/packages/socket.io/lib/client.ts
+++ b/packages/socket.io/lib/client.ts
@@ -11,6 +11,16 @@ import type { Socket as RawSocket } from "engine.io";
 
 const debug = debugModule("socket.io:client");
 
+function objectFromEntries(
+  entries: Iterable<readonly [PropertyKey, string]>,
+): Record<string, string> {
+  const obj: Record<string, string> = Object.create(null);
+  for (const [key, value] of entries) {
+    obj[key as string] = value;
+  }
+  return obj;
+}
+
 interface WriteOptions {
   compress?: boolean;
   volatile?: boolean;
@@ -296,7 +306,7 @@ export class Client<
     const url = new URL(packet.nsp, "https://socket.io");
     return {
       namespace: url.pathname,
-      authPayload: Object.fromEntries(url.searchParams.entries()),
+      authPayload: objectFromEntries(url.searchParams.entries()),
     };
   }
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

`socket.io` still advertises `engines.node: >=10.2.0`. Engine.v3 namespace handshake parsing in `Client._parseNamespace` uses `Object.fromEntries()` on `URLSearchParams`, which does not exist on Node 10/11.

A protocol-3 connect packet with query auth therefore throws on the Node versions the package still claims to support.

### New behavior

Parse the query with a local `objectFromEntries` helper that does not depend on `Object.fromEntries`.

### Other information (e.g. related issues)

Related leftover from #5527. Separate from the engine.io HTTP/uWS query parsers.
