### PR TITLE
fix(engine.io): run the polling write callback when the client aborts a compressed response

### DIFF
--- a/packages/engine.io/lib/transports/polling.ts
+++ b/packages/engine.io/lib/transports/polling.ts
@@ -322,6 +322,15 @@ export class Polling extends Transport {
     const stream = compressionMethods[encoding](this.httpCompression);
 
     let isErrored = false;
+    let isDone = false;
+
+    const done = () => {
+      if (isDone || isErrored) {
+        return;
+      }
+      isDone = true;
+      callback();
+    };
 
     stream.on("error", (err) => {
       isErrored = true;
@@ -329,11 +338,11 @@ export class Polling extends Transport {
       callback(err);
     });
 
-    this.res.once("finish", () => {
-      if (!isErrored) {
-        callback();
-      }
-    });
+    // 'close' also fires after a normal completion, hence the guard: whatever
+    // happens, the write callback must run exactly once so the transport
+    // cleans up its request state and emits 'drain'.
+    this.res.once("finish", done);
+    this.res.once("close", done);
 
     stream.pipe(this.res);
     stream.end(data);

--- a/packages/engine.io/test/compression-abort.js
+++ b/packages/engine.io/test/compression-abort.js
@@ -1,0 +1,76 @@
+/* eslint-disable standard/no-callback-literal */
+
+const http = require("http");
+const crypto = require("crypto");
+const cookieMod = require("cookie");
+const { listen } = require("./common");
+const expect = require("expect.js");
+
+function getSidFromResponse(res) {
+  const c = cookieMod.parse(res.headers["set-cookie"][0]);
+  return c[Object.keys(c)[0]];
+}
+
+describe("polling compression", () => {
+  let engine;
+
+  afterEach(() => {
+    if (engine && engine.httpServer) {
+      engine.httpServer.close();
+    }
+  });
+
+  it("should not lose the write callback when the client aborts a compressed response mid-stream", (done) => {
+    engine = listen(
+      {
+        cookie: true,
+        transports: ["polling"],
+        httpCompression: { threshold: 0 },
+        pingInterval: 60000,
+        pingTimeout: 60000,
+      },
+      (port) => {
+        // incompressible content so real bytes keep flowing to the socket
+        const chunk = crypto.randomBytes(1024 * 1024).toString("base64");
+        let sendCallbackCalled = false;
+
+        engine.on("connection", (c) => {
+          const spam = setInterval(() => {
+            if (c.readyState !== "open") {
+              clearInterval(spam);
+              return;
+            }
+            c.send(chunk, () => {
+              sendCallbackCalled = true;
+            });
+          }, 5);
+          setTimeout(() => clearInterval(spam), 2000);
+        });
+
+        http.get({ port, path: "/engine.io/?transport=polling" }, (res) => {
+          const sid = getSidFromResponse(res);
+          const pollReq = http.get(
+            {
+              port,
+              path: "/engine.io/?transport=polling&sid=" + sid,
+              headers: { "Accept-Encoding": "gzip, deflate" },
+            },
+            (pollRes) => {
+              // abort on headers, before any body byte is written
+              pollReq.destroy();
+              setTimeout(() => {
+                try {
+                  expect(sendCallbackCalled).to.be(true);
+                  done();
+                } catch (e) {
+                  done(e);
+                }
+              }, 1500);
+            },
+          );
+          pollReq.on("error", () => {}); // expected: socket hang up
+        });
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Since 91dd763 ("perf(eio): stream compressed polling responses"), `doWrite()` invokes its callback only from the response's `'finish'` handler. If the client aborts the polling request while a large compressed payload is still streaming, `'finish'` never fires — and nothing errors on the zlib pipeline either, because writes into the destroyed socket just become no-ops.

Consequences of the lost callback (`write()` in polling.ts):

- `req.cleanup()` never runs for that request
- `this.emit("drain")` never fires, so the send callbacks queued for that batch (`sentCallbackFn`) are dropped

Before 91dd763, the whole payload was buffered and the callback ran unconditionally right after `res.end()`, so this could not happen.

Reproduction: new test `packages/engine.io/test/compression-abort.js` — a client opens a polling request with `Accept-Encoding: gzip`, the server keeps sending incompressible random data (threshold 0), and the client destroys the request as soon as the response headers arrive. On current main, the server-side send callback of that batch is never invoked; with this PR it always is (verified by stashing the fix and re-running).

## Fix

The callback now also runs on the response's `'close'` event, with a guard so it still runs exactly once (`'close'` also fires after normal completion):

```ts
this.res.once("finish", done);
this.res.once("close", done);
```

## Testing

- new test: `packages/engine.io/test/compression-abort.js` (fails without the fix, passes with it)
- existing suites unaffected