### PR TITLE
fix(client): discard timed-out buffered packets

### DIFF
--- a/packages/engine.io-client/lib/socket.ts
+++ b/packages/engine.io-client/lib/socket.ts
@@ -690,6 +690,26 @@ export class SocketWithoutUpgrade extends Emitter<
   }
 
   /**
+   * Removes packets that have not been handed to the transport yet.
+   *
+   * @param options - the options object shared by the packets to remove
+   * @private
+   */
+  public _removeFromWriteBuffer(options: WriteOptions) {
+    for (let i = 0; i < this._prevBufferLen; i++) {
+      if (this.writeBuffer[i].options === options) {
+        return;
+      }
+    }
+
+    for (let i = this.writeBuffer.length - 1; i >= this._prevBufferLen; i--) {
+      if (this.writeBuffer[i].options === options) {
+        this.writeBuffer.splice(i, 1);
+      }
+    }
+  }
+
+  /**
    * Flush write buffers.
    *
    * @private

--- a/packages/engine.io-client/test/socket.js
+++ b/packages/engine.io-client/test/socket.js
@@ -13,6 +13,32 @@ const { repeat } = require("./util");
 describe("Socket", function () {
   this.timeout(10000);
 
+  describe("_removeFromWriteBuffer", () => {
+    it("should remove all matching packets that have not been flushed", () => {
+      const socket = Object.create(Socket.prototype);
+      const options = {};
+      const otherPacket = { options: {} };
+      socket.writeBuffer = [{ options }, otherPacket, { options }];
+      socket._prevBufferLen = 0;
+
+      socket._removeFromWriteBuffer(options);
+
+      expect(socket.writeBuffer).to.eql([otherPacket]);
+    });
+
+    it("should preserve all matching packets when one has been flushed", () => {
+      const socket = Object.create(Socket.prototype);
+      const options = {};
+      const packets = [{ options }, { options }];
+      socket.writeBuffer = packets.slice();
+      socket._prevBufferLen = 1;
+
+      socket._removeFromWriteBuffer(options);
+
+      expect(socket.writeBuffer).to.eql(packets);
+    });
+  });
+
   describe("filterUpgrades", () => {
     it("should return only available transports", () => {
       const socket = new Socket({ transports: ["polling"] });

--- a/packages/socket.io-client/lib/manager.ts
+++ b/packages/socket.io-client/lib/manager.ts
@@ -511,6 +511,16 @@ export class Manager<
   }
 
   /**
+   * Removes a packet that has not been handed to the transport yet.
+   *
+   * @param packet
+   * @private
+   */
+  _removePacketFromBuffer(packet: Partial<Packet & { options: any }>): void {
+    this.engine?._removeFromWriteBuffer(packet.options);
+  }
+
+  /**
    * Clean up transport subscriptions and packet buffer.
    *
    * @private

--- a/packages/socket.io-client/lib/socket.ts
+++ b/packages/socket.io-client/lib/socket.ts
@@ -436,7 +436,7 @@ export class Socket<
       debug("emitting packet with ack id %d", id);
 
       const ack = args.pop() as (...args: any[]) => void;
-      this._registerAckCallback(id, ack);
+      this._registerAckCallback(id, ack, packet);
       packet.id = id;
     }
 
@@ -461,7 +461,11 @@ export class Socket<
   /**
    * @private
    */
-  private _registerAckCallback(id: number, ack: (...args: any[]) => void) {
+  private _registerAckCallback(
+    id: number,
+    ack: (...args: any[]) => void,
+    packet: Packet,
+  ) {
     const timeout = this.flags.timeout ?? this._opts.ackTimeout;
     if (timeout === undefined) {
       this.acks[id] = ack;
@@ -471,6 +475,7 @@ export class Socket<
     // @ts-ignore
     const timer = this.io.setTimeoutFn(() => {
       delete this.acks[id];
+      this.io._removePacketFromBuffer(packet);
       for (let i = 0; i < this.sendBuffer.length; i++) {
         if (this.sendBuffer[i].id === id) {
           debug("removing packet with ack id %d from the buffer", id);

--- a/packages/socket.io-client/test/socket.ts
+++ b/packages/socket.io-client/test/socket.ts
@@ -583,6 +583,50 @@ describe("socket", () => {
       });
     });
 
+    it("should discard a timed out packet buffered by Engine.IO", () => {
+      return wrap((done) => {
+        const socket = io(BASE_URL + "/", {
+          forceNew: true,
+        });
+
+        socket.on("connect", () => {
+          const engine = socket.io.engine;
+          setTimeout(() => {
+            engine.transport.writable = false;
+
+            const enginePackets = [];
+            const onPacketCreate = (packet) => {
+              enginePackets.push(packet);
+            };
+            engine.on("packetCreate", onPacketCreate);
+
+            let received = false;
+            socket.on("hi", () => {
+              received = true;
+            });
+
+            socket.timeout(50).emit("hi", Uint8Array.from([1]), (err) => {
+              expect(err).to.be.an(Error);
+              expect(enginePackets.length).to.be(2);
+              enginePackets.forEach((packet) => {
+                expect(engine.writeBuffer.indexOf(packet)).to.be(-1);
+              });
+
+              engine.transport.writable = true;
+              // @ts-ignore flush any remaining Engine.IO packets
+              engine.flush();
+
+              setTimeout(() => {
+                expect(received).to.be(false);
+                success(done, socket);
+              }, 50);
+            });
+            engine.off("packetCreate", onPacketCreate);
+          }, 0);
+        });
+      });
+    });
+
     it("should timeout when the server does not acknowledge the event", () => {
       return wrap((done) => {
         const socket = io(BASE_URL + "/");


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

An event with an acknowledgement timeout can already be queued in the Engine.IO write buffer when the transport becomes temporarily unwritable. The Socket.IO acknowledgement callback times out and the packet is removed from the Socket.IO send buffer, but the Engine.IO packet remains queued and is sent when the transport becomes writable again.

For binary events, one Socket.IO event can map to several Engine.IO packets.

### New behavior

When an acknowledgement times out, the client removes every Engine.IO packet created from that Socket.IO event if none of them has been handed to the transport yet.

If any encoded packet is already part of the current transport batch, all related packets are preserved so a binary event cannot be left partially transmitted.

### Other information (e.g. related issues)

Fixes #4318.

Tests cover both multi-packet binary events and the partially-flushed safety boundary.

Verification:

- Engine.IO client formatting and TypeScript compilation
- Socket.IO client formatting and TypeScript compilation
- Engine.IO buffer-removal regression tests
- Socket.IO timeout tests (20 passing)

AI assistance disclosure: OpenAI Codex assisted with investigation, implementation, and test review; the change was manually validated.
