### PR TITLE
fix(adapter): do not let volatile packets break connection state recovery

### DIFF
--- a/packages/socket.io-adapter/lib/in-memory-adapter.ts
+++ b/packages/socket.io-adapter/lib/in-memory-adapter.ts
@@ -466,7 +466,9 @@ export class SessionAwareAdapter extends Adapter {
     const missedPackets = [];
     for (let i = index + 1; i < this.packets.length; i++) {
       const packet = this.packets[i];
-      if (shouldIncludePacket(session.rooms, packet.opts)) {
+      // volatile packets are part of the offset chain but are never replayed
+      const isVolatile = packet.opts.flags?.volatile !== undefined;
+      if (!isVolatile && shouldIncludePacket(session.rooms, packet.opts)) {
         missedPackets.push(packet.data);
       }
     }
@@ -478,15 +480,16 @@ export class SessionAwareAdapter extends Adapter {
 
   override broadcast(packet: any, opts: BroadcastOptions) {
     const isEventPacket = packet.type === 2;
-    // packets with acknowledgement are not stored because the acknowledgement function cannot be serialized and
-    // restored on another server upon reconnection
+    // packets with acknowledgement are not stored because the acknowledgement function cannot be
+    // serialized and restored on another server upon reconnection
     const withoutAcknowledgement = packet.id === undefined;
-    const notVolatile = opts.flags?.volatile === undefined;
-    if (isEventPacket && withoutAcknowledgement && notVolatile) {
+    if (isEventPacket && withoutAcknowledgement) {
       const id = yeast();
       // the offset is stored at the end of the data array, so the client knows the ID of the last packet it has
       // processed (and the format is backward-compatible)
       packet.data.push(id);
+      // volatile packets are included in the offset chain so that the client always sends a known
+      // offset upon reconnection, but they are excluded from the replay in restoreSession()
       this.packets.push({
         id,
         opts,

--- a/packages/socket.io-adapter/test/index.ts
+++ b/packages/socket.io-adapter/test/index.ts
@@ -551,5 +551,67 @@ describe("socket.io-adapter", () => {
 
       expect(session).to.be(null);
     });
+
+    it("should still restore a session after the client received a volatile packet", async () => {
+      const adapter = new SessionAwareAdapter({
+        server: {
+          encoder: {
+            encode(packet) {
+              return packet;
+            },
+          },
+          opts: {
+            connectionStateRecovery: {
+              maxDisconnectionDuration: 5000,
+            },
+          },
+        },
+      });
+
+      adapter.persistSession({
+        sid: "abc",
+        pid: "def",
+        data: "ghi",
+        rooms: ["r1"],
+      });
+
+      const packetData = ["hello"];
+
+      adapter.broadcast(
+        {
+          nsp: "/",
+          type: 2,
+          data: packetData,
+        },
+        {
+          rooms: new Set(),
+          except: new Set(),
+        },
+      );
+
+      const volatileData = ["status", "connected"];
+
+      adapter.broadcast(
+        {
+          nsp: "/",
+          type: 2,
+          data: volatileData,
+        },
+        {
+          rooms: new Set(),
+          except: new Set(),
+          flags: {
+            volatile: true,
+          },
+        },
+      );
+
+      // the adapter appends its own offset at the end of the data array, so the client stores
+      // that offset instead of the last argument of the event itself
+      const session = await adapter.restoreSession("def", volatileData[2]);
+
+      expect(session).to.not.be(null);
+      expect(session.missedPackets.length).to.eql(0);
+    });
   });
 });


### PR DESCRIPTION
## Problem

When `connectionStateRecovery` is enabled, a volatile event whose last argument is a string breaks the recovery of the client that received it.

Reproduction (server + client from current main):

```js
const io = new Server(httpServer, { connectionStateRecovery: {} });

io.on("connection", (socket) => {
  // ...
});

// after a normal broadcast has initialized the offset chain:
io.volatile.emit("status", "connected");
```

The client then disconnects and reconnects: `socket.recovered` is `false`, and every packet emitted during the disconnection is silently lost.

With the same scenario minus the `io.volatile.emit(...)` line, `socket.recovered` is `true`.

## Cause

The two sides of the offset mechanism disagree about volatile packets:

- server side (`SessionAwareAdapter.broadcast()`): a volatile EVENT packet gets **no** offset appended
- client side (`emitEvent()`): any trailing string argument of a received event is stored as the offset

So after `io.volatile.emit("status", "connected")`, the client stores the literal string "connected" as its offset. On reconnection, `restoreSession()` does `findIndex(packet.id === "connected")`, which fails, and the session is dropped.

This also affects the cluster adapters, which share the same condition in `addOffsetIfNecessary()`. I have deliberately not touched them here, because their packet storage/replay lives in the external adapter packages and needs to be changed in sync.

## Fix

In the in-memory adapter, volatile EVENT packets are now part of the offset chain like any other EVENT packet (they get an offset, and they are stored), but they are excluded from the replay in `restoreSession()`. Their semantics are unchanged - a volatile packet is still never delivered late.

## Testing

- new test in `packages/socket.io-adapter/test/index.ts`: session restore still succeeds with the volatile packet's offset, and the volatile packet is still excluded from `missedPackets`
- `npm test` in `packages/socket.io-adapter`: 49 passing (48 before)
- full suite in `packages/socket.io`: 216 passing

I also verified end-to-end with a script against the built packages: before the fix `recovered: false` / no replay; after the fix `recovered: true` / non-volatile packets replayed in order / volatile packets not replayed.