### PR TITLE
fix: allow session recovery even if no event was received

### DIFF
--- a/packages/socket.io-adapter/lib/in-memory-adapter.ts
+++ b/packages/socket.io-adapter/lib/in-memory-adapter.ts
@@ -387,11 +387,11 @@ export class Adapter extends EventEmitter {
   /**
    * Restore the session and find the packets that were missed by the client.
    * @param pid
-   * @param offset
+   * @param offset - the offset of the last packet received by the client, if any
    */
   public restoreSession(
     pid: PrivateSessionId,
-    offset: string,
+    offset?: string,
   ): Promise<Session> {
     return null;
   }
@@ -444,7 +444,7 @@ export class SessionAwareAdapter extends Adapter {
 
   override restoreSession(
     pid: PrivateSessionId,
-    offset: string,
+    offset?: string,
   ): Promise<Session> {
     const session = this.sessions.get(pid);
     if (!session) {
@@ -458,16 +458,18 @@ export class SessionAwareAdapter extends Adapter {
       this.sessions.delete(pid);
       return null;
     }
-    const index = this.packets.findIndex((packet) => packet.id === offset);
-    if (index === -1) {
-      // the offset may be too old
-      return null;
-    }
     const missedPackets = [];
-    for (let i = index + 1; i < this.packets.length; i++) {
-      const packet = this.packets[i];
-      if (shouldIncludePacket(session.rooms, packet.opts)) {
-        missedPackets.push(packet.data);
+    if (offset !== undefined) {
+      const index = this.packets.findIndex((packet) => packet.id === offset);
+      if (index === -1) {
+        // the offset may be too old
+        return null;
+      }
+      for (let i = index + 1; i < this.packets.length; i++) {
+        const packet = this.packets[i];
+        if (shouldIncludePacket(session.rooms, packet.opts)) {
+          missedPackets.push(packet.data);
+        }
       }
     }
     return Promise.resolve({

--- a/packages/socket.io-adapter/lib/in-memory-adapter.ts
+++ b/packages/socket.io-adapter/lib/in-memory-adapter.ts
@@ -458,18 +458,19 @@ export class SessionAwareAdapter extends Adapter {
       this.sessions.delete(pid);
       return null;
     }
-    const missedPackets = [];
+    let index = -1;
     if (offset !== undefined) {
-      const index = this.packets.findIndex((packet) => packet.id === offset);
+      index = this.packets.findIndex((packet) => packet.id === offset);
       if (index === -1) {
         // the offset may be too old
         return null;
       }
-      for (let i = index + 1; i < this.packets.length; i++) {
-        const packet = this.packets[i];
-        if (shouldIncludePacket(session.rooms, packet.opts)) {
-          missedPackets.push(packet.data);
-        }
+    }
+    const missedPackets = [];
+    for (let i = index + 1; i < this.packets.length; i++) {
+      const packet = this.packets[i];
+      if (shouldIncludePacket(session.rooms, packet.opts)) {
+        missedPackets.push(packet.data);
       }
     }
     return Promise.resolve({

--- a/packages/socket.io-adapter/test/index.ts
+++ b/packages/socket.io-adapter/test/index.ts
@@ -551,5 +551,48 @@ describe("socket.io-adapter", () => {
 
       expect(session).to.be(null);
     });
+
+    it("should restore a known session without offset", async () => {
+      const adapter = new SessionAwareAdapter({
+        server: {
+          encoder: {
+            encode(packet) {
+              return packet;
+            },
+          },
+          opts: {
+            connectionStateRecovery: {
+              maxDisconnectionDuration: 5000,
+            },
+          },
+        },
+      });
+
+      adapter.persistSession({
+        sid: "abc",
+        pid: "def",
+        data: "ghi",
+        rooms: ["r1", "r2"],
+      });
+
+      adapter.broadcast(
+        {
+          nsp: "/",
+          type: 2,
+          data: ["hello"],
+        },
+        {
+          rooms: new Set(),
+          except: new Set(),
+        },
+      );
+
+      const session = await adapter.restoreSession("def");
+
+      expect(session).to.not.be(null);
+      expect(session.sid).to.eql("abc");
+      expect(session.pid).to.eql("def");
+      expect(session.missedPackets).to.eql([]);
+    });
   });
 });

--- a/packages/socket.io-adapter/test/index.ts
+++ b/packages/socket.io-adapter/test/index.ts
@@ -592,6 +592,39 @@ describe("socket.io-adapter", () => {
       expect(session).to.not.be(null);
       expect(session.sid).to.eql("abc");
       expect(session.pid).to.eql("def");
+      // when offset is undefined (zero-event case), replay should start from the beginning
+      expect(session.missedPackets.length).to.eql(1);
+      expect(session.missedPackets[0][0]).to.eql("hello");
+    });
+
+    it("should restore a known session without offset and without missed packets", async () => {
+      const adapter = new SessionAwareAdapter({
+        server: {
+          encoder: {
+            encode(packet) {
+              return packet;
+            },
+          },
+          opts: {
+            connectionStateRecovery: {
+              maxDisconnectionDuration: 5000,
+            },
+          },
+        },
+      });
+
+      adapter.persistSession({
+        sid: "abc",
+        pid: "def",
+        data: "ghi",
+        rooms: ["r1", "r2"],
+      });
+
+      const session = await adapter.restoreSession("def");
+
+      expect(session).to.not.be(null);
+      expect(session.sid).to.eql("abc");
+      expect(session.pid).to.eql("def");
       expect(session.missedPackets).to.eql([]);
     });
   });

--- a/packages/socket.io-client/test/connection-state-recovery.ts
+++ b/packages/socket.io-client/test/connection-state-recovery.ts
@@ -27,4 +27,30 @@ describe("connection state recovery", () => {
       });
     });
   });
+
+  it("should restore session even if no event was received", () => {
+    return wrap((done) => {
+      const socket = io(BASE_URL, {
+        forceNew: true,
+        reconnectionDelay: 10,
+      });
+
+      expect(socket.recovered).to.eql(false);
+
+      let id: string;
+
+      socket.on("connect", () => {
+        if (!id) {
+          // first connection: no event has been exchanged yet
+          id = socket.id;
+
+          socket.io.engine.close();
+        } else {
+          expect(socket.id).to.eql(id); // means that the reconnection was successful
+          expect(socket.recovered).to.eql(true); // means that the reconnection was successful
+          done();
+        }
+      });
+    });
+  });
 });

