### PR TITLE
Workaround to avoid false positives when detecting an offset

### DIFF
--- a/packages/socket.io-client/lib/socket.ts
+++ b/packages/socket.io-client/lib/socket.ts
@@ -772,7 +772,9 @@ export class Socket<
       }
     }
     super.emit.apply(this, args);
-    if (this._pid && args.length && typeof args[args.length - 1] === "string") {
+
+    // Consider designing a better way of tracking if an offset was actually added or not
+    if (this._pid && args.length && typeof args[args.length - 1] === "string" && /^\d+-\d+$/.test(args[args.length - 1]) ) {
       this._lastOffset = args[args.length - 1];
     }
   }


### PR DESCRIPTION
The last element of the arguments of a message received by the client can be a string even without an offset, for example in the case of sending only an event name or a message that contains a payload which is a string instead of an object, so the best approach is checking if the last argument is a string and follows the format of an offset. However, this approach is still prone to causing the same effect as before so I suggest designing a way of tracking if an offset was added or not. This workaround will prevent most errors where the frontend will try to use something that isn't an offset as if it were, causing an exception at the backend.


### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior
If the client disconnects and the connection state recovery feature is enabled, in the case of the last message received not having an offset but having the last argument being a string will cause the front-end to assume it is an offset thus causing an exception at the back-end.

### New behavior
It will avoid most false positives by checking if the last string follows the "number-number" format (which is used for the offsets). However, this is still prone to false positives so tracking if an offset was added or not is suggested.