### PR TITLE
types(client): add and export ExtendedError for connect_error event

### DIFF
--- a/packages/socket.io-client/lib/index.ts
+++ b/packages/socket.io-client/lib/index.ts
@@ -1,6 +1,11 @@
 import { url } from "./url.js";
 import { Manager, ManagerOptions } from "./manager.js";
-import { DisconnectDescription, Socket, SocketOptions } from "./socket.js";
+import {
+  DisconnectDescription,
+  ExtendedError,
+  Socket,
+  SocketOptions,
+} from "./socket.js";
 import debugModule from "debug"; // debug()
 
 const debug = debugModule("socket.io-client"); // debug()
@@ -92,6 +97,7 @@ export { protocol } from "socket.io-parser";
 
 export {
   DisconnectDescription,
+  ExtendedError,
   Manager,
   ManagerOptions,
   Socket,

--- a/packages/socket.io-client/lib/socket.ts
+++ b/packages/socket.io-client/lib/socket.ts
@@ -111,9 +111,13 @@ export type DisconnectDescription =
       context?: unknown; // context should be typed as CloseEvent | XMLHttpRequest, but these types are not available on non-browser platforms
     };
 
+export interface ExtendedError extends Error {
+  data?: any;
+}
+
 interface SocketReservedEvents {
   connect: () => void;
-  connect_error: (err: Error) => void;
+  connect_error: (err: ExtendedError) => void;
   disconnect: (
     reason: Socket.DisconnectReason,
     description?: DisconnectDescription,
@@ -734,8 +738,7 @@ export class Socket<
 
       case PacketType.CONNECT_ERROR:
         this.destroy();
-        const err = new Error(packet.data.message);
-        // @ts-ignore
+        const err: ExtendedError = new Error(packet.data.message);
         err.data = packet.data.data;
         this.emitReserved("connect_error", err);
         break;

--- a/packages/socket.io-client/lib/socket.ts
+++ b/packages/socket.io-client/lib/socket.ts
@@ -738,7 +738,7 @@ export class Socket<
 
       case PacketType.CONNECT_ERROR:
         this.destroy();
-        const err: ExtendedError = new Error(packet.data.message);
+        const err = new Error(packet.data.message) as ExtendedError;
         err.data = packet.data.data;
         this.emitReserved("connect_error", err);
         break;

--- a/packages/socket.io-client/test/socket.ts
+++ b/packages/socket.io-client/test/socket.ts
@@ -286,6 +286,19 @@ describe("socket", () => {
     });
   });
 
+  it("should fire a connect_error event with error data on middleware failure", () => {
+    return wrap((done) => {
+      const socket = io(BASE_URL + "/with-data", { forceNew: true });
+      socket.on("connect_error", (err) => {
+        expect(err).to.be.an(Error);
+        expect(err.message).to.eql("Auth failed (with data)");
+        expect(err.data).to.eql({ code: 401, details: "Invalid token" });
+        socket.disconnect();
+        done();
+      });
+    });
+  });
+
   it("should not try to reconnect after a middleware failure", () => {
     return wrap((done) => {
       const socket = io(BASE_URL + "/no", {

--- a/packages/socket.io-client/test/support/server.ts
+++ b/packages/socket.io-client/test/support/server.ts
@@ -44,6 +44,12 @@ export function createServer() {
     next(new Error("Auth failed (custom namespace)"));
   });
 
+  server.of("/with-data").use((socket, next) => {
+    const err: any = new Error("Auth failed (with data)");
+    err.data = { code: 401, details: "Invalid token" };
+    next(err);
+  });
+
   server.on("connection", (socket) => {
     // simple test
     socket.on("hi", () => {

--- a/packages/socket.io-client/test/typed-events.test-d.ts
+++ b/packages/socket.io-client/test/typed-events.test-d.ts
@@ -1,4 +1,4 @@
-import { io, Socket } from "..";
+import { io, Socket, ExtendedError } from "..";
 import type { DefaultEventsMap } from "@socket.io/component-emitter";
 import { expectError, expectType } from "tsd";
 
@@ -26,7 +26,8 @@ describe("typed events", () => {
         expectError(socket.on("connect", (arg) => {}));
 
         socket.on("connect_error", (err) => {
-          expectType<Error>(err);
+          expectType<ExtendedError>(err);
+          expectType<any>(err.data);
         });
 
         socket.on("disconnect", (reason) => {


### PR DESCRIPTION
### Description

This PR adds and exports the `ExtendedError` interface in `socket.io-client` and updates `SocketReservedEvents` to type `connect_error: (err: ExtendedError) => void`.

### Motivation

When a connection middleware rejects the connection with extra metadata, the client receives `PacketType.CONNECT_ERROR` and sets `err.data = packet.data.data`. Previously, `connect_error` was typed as standard `Error`, which required TypeScript users to write `(err as any).data`.

This change mirrors the server package's `ExtendedError` declaration, enables type-safe access to `err.data`, and removes the need for `// @ts-ignore` in `onpacket`.

Fixes #5542

### Checklist
- [x] TypeScript builds successfully (`npm run compile --workspace=socket.io-client`)
- [x] Code matches Prettier style (`npm run format:check --workspace=socket.io-client`)
- [x] Unit tests and type tests added and passing
