### PR TITLE
test: quote process.execPath and fixture path to support paths with spaces

### DIFF
--- a/packages/engine.io-client/test/node.js
+++ b/packages/engine.io-client/test/node.js
@@ -8,7 +8,11 @@ const { parse } = require("../build/cjs/globals.node.js");
 describe("node.js", () => {
   describe("autoRef option", () => {
     const fixture = (filename) =>
-      process.execPath + " " + path.join(__dirname, "fixtures", filename);
+      '"' +
+      process.execPath +
+      '" "' +
+      path.join(__dirname, "fixtures", filename) +
+      '"';
 
     it("should stop once the timer is triggered", (done) => {
       exec(fixture("unref.js"), done);

--- a/packages/engine.io/test/server.js
+++ b/packages/engine.io/test/server.js
@@ -1750,7 +1750,11 @@ describe("server", () => {
 
       function fixture(filename) {
         return (
-          process.execPath + " " + path.join(__dirname, "fixtures", filename)
+          '"' +
+          process.execPath +
+          '" "' +
+          path.join(__dirname, "fixtures", filename) +
+          '"'
         );
       }
 

--- a/packages/socket.io-client/test/node.ts
+++ b/packages/socket.io-client/test/node.ts
@@ -9,7 +9,11 @@ describe("autoUnref option", function () {
   });
 
   const fixture = (filename) =>
-    process.execPath + " " + path.join(__dirname, "fixtures", filename);
+    '"' +
+    process.execPath +
+    '" "' +
+    path.join(__dirname, "fixtures", filename) +
+    '"';
 
   it("should stop once the timer is triggered", (done) => {
     exec(fixture("unref.ts"), done);


### PR DESCRIPTION
### Description

Quotes `process.execPath` and fixture paths when invoking child processes in test suites across `engine.io`, `engine.io-client`, and `socket.io-client`.

### Motivation

When tests run on environments where Node.js or the project folder path contains spaces (such as the Windows default `C:\Program Files\nodejs\node.exe` or directories with spaces), `child_process.exec()` fails with `'C:\Program' is not recognized as an internal or external command`.

Quoting the paths fixes this issue and aligns these packages with `packages/socket.io/test/close.ts`.

### Checklist
- [x] Prettier code style verified (`npm run format:check`)
- [x] Tests passing across `engine.io`, `engine.io-client`, and `socket.io-client`
