### PR TITLE
fix(eio): report oversized polling payloads

### DIFF
--- a/packages/engine.io/lib/transports/polling.ts
+++ b/packages/engine.io/lib/transports/polling.ts
@@ -153,6 +153,7 @@ export class Polling extends Transport {
         exceededMaxHttpBufferSize = true;
         res.writeHead(413).end();
         cleanup();
+        this.onError("payload too large");
         return;
       }
 

--- a/packages/engine.io/test/server.js
+++ b/packages/engine.io/test/server.js
@@ -1823,7 +1823,7 @@ describe("server", () => {
       });
     });
 
-    it("should not be receiving data when getting a message longer than maxHttpBufferSize when polling", (done) => {
+    it("should report a message longer than maxHttpBufferSize when polling", (done) => {
       const opts = {
         allowUpgrades: false,
         transports: ["polling"],
@@ -1837,12 +1837,16 @@ describe("server", () => {
               new Error("Test invalidation (message is longer than allowed)"),
             );
           });
+          conn.on("close", (reason, description) => {
+            expect(reason).to.be("transport error");
+            expect(description).to.be.an(Error);
+            expect(description.type).to.be("TransportError");
+            expect(description.message).to.be("payload too large");
+            done();
+          });
         });
         socket.on("open", () => {
           socket.send("aasdasdakjhasdkjhasdkjhasdkjhasdkjhasdkjhasdkjha");
-        });
-        socket.on("close", () => {
-          done();
         });
       });
     });


### PR DESCRIPTION
## Summary

- emit a transport error when an HTTP polling payload exceeds `maxHttpBufferSize`
- preserve the existing HTTP 413 response
- assert that server-side close handlers receive an actionable `TransportError`

## Context

The polling transport returned HTTP 413 when the incoming body crossed the configured limit, but it did not notify the Engine.IO socket about the cause. As a result, server-side Socket.IO handlers only received `transport close` without a description.

The uWebSockets polling implementation already reports `payload too large`, and the WebSocket implementation reports the corresponding `ws` range error. This change brings the Node.js polling transport in line with those paths by using the existing transport error pipeline after the request has been cleaned up.

Fixes socketio/engine.io#706

## Verification

- `npm run compile --workspace=engine.io`
- `npm run format:check --workspace=engine.io`
- Engine.IO Node test suite: 175 passing, 2 pending
- Engine.IO v3 compatibility suite: 175 passing, 2 pending
- regression test fails before the fix with `transport close` and passes after the fix with `transport error` / `payload too large`

The aggregate `npm test --workspace=engine.io` command reaches 175 passing tests but the local WebTransport test times out because the optional `@fails-components/webtransport-transport-http3-quiche` native module is not built in this environment.

AI assistance disclosure: OpenAI Codex assisted with reproduction, implementation, and verification. The change was reviewed and tested against the repository's current main branch.
