### PR TITLE
fix(parser): reject a namespace containing a comma

### DIFF
--- a/docs/socket.io-protocol/v5-current.md
+++ b/docs/socket.io-protocol/v5-current.md
@@ -277,6 +277,8 @@ long-polling, or in the WebSocket frame).
 
 Note: the namespace is only included if it is different from the main namespace (`/`)
 
+Note: the namespace is delimited by a comma, and there is no escape sequence, so it must not contain one.
+
 ### Examples
 
 #### Connection to a namespace

--- a/packages/socket.io-parser/lib/index.ts
+++ b/packages/socket.io-parser/lib/index.ts
@@ -98,7 +98,12 @@ export class Encoder {
     // if we have a namespace other than `/`
     // we append it followed by a comma `,`
     if (obj.nsp && "/" !== obj.nsp) {
-      str += obj.nsp + ",";
+      // coerce once: the check must see the same string that is appended below
+      const nsp = "" + obj.nsp;
+      if (nsp.indexOf(",") !== -1) {
+        throw new Error("invalid namespace: must not contain a comma");
+      }
+      str += nsp + ",";
     }
 
     // immediately followed by the id
@@ -377,7 +382,8 @@ class BinaryReconstructor {
 }
 
 function isNamespaceValid(nsp: unknown) {
-  return typeof nsp === "string";
+  // a comma terminates the namespace on the wire, so one inside it cannot be decoded back
+  return typeof nsp === "string" && nsp.indexOf(",") === -1;
 }
 
 // see https://caniuse.com/mdn-javascript_builtins_number_isinteger

--- a/packages/socket.io-parser/test/parser.js
+++ b/packages/socket.io-parser/test/parser.js
@@ -98,6 +98,26 @@ describe("socket.io-parser", () => {
     expect(() => encoder.encode(data)).to.throwException();
   });
 
+  it("throws an error when encoding a namespace containing a comma", () => {
+    const encoder = new Encoder();
+
+    expect(() =>
+      encoder.encode({
+        type: PacketType.EVENT,
+        nsp: "/a,b",
+        data: ["hello"],
+      }),
+    ).to.throwException(/^invalid namespace: must not contain a comma$/);
+
+    expect(() =>
+      encoder.encode({
+        type: PacketType.EVENT,
+        nsp: "/a,b",
+        data: ["hello", Uint8Array.from([1, 2, 3])],
+      }),
+    ).to.throwException(/^invalid namespace: must not contain a comma$/);
+  });
+
   it("decodes a bad binary packet", () => {
     try {
       const decoder = new Decoder();
@@ -223,6 +243,13 @@ describe("socket.io-parser", () => {
         type: 0,
         nsp: "/admin",
         data: "invalid",
+      }),
+    ).to.eql(false);
+
+    expect(
+      isPacketValid({
+        type: 0,
+        nsp: "/a,b",
       }),
     ).to.eql(false);
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

A namespace whose name comes from data — a tenant, a customer, a label out of a
spreadsheet — silently stops working as soon as that name contains a comma:

```js
const tenant = "Acme, Inc.";          // from the database
io.of("/" + tenant).emit("hello");    // no error here
```

Nothing throws. `Server#of()` only prepends a missing leading slash and validates
nothing else, so the namespace is created and looks fine. But the wire format
delimits the namespace with a comma:

```
<packet type>[<# of binary attachments>-][<namespace>,][<acknowledgment id>][JSON-stringified payload without binary]
```

and there is no escape sequence. The encoder writes `2/Acme, Inc.,["hello"]`, the
decoder stops the namespace at the first comma, and what is left is not valid
JSON, so every packet fails with `invalid payload`. The client never connects, and
the server closes the connection after a `debug()` line reading `invalid packet
format` — which is invisible unless `DEBUG` is set. Neither mentions the namespace.

I found this round-tripping the parser rather than from a bug report: over 12
namespaces × every combination of acknowledgement id and payload shape, the only
failures were the three namespaces containing a comma, and those failed in every
combination.

### New behavior

The encoder throws `invalid namespace: must not contain a comma` instead of
emitting a packet the peer cannot read — the same thing it already does with a
payload it cannot serialise. `isNamespaceValid()` rejects one too, so
`isPacketValid()` no longer reports such a packet as valid. The protocol document
gets the matching note.

A namespace containing a comma has never been decodable, so no working code
changes behaviour. Two things worth flagging rather than leaving you to find:

- Where the client-side throw lands depends on the transport. If the manager is
  already open — opening a second namespace on a live connection — `connect()`
  calls `onopen()` synchronously, so it comes back out of `io()` and can be
  caught. If the manager opens later it surfaces inside the `open` handler, where
  application code cannot reach it. That configuration previously just never
  connected, so it is broken either way, but the asymmetry is worth knowing. On
  the server the throw lands at the user's `emit()`.
- I checked whether a comma could be used to smuggle a second packet past the
  decoder — a forged `CONNECT` payload, a forged `EVENT` — and it cannot. The
  encoder appends its own delimiter after the injected text, which leaves invalid
  JSON in the tail, so all seven attempts threw. This is a robustness fix, not a
  security one.

### Other information (e.g. related issues)

**Why only the comma.** A namespace that does not begin with a slash is
undecodable for the same reason — `decodeString()` only reads one when it sees
the leading slash. I left it alone because `Server#of()` normalises it away and
`io()` takes the namespace from a URL path, so reaching it needs a direct
`Manager#socket()` call. Happy to fold it in if you would rather have both.

Escaping the comma on the wire would fix it without an error, but it changes the
format and breaks every non-JS implementation of the v5 protocol, so I did not go
that way. Validating in `Server#of()` would give a better error at a better time
and I would be glad to add it — it just would not cover the client, which is why
the parser seemed the right single place.

No CHANGELOG entry: the two most recent parser fixes (7c6ef571, 57f11143) touched
only `lib/` and `test/`, with the changelog written at release time.
