### PR TITLE
fix(types): include the data attribute on the connect_error event

### DIFF
--- a/packages/socket.io-client/lib/socket.ts
+++ b/packages/socket.io-client/lib/socket.ts
@@ -111,9 +111,11 @@ export type DisconnectDescription =
       context?: unknown; // context should be typed as CloseEvent | XMLHttpRequest, but these types are not available on non-browser platforms
     };
 
+type ConnectError = Error & { data?: any };
+
 interface SocketReservedEvents {
   connect: () => void;
-  connect_error: (err: Error & { data?: any }) => void;
+  connect_error: (err: ConnectError) => void;
   disconnect: (
     reason: Socket.DisconnectReason,
     description?: DisconnectDescription,
@@ -734,7 +736,7 @@ export class Socket<
 
       case PacketType.CONNECT_ERROR:
         this.destroy();
-        const err: Error & { data?: any } = new Error(packet.data.message);
+        const err: ConnectError = new Error(packet.data.message);
         err.data = packet.data.data;
         this.emitReserved("connect_error", err);
         break;

--- a/packages/socket.io-client/lib/socket.ts
+++ b/packages/socket.io-client/lib/socket.ts
@@ -113,7 +113,7 @@ export type DisconnectDescription =
 
 interface SocketReservedEvents {
   connect: () => void;
-  connect_error: (err: Error) => void;
+  connect_error: (err: Error & { data?: any }) => void;
   disconnect: (
     reason: Socket.DisconnectReason,
     description?: DisconnectDescription,
@@ -734,8 +734,7 @@ export class Socket<
 
       case PacketType.CONNECT_ERROR:
         this.destroy();
-        const err = new Error(packet.data.message);
-        // @ts-ignore
+        const err: Error & { data?: any } = new Error(packet.data.message);
         err.data = packet.data.data;
         this.emitReserved("connect_error", err);
         break;

--- a/packages/socket.io-client/test/socket.ts
+++ b/packages/socket.io-client/test/socket.ts
@@ -286,6 +286,17 @@ describe("socket", () => {
     });
   });
 
+  it("should forward the data attached to a middleware error", () => {
+    return wrap((done) => {
+      const socket = io(BASE_URL + "/no-with-data", { forceNew: true });
+      socket.on("connect_error", (err) => {
+        expect(err.data).to.eql({ code: "UNAUTHORIZED" });
+        socket.disconnect();
+        done();
+      });
+    });
+  });
+
   it("should not try to reconnect after a middleware failure", () => {
     return wrap((done) => {
       const socket = io(BASE_URL + "/no", {

--- a/packages/socket.io-client/test/support/server.ts
+++ b/packages/socket.io-client/test/support/server.ts
@@ -1,4 +1,4 @@
-import { Server } from "socket.io";
+import { ExtendedError, Server } from "socket.io";
 import expect = require("expect.js");
 
 export function createServer() {
@@ -42,6 +42,12 @@ export function createServer() {
 
   server.of("/no").use((socket, next) => {
     next(new Error("Auth failed (custom namespace)"));
+  });
+
+  server.of("/no-with-data").use((socket, next) => {
+    const err: ExtendedError = new Error("Auth failed (with data)");
+    err.data = { code: "UNAUTHORIZED" };
+    next(err);
   });
 
   server.on("connection", (socket) => {

--- a/packages/socket.io-client/test/typed-events.test-d.ts
+++ b/packages/socket.io-client/test/typed-events.test-d.ts
@@ -26,7 +26,7 @@ describe("typed events", () => {
         expectError(socket.on("connect", (arg) => {}));
 
         socket.on("connect_error", (err) => {
-          expectType<Error>(err);
+          expectType<Error & { data?: any }>(err);
         });
 
         socket.on("disconnect", (reason) => {


### PR DESCRIPTION

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

`connect_error` is typed as plain `Error`, even though the client always attaches a `data` property to it (forwarded from the `err.data` set on the server-side middleware error). Accessing `err.data` from a listener is a type error unless you cast it yourself.

### New behavior

`connect_error` is now typed as `Error & { data?: any }`, matching the `ExtendedError` shape already used on the server side. The internal `@ts-ignore` needed to attach `.data` in `onpacket()` is gone too, since the variable is properly typed.

### Other information (e.g. related issues)

Fixes #5542