--- a/packages/socket.io/lib/namespace.ts
+++ b/packages/socket.io/lib/namespace.ts
@@ -384,12 +384,12 @@ export class Namespace<
     auth: Record<string, unknown>,
   ) {
     const sessionId = auth.pid;
-    const offset = auth.offset;
+    // note: the offset may be undefined, if the client has not yet received any event
+    const offset = typeof auth.offset === "string" ? auth.offset : undefined;
     if (
       // @ts-ignore
       this.server.opts.connectionStateRecovery &&
-      typeof sessionId === "string" &&
-      typeof offset === "string"
+      typeof sessionId === "string"
     ) {
       let session;
       try {

--- a/packages/socket.io/lib/namespace.ts
+++ b/packages/socket.io/lib/namespace.ts
@@ -384,15 +384,16 @@ export class Namespace<
     auth: Record<string, unknown>,
   ) {
     const sessionId = auth.pid;
-    // note: the offset may be undefined, if the client has not yet received any event
-    const offset = typeof auth.offset === "string" ? auth.offset : undefined;
+    const offset = auth.offset;
     if (
       // @ts-ignore
       this.server.opts.connectionStateRecovery &&
-      typeof sessionId === "string"
+      typeof sessionId === "string" &&
+      (typeof offset === "string" || offset === undefined)
     ) {
       let session;
       try {
+        // @ts-ignore - offset may be undefined for zero-event recovery (see #5538)
         session = await this.adapter.restoreSession(sessionId, offset);
       } catch (e) {
         debug("error while restoring session: %s", e);

--- a/packages/socket.io/test/connection-state-recovery.ts
+++ b/packages/socket.io/test/connection-state-recovery.ts
@@ -113,6 +113,93 @@ describe("connection state recovery", () => {
     io.close();
   });
 
+  it("should restore session even if the client did not receive any event", async () => {
+    const httpServer = createServer().listen(0);
+    const io = new Server(httpServer, {
+      connectionStateRecovery: {},
+    });
+
+    io.once("connection", (socket) => {
+      expect(socket.recovered).to.eql(false);
+
+      socket.join("room1");
+      socket.data.foo = "bar";
+    });
+
+    // Engine.IO handshake
+    const eioSid = await eioHandshake(httpServer);
+
+    // Socket.IO handshake (without any prior event, hence without any offset)
+    await eioPush(httpServer, eioSid, "40");
+    const handshakeBody = await eioPoll(httpServer, eioSid);
+
+    expect(handshakeBody.startsWith("40")).to.be(true);
+
+    const handshake = JSON.parse(handshakeBody.substring(2));
+
+    expect(handshake.sid).to.not.be(undefined);
+    expect(handshake.pid).to.not.be(undefined);
+
+    await eioPush(httpServer, eioSid, "1"); // close
+
+    const newSid = await eioHandshake(httpServer);
+
+    const [socket] = await Promise.all([
+      waitFor<Socket>(io, "connection"),
+      eioPush(httpServer, newSid, `40{"pid":"${handshake.pid}"}`),
+    ]);
+
+    expect(socket.id).to.eql(handshake.sid);
+    expect(socket.recovered).to.eql(true);
+
+    expect(socket.rooms.has(socket.id)).to.eql(true);
+    expect(socket.rooms.has("room1")).to.eql(true);
+
+    expect(socket.data.foo).to.eql("bar");
+
+    const payload = await eioPoll(httpServer, newSid);
+    expect(payload).to.eql(
+      `40{"sid":"${handshake.sid}","pid":"${handshake.pid}"}`,
+    );
+
+    io.close();
+  });
+
+  it("should restore session even if the provided offset is not a string", async () => {
+    const httpServer = createServer().listen(0);
+    const io = new Server(httpServer, {
+      connectionStateRecovery: {},
+    });
+
+    io.once("connection", (socket) => {
+      socket.join("room1");
+    });
+
+    // Engine.IO handshake
+    const eioSid = await eioHandshake(httpServer);
+
+    // Socket.IO handshake
+    await eioPush(httpServer, eioSid, "40");
+    const handshakeBody = await eioPoll(httpServer, eioSid);
+    const handshake = JSON.parse(handshakeBody.substring(2));
+
+    await eioPush(httpServer, eioSid, "1"); // close
+
+    const newSid = await eioHandshake(httpServer);
+
+    const [socket] = await Promise.all([
+      waitFor<Socket>(io, "connection"),
+      eioPush(httpServer, newSid, `40{"pid":"${handshake.pid}","offset":123}`),
+    ]);
+
+    expect(socket.id).to.eql(handshake.sid);
+    expect(socket.recovered).to.eql(true);
+    expect(socket.rooms.has("room1")).to.eql(true);
+
+    await eioPoll(httpServer, newSid); // drain buffer
+    io.close();
+  });
+
   it("should not run middlewares upon recovery by default", async () => {
     const httpServer = createServer().listen(0);
     const io = new Server(httpServer, {

--- a/packages/socket.io/test/connection-state-recovery.ts
+++ b/packages/socket.io/test/connection-state-recovery.ts
@@ -165,7 +165,56 @@ describe("connection state recovery", () => {
     io.close();
   });
 
-  it("should restore session even if the provided offset is not a string", async () => {
+  it("should replay missed packets even if the client did not receive any event before disconnection", async () => {
+    const httpServer = createServer().listen(0);
+    const io = new Server(httpServer, {
+      connectionStateRecovery: {},
+    });
+
+    io.once("connection", (socket) => {
+      socket.join("room1");
+    });
+
+    // Engine.IO handshake
+    const eioSid = await eioHandshake(httpServer);
+
+    // Socket.IO handshake (without any prior event, hence without any offset)
+    await eioPush(httpServer, eioSid, "40");
+    const handshakeBody = await eioPoll(httpServer, eioSid);
+    const handshake = JSON.parse(handshakeBody.substring(2));
+
+    await eioPush(httpServer, eioSid, "1"); // close
+
+    // emit while disconnected - these packets should be replayed even though the client never received any event before
+    io.to("room1").emit("hello", "world");
+    io.emit("broadcast");
+
+    const newSid = await eioHandshake(httpServer);
+
+    const [socket] = await Promise.all([
+      waitFor<Socket>(io, "connection"),
+      eioPush(httpServer, newSid, `40{"pid":"${handshake.pid}"}`),
+    ]);
+
+    expect(socket.id).to.eql(handshake.sid);
+    expect(socket.recovered).to.eql(true);
+    expect(socket.rooms.has("room1")).to.eql(true);
+
+    const payload = await eioPoll(httpServer, newSid);
+    const packets = payload.split("\x1e");
+
+    // missed packets are sent before the CONNECT packet
+    expect(packets.length).to.eql(3);
+    expect(packets[0].startsWith('42["hello"')).to.be(true);
+    expect(packets[1].startsWith('42["broadcast"')).to.be(true);
+    expect(packets[2]).to.eql(
+      `40{"sid":"${handshake.sid}","pid":"${handshake.pid}"}`,
+    );
+
+    io.close();
+  });
+
+  it("should not restore session if the provided offset is not a string", async () => {
     const httpServer = createServer().listen(0);
     const io = new Server(httpServer, {
       connectionStateRecovery: {},
@@ -192,9 +241,10 @@ describe("connection state recovery", () => {
       eioPush(httpServer, newSid, `40{"pid":"${handshake.pid}","offset":123}`),
     ]);
 
-    expect(socket.id).to.eql(handshake.sid);
-    expect(socket.recovered).to.eql(true);
-    expect(socket.rooms.has("room1")).to.eql(true);
+    // malformed offset should fail closed - new session, not recovered
+    expect(socket.recovered).to.eql(false);
+    expect(socket.id).to.not.eql(handshake.sid);
+    expect(socket.rooms.has("room1")).to.eql(false);
 
     await eioPoll(httpServer, newSid); // drain buffer
     io.close();


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix

### Current behavior

When `connectionStateRecovery` is enabled, a client that connects, joins rooms, and disconnects **before the server emits any events** cannot recover its session on reconnection (`socket.recovered` is `false`, a new `socket.id` is generated, room memberships and `socket.data` are lost).

This happens because `_lastOffset` is only set on the client when an EVENT packet is received. In the "zero-event" case, the reconnect CONNECT packet contains no offset at all (`{"pid":"..."}`), and the server-side check in `namespace.ts`:

```ts
if (
  this.server.opts.connectionStateRecovery &&
  typeof sessionId === "string" &&
  typeof offset === "string"
) {
```

skips `restoreSession()` entirely.

### New behavior

The offset is now optional in `Adapter#restoreSession()`:

- in `namespace.ts`, a non-string offset is normalized to `undefined`, and recovery is attempted as long as a valid private session id (`pid`) is provided
- in `SessionAwareAdapter#restoreSession()`, an undefined offset means the client did not receive any event yet, so the session (id, rooms, data) is restored without replaying any event

Note for external adapters (Redis adapter, Postgres adapter, cluster adapters...): `restoreSession()` may now be called with `offset === undefined`. Implementations that don't handle it can keep their current signature; returning `null` preserves the previous behavior.

### Other information (e.g. related issues)

Fixes #5538

Testing:
- added 2 cases in the server raw-packet suite (`test/connection-state-recovery.ts`): zero-event recovery (id/rooms/data restored, no replayed events) and recovery with a non-string offset
- added 1 case in `packages/socket.io-adapter/test/index.ts`: restore with an undefined offset returns the session with an empty `missedPackets` array
- added 1 end-to-end case in `packages/socket.io-client/test/connection-state-recovery.ts`: real client reconnects with `recovered === true` without any prior event
- all suites pass locally: `npm test -w packages/socket.io` (217 passing), adapter suite (22 passing), client node suite (112 passing; one pre-existing flaky failure in the unrelated `autoUnref` child-process test, which also fails on a clean checkout)